### PR TITLE
fix(repo): enforce LF checkout for examples/canonical/**

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 tests/golden_snapshots/** text eol=lf
 tests/fixtures/ui_frame_inspection/** text eol=lf
 tests/fixtures/hub/** text eol=lf
+examples/canonical/** text eol=lf


### PR DESCRIPTION
## Summary

Fixes #1789 (opened during Phase B Repair Slice 1.5's qualification-harness investigation, PR #1792).

## Previous behavior

`canonical_pack_all_sm_files_are_fmt_clean_and_lexically_sound` (`tests/canonical_source_style.rs`) fails locally on Windows:

```
examples/canonical/stdlib_v0_helpers/src/main.sm contains CR (must be LF-only)
```

## Root cause

`docs/spec/source_style.md` rule 2 ("Required Lexical/File Invariants") is explicit: canonical `.sm` files must have **"Line endings are LF (`\n`) only; no CR"**, a byte-canonical contract, not a semantic-equivalence one, enforced by `smc fmt --check` and this test.

`.gitattributes` already enforces `eol=lf` for three other directories with the same requirement:

```
tests/golden_snapshots/** text eol=lf
tests/fixtures/ui_frame_inspection/** text eol=lf
tests/fixtures/hub/** text eol=lf
```

`examples/canonical/**`, the exact directory `discover_canonical_sm_files()` scans, was missing from that list, so it fell under the blanket `* text=auto` rule. On a Windows checkout with `core.autocrlf=true`, git converts those files to CRLF on checkout, even though the committed blobs are LF-only (confirmed via `git show HEAD:examples/canonical/stdlib_v0_helpers/src/main.sm`, no CR present). Linux CI (`ubuntu-latest`) doesn't CRLF-convert on checkout, so this was never visible there.

## Repaired invariant

`examples/canonical/** text eol=lf` added to `.gitattributes`, matching the existing pattern. This is a checkout-enforcement fix, not a test or content change: the repository content was already correct; only the Windows checkout behavior was wrong.

## Regression test

No new test needed, this is a checkout-behavior fix for an existing test (`canonical_pack_all_sm_files_are_fmt_clean_and_lexically_sound`, plus the other 18 tests in the same file) that already encodes the contract. I reproduced the failure first (before any change), confirmed the committed blob was already LF-only, applied the `.gitattributes` change, forced a re-checkout (`git checkout HEAD -- examples/canonical`) to prove it actually changes the working-tree bytes (verified 0 CR bytes remain), and confirmed all 19 tests in `tests/canonical_source_style.rs` pass locally afterward.

## Validation

- `cargo test --test canonical_source_style` before the fix: 1 failed (the CRLF assertion), 18 passed.
- `cargo test --test canonical_source_style` after the fix: **19 passed, 0 failed**.
- Diff is `.gitattributes` only (1 line added); no `.sm` file content changed, since the repository content was never wrong.

## Test plan

- [x] Reproduced the failure locally before changing anything
- [x] Confirmed the committed blob was already LF-only (repository-content, not test, was correct)
- [x] Applied the fix, forced re-checkout, verified 0 CR bytes remain
- [x] All 19 tests in `tests/canonical_source_style.rs` pass
- [ ] Reviewer feedback cycle (in progress per repair workflow)

Generated with [Claude Code](https://claude.com/claude-code)
