### PR TITLE
tooling: make full workspace fmt qualification Windows-safe

### DIFF
--- a/scripts/admission_guard.ps1
+++ b/scripts/admission_guard.ps1
@@ -38,15 +38,25 @@ function Invoke-WorkspaceFmtCheck {
     # (every package still gets checked, none skipped), just split across
     # multiple invocations that each stay under the limit.
     #
-    # The package set comes from `cargo metadata`, not a hand-maintained
-    # list, so it also covers workspace packages that are pulled in only as
-    # a local path-dependency of a member and are not themselves listed in
-    # [workspace.members] (e.g. ui-shell-kit).
-    $metadataJson = cargo metadata --no-deps --format-version 1
+    # The package set comes from the full `cargo metadata` resolution
+    # (not --no-deps, and not a hand-maintained list), filtered to local
+    # (source = null) packages. `cargo fmt --all` covers "all packages, and
+    # also their local path-based dependencies" (per `cargo fmt --help`) -
+    # a broader set than just [workspace.members], since a local path
+    # dependency does not have to be a declared member to be part of that
+    # set (e.g. this repo's own ui-shell-kit is pulled in only as a path
+    # dependency of a member and isn't listed in [workspace.members]).
+    # --no-deps would miss a local path dependency that lives outside the
+    # workspace root's directory tree; filtering the full graph by
+    # source = null does not, matching --all's actual scope exactly.
+    $metadataJson = cargo metadata --format-version 1
     if ($LASTEXITCODE -ne 0) {
         throw "cargo metadata failed while deriving the workspace package set for fmt check"
     }
-    $packages = ($metadataJson | ConvertFrom-Json).packages.name | Sort-Object
+    $packages = ($metadataJson | ConvertFrom-Json).packages |
+        Where-Object { $null -eq $_.source } |
+        Select-Object -ExpandProperty name |
+        Sort-Object
 
     $failed = @()
     foreach ($pkg in $packages) {

--- a/scripts/admission_guard.ps1
+++ b/scripts/admission_guard.ps1
@@ -4,7 +4,9 @@
 # replace GitHub Actions and must not be treated as a release gate by itself.
 #
 # Formatting gate:
-# cargo fmt --all --check
+# equivalent to `cargo fmt --all --check`, run per-package (see
+# Invoke-WorkspaceFmtCheck) so it doesn't exceed the Windows CreateProcess
+# command-line length limit on this workspace.
 #
 # This script includes formatting because the baseline has been normalized.
 # Do not use formatting as a substitute for behavior checks. After any manual
@@ -26,6 +28,40 @@ Set-StrictMode -Version Latest
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 Set-Location $RepoRoot
+
+function Invoke-WorkspaceFmtCheck {
+    # `cargo fmt --all --check` spawns rustfmt with every source file's
+    # absolute path as a single argument list. On this workspace (554 .rs
+    # files) that list is ~60K characters against Windows' ~32K CreateProcess
+    # command-line limit, and the invocation fails with OS error 206 before
+    # rustfmt itself ever runs. Loop per package instead: same coverage
+    # (every package still gets checked, none skipped), just split across
+    # multiple invocations that each stay under the limit.
+    #
+    # The package set comes from `cargo metadata`, not a hand-maintained
+    # list, so it also covers workspace packages that are pulled in only as
+    # a local path-dependency of a member and are not themselves listed in
+    # [workspace.members] (e.g. ui-shell-kit).
+    $metadataJson = cargo metadata --no-deps --format-version 1
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo metadata failed while deriving the workspace package set for fmt check"
+    }
+    $packages = ($metadataJson | ConvertFrom-Json).packages.name | Sort-Object
+
+    $failed = @()
+    foreach ($pkg in $packages) {
+        cargo fmt -p $pkg -- --check
+        if ($LASTEXITCODE -ne 0) {
+            $failed += $pkg
+        }
+    }
+
+    if ($failed.Count -gt 0) {
+        throw "cargo fmt --check failed for package(s): $($failed -join ', ')"
+    }
+
+    Write-Host "cargo fmt --check passed for all $($packages.Count) workspace packages"
+}
 
 function Invoke-LocalCiStep {
     param(
@@ -142,8 +178,8 @@ function Invoke-QuickGate {
     Invoke-LocalCiStep "cargo check --workspace --all-targets" {
         cargo check --workspace --all-targets
     }
-    Invoke-LocalCiStep "cargo fmt --all --check" {
-        cargo fmt --all --check
+    Invoke-LocalCiStep "cargo fmt --all --check (per-package, Windows-safe)" {
+        Invoke-WorkspaceFmtCheck
     }
 }
 
@@ -154,8 +190,8 @@ function Invoke-PRReadyGate {
     Invoke-LocalCiStep "cargo clippy --workspace --all-targets" {
         cargo clippy --workspace --all-targets -- -D warnings
     }
-    Invoke-LocalCiStep "cargo fmt --all --check" {
-        cargo fmt --all --check
+    Invoke-LocalCiStep "cargo fmt --all --check (per-package, Windows-safe)" {
+        Invoke-WorkspaceFmtCheck
     }
     Invoke-LocalCiStep "cargo test --workspace --quiet" {
         cargo test --workspace --quiet
@@ -166,8 +202,8 @@ function Invoke-PRReadyGate {
 }
 
 function Invoke-CIParityGate {
-    Invoke-LocalCiStep "ci/pr-ready: cargo fmt --all --check" {
-        cargo fmt --all --check
+    Invoke-LocalCiStep "ci/pr-ready: cargo fmt --all --check (per-package, Windows-safe)" {
+        Invoke-WorkspaceFmtCheck
     }
     Invoke-LocalCiStep "ci/pr-ready: cargo clippy --workspace --all-targets -- -D warnings" {
         cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

Fixes #1790 (opened during Phase B Repair Slice 1.5's qualification-harness investigation, PR #1792).

## 1. Reproduce and measure

- Toolchain: `rustc 1.97.1`, `cargo 1.97.1` (matches CI).
- Workspace: 554 `.rs` files (excluding `target/`).
- Exact failing command: `cargo fmt --all --check`.
- Exact error: `Имя файла или его расширение имеет слишком большую длину. (os error 206)` — Win32 `ERROR_FILENAME_EXCED_RANGE`.
- Confirmed the failure originates at process-spawn (`CreateProcess`), before rustfmt's own formatting logic ever runs: `cargo fmt -p sm-verify -- --check` (a single package) succeeds cleanly with exit 0.
- Measured the actual cause quantitatively rather than assuming it: `cargo fmt --all` invokes `rustfmt` with every source file's absolute path as a separate argument. For this workspace's 554 files from this checkout location, that's **~59,735 combined characters**, against Windows' **~32,767-character** `CreateProcess` command-line limit — nearly double.

## 2. Authoritative package set

Derived from `cargo metadata --no-deps --format-version 1`, not a hand-maintained list. It reports **36 packages** — one more than the 34 entries actually written in `[workspace.members]` in `Cargo.toml`. The extra one is `ui-shell-kit` (`experiments/ui-shell-kit`), pulled into the workspace only as a local path-dependency of a member, never listed explicitly. A hand-maintained list would have silently skipped it — this is exactly the trap the issue warned about, and it's real, not hypothetical.

Confirmed `cargo fmt -p ui-shell-kit -- --check` resolves and works correctly despite the package not being explicitly listed, since Cargo's package resolution is name-based within the resolved workspace graph, not membership-list-based.

## 3. The fix

Added `Invoke-WorkspaceFmtCheck` to `scripts/admission_guard.ps1` (the repo's existing local CI-parity tool, which already called `cargo fmt --all --check` in three places — `Quick`, `PRReady`, and `CIParity` gates):

```powershell
function Invoke-WorkspaceFmtCheck {
    $metadataJson = cargo metadata --no-deps --format-version 1
    if ($LASTEXITCODE -ne 0) { throw "cargo metadata failed while deriving the workspace package set for fmt check" }
    $packages = ($metadataJson | ConvertFrom-Json).packages.name | Sort-Object

    $failed = @()
    foreach ($pkg in $packages) {
        cargo fmt -p $pkg -- --check
        if ($LASTEXITCODE -ne 0) { $failed += $pkg }
    }

    if ($failed.Count -gt 0) {
        throw "cargo fmt --check failed for package(s): $($failed -join ', ')"
    }
    Write-Host "cargo fmt --check passed for all $($packages.Count) workspace packages"
}
```

Every workspace package still gets checked, none skipped; the single oversized invocation is just split into several that each stay under the Windows argument limit. All failures are collected (not just the first), matching `--all --check`'s behavior of reporting every violation in one pass.

## 4. Scope discipline (per the issue's "important requirement")

**Linux CI is untouched.** `.github/workflows/ci.yml`'s `pr-ready` job still runs plain `cargo fmt --all --check` — it already passes there and isn't invoked from this script. Confirmed `admission_guard.ps1`/`local_ci.ps1` are not referenced anywhere in `.github/workflows/`, so this change has zero effect on the authoritative CI gate. This PR only makes the existing local Windows dev-tool usable again.

## 5. Regression proof

- **Clean tree, before:** ran `admission_guard.ps1 -Quick` — `cargo fmt --check passed for all 36 workspace packages`.
- **Controlled violation:** appended a deliberately misformatted function to `experiments/ui-shell-kit/src/action.rs`. `ui-shell-kit` sorts **last** of the 36 packages alphabetically, chosen deliberately so the proof also shows the loop doesn't stop early or silently skip the tail of the list.
- **Caught:** `Invoke-WorkspaceFmtCheck` printed the exact rustfmt diff and threw `cargo fmt --check failed for package(s): ui-shell-kit`, propagating as a nonzero exit through `admission_guard.ps1`.
- **Restored:** reverted the file, confirmed zero diff against `git diff`.
- **Clean tree, after:** reran `-Quick` — `cargo fmt --check passed for all 36 workspace packages` again.

## Files changed

`scripts/admission_guard.ps1` only — no other files touched, no dependency changes, no CI workflow changes, no production code changes.

## Test plan

- [x] Reproduced and quantitatively measured the Windows failure before changing anything
- [x] Derived the package set from `cargo metadata`, not a hand-maintained list (caught a real gap: `ui-shell-kit`)
- [x] Clean-tree pass confirmed (36/36 packages)
- [x] Controlled violation in the last-sorted, non-root package caught with the exact diff and correct failure propagation
- [x] File restored, clean-tree pass reconfirmed
- [x] Linux CI (`ci.yml`) confirmed untouched and unaffected
- [x] Reviewer feedback cycle (in progress per repair workflow)

Generated with [Claude Code](https://claude.com/claude-code)
