### PR TITLE
test(sm-verify): target SemCode mutations structurally

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -1752,7 +1752,7 @@ mod tests {
     fn verifier_rejects_jump_past_instruction_stream() {
         let mut bytes = compile_program_to_semcode("fn main() { if true { return; } return; }")
             .expect("compile");
-        let opcode_pos = find_opcode(&bytes, Opcode::JmpIf.byte()).expect("jmpif");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::JmpIf, 0);
         let target_pos = opcode_pos + 1 + 2;
         bytes[target_pos..target_pos + 4].copy_from_slice(&999u32.to_le_bytes());
         let report = verify_semcode(&bytes).expect_err("must reject");
@@ -1767,7 +1767,7 @@ mod tests {
         let mut bytes =
             compile_program_to_semcode("fn helper() { return; } fn main() { helper(); return; }")
                 .expect("compile");
-        let opcode_pos = find_opcode(&bytes, Opcode::Call.byte()).expect("call");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::Call, 0);
         let sid_pos = opcode_pos + 1 + 1 + 2;
         bytes[sid_pos..sid_pos + 2].copy_from_slice(&99u16.to_le_bytes());
         let report = verify_semcode(&bytes).expect_err("must reject");
@@ -1781,7 +1781,7 @@ mod tests {
     fn verifier_rejects_register_past_verified_local_budget() {
         let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
             .expect("compile");
-        let opcode_pos = find_opcode(&bytes, Opcode::LoadBool.byte()).expect("load bool");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::LoadBool, 0);
         let dst_pos = opcode_pos + 1;
         bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
         let report = verify_semcode(&bytes).expect_err("must reject");
@@ -1798,7 +1798,7 @@ mod tests {
     fn verifier_rejects_non_canonical_bool_literal() {
         let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
             .expect("compile");
-        let opcode_pos = find_opcode(&bytes, Opcode::LoadBool.byte()).expect("load bool");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::LoadBool, 0);
         let literal_pos = opcode_pos + 1 + 2;
         bytes[literal_pos] = 0xff;
         let report = verify_semcode(&bytes).expect_err("must reject");
@@ -1813,13 +1813,15 @@ mod tests {
     // a Verified token and only failing later in the VM as BadFormat.
     #[test]
     fn verifier_rejects_non_canonical_quad_literal() {
-        // No let-binding: a named local would intern a string, and a short
-        // string's length byte can coincidentally equal LoadQ's opcode byte
-        // (0x01), making a naive byte scan land on the wrong offset.
+        // This exact fixture interns "a" as a string; the string table's
+        // length byte for a 1-character string equals LoadQ's opcode byte
+        // (0x01), which used to make a naive whole-buffer byte scan land on
+        // the string table instead of the real LOAD_Q instruction (see
+        // #1791). find_instruction locates it via the decoded instruction
+        // stream instead, so it is unaffected by that coincidence.
         let mut bytes =
-            compile_program_to_semcode("fn get() -> quad { return T; } fn main() { return; }")
-                .expect("compile");
-        let opcode_pos = find_opcode(&bytes, Opcode::LoadQ.byte()).expect("load q");
+            compile_program_to_semcode("fn main() { let a: quad = N; return; }").expect("compile");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::LoadQ, 0);
         let literal_pos = opcode_pos + 1 + 2;
         bytes[literal_pos] = 0xff;
         let report = verify_semcode(&bytes).expect_err("must reject");
@@ -1836,7 +1838,7 @@ mod tests {
         let mut bytes =
             compile_program_to_semcode("fn helper() { return; } fn main() { helper(); return; }")
                 .expect("compile");
-        let opcode_pos = find_opcode(&bytes, Opcode::Call.byte()).expect("call");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::Call, 0);
         bytes[opcode_pos + 1] = 0xff;
         let report = verify_semcode(&bytes).expect_err("must reject");
         assert_eq!(
@@ -1877,7 +1879,7 @@ mod tests {
             false,
         )
         .expect("emit");
-        let opcode_pos = find_opcode(&bytes, Opcode::ClosureCall.byte()).expect("closure call");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::ClosureCall, 0);
         bytes[opcode_pos + 1] = 0xff;
         let report = verify_semcode(&bytes).expect_err("must reject");
         assert_eq!(
@@ -1890,7 +1892,7 @@ mod tests {
     #[test]
     fn verifier_rejects_non_canonical_ret_src_flag() {
         let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
-        let opcode_pos = find_opcode(&bytes, Opcode::Ret.byte()).expect("ret");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::Ret, 0);
         bytes[opcode_pos + 1] = 0xff;
         let report = verify_semcode(&bytes).expect_err("must reject");
         assert_eq!(
@@ -2361,8 +2363,58 @@ mod tests {
         cursor
     }
 
-    fn find_opcode(bytes: &[u8], opcode: u8) -> Option<usize> {
-        bytes.iter().position(|byte| *byte == opcode)
+    /// Locates the absolute byte offset of the `occurrence`-th (0-indexed)
+    /// instance of `opcode` within `function_name`'s actual decoded
+    /// instruction stream.
+    ///
+    /// Walks instruction-by-instruction from the real `instr_start_offset`,
+    /// reusing the same decode logic (`decode_semcode_envelope`,
+    /// `decode_operands`) the verifier's own admission path uses, instead of
+    /// scanning raw bytes for the first matching value anywhere in the
+    /// buffer. This cannot match a header, function-name, string-table,
+    /// debug-section, or ownership-section byte, and cannot match an earlier
+    /// instruction's operand byte, because those are never mistaken for an
+    /// opcode-position read during the walk.
+    ///
+    /// Panics with a precise message if the function isn't found, if
+    /// decoding fails, or if fewer than `occurrence + 1` matches exist -
+    /// never silently selects an arbitrary occurrence when more than one
+    /// exists.
+    fn find_instruction(
+        bytes: &[u8],
+        function_name: &str,
+        opcode: Opcode,
+        occurrence: usize,
+    ) -> usize {
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(bytes).expect("decode semcode");
+        let env = functions
+            .iter()
+            .find(|f| f.name == function_name)
+            .unwrap_or_else(|| panic!("function '{function_name}' not found"));
+
+        let code = env.code_slice;
+        let mut cursor = env.instr_start_offset;
+        let mut matches = Vec::new();
+        while cursor < code.len() {
+            let instr_offset = cursor;
+            let raw = read_u8(code, &mut cursor).expect("read opcode byte");
+            let decoded = Opcode::from_byte(raw).expect("valid opcode");
+            if decoded == opcode {
+                matches.push(instr_offset);
+            }
+            decode_operands(function_name, code, &mut cursor, instr_offset, decoded)
+                .expect("decode operands");
+        }
+
+        let relative = *matches.get(occurrence).unwrap_or_else(|| {
+            panic!(
+                "expected occurrence {occurrence} of {opcode:?} in '{function_name}', found \
+                 {} match(es) at {matches:?}",
+                matches.len()
+            )
+        });
+        env.code_offset + relative
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1791 (opened during Phase B Repair Slice 1.5's qualification-harness investigation, PR #1792). Test-only change — no production verifier/VM/format behavior is touched.

## 1. Audit (all 8 call sites)

`find_opcode(bytes, opcode) -> Option<usize>` scanned the *entire* serialized SemCode buffer for the first byte equal to a given opcode value — header, function name, string-table bytes, everything, not just the instruction stream.

| Call site | Opcode sought | Byte value | Collision risk |
| --- | --- | --- | --- |
| `verifier_rejects_jump_past_instruction_stream` | `JmpIf` | `0x31` | low (larger value) |
| `verifier_rejects_bad_string_reference` | `Call` | `0x40` | low |
| `verifier_rejects_register_past_verified_local_budget` | `LoadBool` | `0x02` | **high** — small int, common as a string/count field |
| `verifier_rejects_non_canonical_bool_literal` | `LoadBool` | `0x02` | **high** |
| `verifier_rejects_non_canonical_quad_literal` | `LoadQ` | `0x01` | **high** — this is the one that already broke, in #1788 |
| `verifier_rejects_non_canonical_call_dst_flag` | `Call` | `0x40` | low |
| `verifier_rejects_non_canonical_closure_call_dst_flag` | `ClosureCall` | `0x5e` | low |
| `verifier_rejects_non_canonical_ret_src_flag` | `Ret` | `0x41` | low |

All 8 share the identical technique. Only `LoadQ` (#1788) has actually failed so far; `LoadBool` shares the same structural risk category (small integer, easily coincides with a string-table length/count field) and was fragile by luck, not by design — its two fixtures simply didn't happen to intern a string whose length equalled `2`. This confirms a single shared root cause across all 8, not 8 independent issues — one structural helper replaces all of them.

## 2. Reproduce the known failure structurally

Before writing the fix, added a temporary test reproducing the exact #1788 fixture (`"fn main() { let a: quad = N; return; }"`) and asserted, using the real decoder, that `find_opcode`'s returned position is **strictly before** the real instruction stream's start offset (`decode_semcode_envelope`'s `instr_start_offset`) — i.e. structurally inside the string table, never a genuine instruction:

```
bytes around naive pos: [00, 00, 01, 00, 01, 00]   <- string-table length bytes
bytes around real pos:  [01, 00, 00, 00, 05, 00]   <- the actual LOAD_Q instruction
```

Assertion passed, proving the false-target precisely rather than trusting the historical incident report. This temporary test was removed before the real fix (not committed) — it existed only to nail down the exact evidence.

## 3. The structural helper

```rust
fn find_instruction(
    bytes: &[u8],
    function_name: &str,
    opcode: Opcode,
    occurrence: usize,
) -> usize
```

Walks `function_name`'s actual decoded instruction stream starting from its real `instr_start_offset`, reusing:
- `sm_format::semcode_decode::decode_semcode_envelope` (the same decoder the verifier's own admission path uses) to locate the function and its instruction-stream boundary,
- this crate's own `decode_operands` (the same function `verify_function_code` uses) to correctly skip each instruction's operands while walking, so the next byte read is always a genuine opcode-position byte, never a header/string-table/debug-section/ownership-section byte and never another instruction's operand byte.

No second parser was written — both pieces of decode logic already existed in production code and are simply called from the test module (`use super::*` already brings `decode_operands` into scope; `sm_format` is already a normal dependency of this crate).

Panics with a precise message if the function isn't found, if decoding fails, or if fewer than `occurrence + 1` matches exist for the requested opcode — it never silently picks an arbitrary occurrence when more than one exists, and never returns a header/string-table position by construction (those bytes are structurally unreachable by this walk).

## 4. Migration scope

All 8 call sites migrated; `find_opcode` is fully removed — not left in the file unsound-but-unused, per the issue's explicit requirement.

`verifier_rejects_non_canonical_quad_literal` was previously worked around in #1788 with a differently-shaped fixture (`"fn get() -> quad { return T; } fn main() { return; }"`) specifically to dodge the bug, with a comment explaining why. Reverted it to the original collision-prone fixture (`"fn main() { let a: quad = N; return; }"`) now that the helper is structurally immune — the test itself now documents and proves the exact scenario that broke the old approach, rather than sidestepping it.

## 5. Validation

- `cargo test -p sm-verify --lib`: **69 passed, 0 failed**.
- `cargo test --workspace` (every package): zero failures anywhere.
- Full local qualification via the harness repaired in #1792/#1794 — `scripts/admission_guard.ps1 -PRReady` (fmt, clippy, workspace tests, `public_api_contracts`): **ADMISSION GUARD PR-READY PASS**. (This run's Windows-safe fmt check — from #1794 — caught a real formatting issue in my own edit along the way; fixed with `cargo fmt -p sm-verify` before the final clean run.)

## Files changed

`crates/sm-verify/src/lib.rs` only. No production code, no dependency changes, no CI workflow changes.

## Test plan

- [x] Audited all 8 `find_opcode` call sites, classified collision risk, confirmed one shared root cause
- [x] Reproduced the known #1788 failure structurally (proved the wrong position, not just cited history)
- [x] Built one minimal helper reusing existing production decode logic, no new parser
- [x] Migrated and removed all 8 uses of the unsound helper — none left in active use
- [x] `sm-verify` full test suite green (69/69)
- [x] Full workspace test suite green
- [x] Full local PR-ready qualification gate green (through the repaired harness)
- [x] Reviewer feedback cycle (in progress per repair workflow)

Generated with [Claude Code](https://claude.com/claude-code)
