### PR TITLE
fix(semcode): enforce canonical verifier admission

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -620,12 +620,18 @@ fn decode_operands(
         Opcode::LoadQ => {
             let dst = read_u16_le(code, cursor).map_err(|_| invalid("truncated dst register"))?;
             mark_reg(dst);
-            read_u8(code, cursor).map_err(|_| invalid("truncated quad literal"))?;
+            let literal = read_u8(code, cursor).map_err(|_| invalid("truncated quad literal"))?;
+            if literal > 3 {
+                return Err(invalid("non-canonical quad literal: must be 0..=3"));
+            }
         }
         Opcode::LoadBool => {
             let dst = read_u16_le(code, cursor).map_err(|_| invalid("truncated dst register"))?;
             mark_reg(dst);
-            read_u8(code, cursor).map_err(|_| invalid("truncated bool literal"))?;
+            let literal = read_u8(code, cursor).map_err(|_| invalid("truncated bool literal"))?;
+            if literal > 1 {
+                return Err(invalid("non-canonical bool literal: must be 0 or 1"));
+            }
         }
         Opcode::LoadI32 => {
             let dst = read_u16_le(code, cursor).map_err(|_| invalid("truncated dst register"))?;
@@ -969,8 +975,14 @@ fn decode_operands(
             }
         }
         Opcode::ClosureCall => {
-            let has_dst =
-                read_u8(code, cursor).map_err(|_| invalid("truncated closure-call dst flag"))? != 0;
+            let has_dst_flag =
+                read_u8(code, cursor).map_err(|_| invalid("truncated closure-call dst flag"))?;
+            if has_dst_flag > 1 {
+                return Err(invalid(
+                    "non-canonical closure-call dst flag: must be 0 or 1",
+                ));
+            }
+            let has_dst = has_dst_flag != 0;
             if has_dst {
                 let dst = read_u16_le(code, cursor)
                     .map_err(|_| invalid("truncated closure-call dst register"))?;
@@ -1060,7 +1072,13 @@ fn decode_operands(
             refs.jump_targets.push(target as usize);
         }
         Opcode::Call => {
-            read_u8(code, cursor).map_err(|_| invalid("truncated call destination flag"))?;
+            let has_dst_flag =
+                read_u8(code, cursor).map_err(|_| invalid("truncated call destination flag"))?;
+            if has_dst_flag > 1 {
+                return Err(invalid(
+                    "non-canonical call destination flag: must be 0 or 1",
+                ));
+            }
             let dst =
                 read_u16_le(code, cursor).map_err(|_| invalid("truncated call dst register"))?;
             mark_reg(dst);
@@ -1137,6 +1155,9 @@ fn decode_operands(
         }
         Opcode::Ret => {
             let has_src = read_u8(code, cursor).map_err(|_| invalid("truncated return flag"))?;
+            if has_src > 1 {
+                return Err(invalid("non-canonical return flag: must be 0 or 1"));
+            }
             if has_src != 0 {
                 let src = read_u16_le(code, cursor)
                     .map_err(|_| invalid("truncated return src register"))?;
@@ -1767,6 +1788,114 @@ mod tests {
         assert_eq!(
             report.diagnostics[0].code,
             VerificationCode::InvalidRegisterReference
+        );
+    }
+
+    // FA-07-001 (#1741): LOAD_BOOL literal byte must be canonical 0/1. A byte
+    // outside that domain must be rejected at admission, not silently
+    // normalized to `true` by the VM's `!= 0` check.
+    #[test]
+    fn verifier_rejects_non_canonical_bool_literal() {
+        let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
+            .expect("compile");
+        let opcode_pos = find_opcode(&bytes, Opcode::LoadBool.byte()).expect("load bool");
+        let literal_pos = opcode_pos + 1 + 2;
+        bytes[literal_pos] = 0xff;
+        let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::OperandOutOfBounds
+        );
+    }
+
+    // FA-07-002 (#1742): LOAD_Q literal byte must be canonical 0..=3. A byte
+    // outside that domain must be rejected at admission instead of receiving
+    // a Verified token and only failing later in the VM as BadFormat.
+    #[test]
+    fn verifier_rejects_non_canonical_quad_literal() {
+        // No let-binding: a named local would intern a string, and a short
+        // string's length byte can coincidentally equal LoadQ's opcode byte
+        // (0x01), making a naive byte scan land on the wrong offset.
+        let mut bytes =
+            compile_program_to_semcode("fn get() -> quad { return T; } fn main() { return; }")
+                .expect("compile");
+        let opcode_pos = find_opcode(&bytes, Opcode::LoadQ.byte()).expect("load q");
+        let literal_pos = opcode_pos + 1 + 2;
+        bytes[literal_pos] = 0xff;
+        let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::OperandOutOfBounds
+        );
+    }
+
+    // FA-07-003 (#1743): CALL's destination-present flag must be canonical
+    // 0/1. The verifier currently reads and discards this byte entirely.
+    #[test]
+    fn verifier_rejects_non_canonical_call_dst_flag() {
+        let mut bytes =
+            compile_program_to_semcode("fn helper() { return; } fn main() { helper(); return; }")
+                .expect("compile");
+        let opcode_pos = find_opcode(&bytes, Opcode::Call.byte()).expect("call");
+        bytes[opcode_pos + 1] = 0xff;
+        let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::OperandOutOfBounds
+        );
+    }
+
+    // FA-07-003 (#1743): CLOSURE_CALL's destination-present flag must be
+    // canonical 0/1, not "any nonzero byte is true".
+    #[test]
+    fn verifier_rejects_non_canonical_closure_call_dst_flag() {
+        let mut bytes = emit_ir_to_semcode(
+            &[
+                IrFunction {
+                    name: "helper".to_string(),
+                    instrs: vec![IrInstr::Ret { src: None }],
+                    ownership_events: Vec::new(),
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    instrs: vec![
+                        IrInstr::MakeClosure {
+                            dst: 0,
+                            name: "helper".to_string(),
+                            captures: Vec::new(),
+                        },
+                        IrInstr::ClosureCall {
+                            dst: None,
+                            closure: 0,
+                            arg: 0,
+                        },
+                        IrInstr::Ret { src: None },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+            ],
+            false,
+        )
+        .expect("emit");
+        let opcode_pos = find_opcode(&bytes, Opcode::ClosureCall.byte()).expect("closure call");
+        bytes[opcode_pos + 1] = 0xff;
+        let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::OperandOutOfBounds
+        );
+    }
+
+    // FA-07-003 (#1743): RET's source-present flag must be canonical 0/1.
+    #[test]
+    fn verifier_rejects_non_canonical_ret_src_flag() {
+        let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
+        let opcode_pos = find_opcode(&bytes, Opcode::Ret.byte()).expect("ret");
+        bytes[opcode_pos + 1] = 0xff;
+        let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::OperandOutOfBounds
         );
     }
 

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -72,6 +72,23 @@ Current ownership-specific structural checks for ownership transport include:
 - structural admission for valid `Borrow(Field)` and `Write(Field)` payloads
 - header/capability consistency for ownership transport
 
+## Canonical Operand Value Domains
+
+Operand shape validity is not only "a byte is present" — for fields with a
+fixed value domain, the byte must also be the canonical encoding for that
+domain. The verifier enforces:
+
+- boolean literal operands (`LOAD_BOOL`): must be `0` (false) or `1` (true)
+- quad literal operands (`LOAD_Q`): must be `0..=3` (the four-value quad
+  domain)
+- presence-flag operands (`CALL` and `CLOSURE_CALL` destination-present,
+  `RET` source-present): must be `0` or `1`
+
+A byte outside the canonical domain for its field is rejected at admission
+(`OperandOutOfBounds`), not normalized downstream. This narrows the
+previously admitted surface: byte values outside these domains that an
+earlier verifier accepted are no longer admissible.
+
 ## Contract Rule
 
 Standard execution uses the chain:


### PR DESCRIPTION
## Summary

Phase B, Repair Slice 1 (SemCode admission / verifier canonicality boundary). Fixes the three in-scope findings where the verifier accepted a byte-level operand encoding as long as *a* byte was present, without checking it was the canonical encoding for that field's domain. Each now fails closed at admission instead of being silently normalized downstream.

FA-05-001 / #1731 is explicitly **out of scope** for this PR — see "Deferred" below.

## Findings repaired

### FA-07-001 / #1741 — non-canonical bool literal

- **Previous behavior:** `decode_operands` for `Opcode::LoadBool` read the literal byte and discarded it (`read_u8(...)?;`), never checking its value.
- **Root cause:** admission proved only that a byte was *present*, not that it was a canonical bool encoding (`0` or `1`). The VM's `read_u8(...)? != 0` then treats every nonzero byte as `true`.
- **Repaired invariant:** the literal byte must be `0` or `1`; any other value is rejected with `VerificationCode::OperandOutOfBounds` before a `VerifiedSemCode` token is issued.
- **Regression test:** `verifier_rejects_non_canonical_bool_literal` — compiles a valid `LOAD_BOOL`, mutates the literal byte to `0xff`, asserts rejection.

### FA-07-002 / #1742 — invalid quad literal

- **Previous behavior:** `decode_operands` for `Opcode::LoadQ` read the literal byte and discarded it, with no value-domain check.
- **Root cause:** the VM enforces the canonical 4-value domain (`0..=3` → `QuadVal::{N,F,T,S}`, else `BadFormat`) only at execution time. An invalid literal could receive a `Verified` token and only fail later inside the VM.
- **Repaired invariant:** the literal byte must be `0..=3`; any other value is rejected at admission with `OperandOutOfBounds`.
- **Regression test:** `verifier_rejects_non_canonical_quad_literal` — compiles a valid `LOAD_Q`, mutates the literal byte to `0xff`, asserts rejection.

### FA-07-003 / #1743 — non-canonical presence flags

- **Previous behavior:**
  - `Call`'s destination-present flag byte was read and discarded entirely — its value never affected verification.
  - `ClosureCall`'s and `Ret`'s presence flags were interpreted as `byte != 0`, so any nonzero byte (not just canonical `1`) was accepted as `true`.
- **Root cause:** the binary contract didn't distinguish canonical `1` from arbitrary non-zero bytes in these flag positions; the VM uses the same `!= 0` interpretation, so non-canonical bytes acquired valid control meaning.
- **Repaired invariant:** each presence flag must be `0` or `1`; any other value is rejected at admission with `OperandOutOfBounds`.
- **Regression tests:** `verifier_rejects_non_canonical_call_dst_flag`, `verifier_rejects_non_canonical_closure_call_dst_flag`, `verifier_rejects_non_canonical_ret_src_flag`.

## Deferred — FA-05-001 / #1731 (DBG0/TupleGet sentinel collision)

Not implemented in this PR. Its fix has materially larger scope than the three above (it isn't a single-byte domain check): the debug section is recognized by sniffing `code[cursor..cursor+4] == b"DBG0"`, and `TupleGet`'s opcode byte (`0x44` = `'D'`) means a legitimately-compiled instruction can coincidentally produce the exact same six bytes as a genuine empty debug section — the two readings are bit-for-bit indistinguishable by content alone.

Full analysis, including why no local/content-based check can resolve it and the two candidate fixes considered, is recorded on [#1731](https://github.com/skulmakov-oss/Semantic/issues/1731#issuecomment-5308667806). The leading candidate for a dedicated follow-up slice is a fail-closed ambiguity check (if both the "debug section present" and "plain instructions" readings would structurally parse to end-of-buffer, reject as ambiguous) built on a small opcode-width primitive shared between `sm-format` and `sm-verify`, rather than a wire-format/version change. No wire-format change has been made in this PR.

## Validation

- `cargo test --workspace --quiet` — all green except one pre-existing, unrelated failure: `canonical_pack_all_sm_files_are_fmt_clean_and_lexically_sound` fails locally because `examples/canonical/stdlib_v0_helpers/src/main.sm` checks out with CRLF under this Windows environment's `core.autocrlf=true` (confirmed via `git status`/`git diff` showing zero change to that file, and the committed blob being LF-only). Environment-specific, not touched by this change, not reproducible on CI (Linux).
- `cargo test -p sm-verify --lib` (within full-workspace feature context, matching how `compile_program_to_semcode`'s default `RustLike` profile gets enabled) — 69 passed, 0 failed, including the 5 new regression tests.
- `cargo fmt -p sm-verify -- --check` — clean. (`cargo fmt --all --check` hits a Windows command-line-length limit (`OS error 206`) in this environment on this large a workspace; scoped to the touched crate instead.)
- `cargo clippy -p sm-verify --all-targets -- -D warnings` — clean.

## Test plan

- [x] New regression tests fail against pre-fix code, pass against the fix
- [x] Full workspace test suite green (bar the pre-existing, unrelated CRLF test failure noted above)
- [x] `cargo fmt` / `cargo clippy` clean for the touched crate
- [ ] Reviewer feedback cycle (in progress per repair workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)