### PR TITLE
ci: align Windows 7hell fmt coverage with full workspace qualification

### DIFF
--- a/scripts/admission_guard.ps1
+++ b/scripts/admission_guard.ps1
@@ -29,49 +29,7 @@ Set-StrictMode -Version Latest
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 Set-Location $RepoRoot
 
-function Invoke-WorkspaceFmtCheck {
-    # `cargo fmt --all --check` spawns rustfmt with every source file's
-    # absolute path as a single argument list. On this workspace (554 .rs
-    # files) that list is ~60K characters against Windows' ~32K CreateProcess
-    # command-line limit, and the invocation fails with OS error 206 before
-    # rustfmt itself ever runs. Loop per package instead: same coverage
-    # (every package still gets checked, none skipped), just split across
-    # multiple invocations that each stay under the limit.
-    #
-    # The package set comes from the full `cargo metadata` resolution
-    # (not --no-deps, and not a hand-maintained list), filtered to local
-    # (source = null) packages. `cargo fmt --all` covers "all packages, and
-    # also their local path-based dependencies" (per `cargo fmt --help`) -
-    # a broader set than just [workspace.members], since a local path
-    # dependency does not have to be a declared member to be part of that
-    # set (e.g. this repo's own ui-shell-kit is pulled in only as a path
-    # dependency of a member and isn't listed in [workspace.members]).
-    # --no-deps would miss a local path dependency that lives outside the
-    # workspace root's directory tree; filtering the full graph by
-    # source = null does not, matching --all's actual scope exactly.
-    $metadataJson = cargo metadata --format-version 1
-    if ($LASTEXITCODE -ne 0) {
-        throw "cargo metadata failed while deriving the workspace package set for fmt check"
-    }
-    $packages = ($metadataJson | ConvertFrom-Json).packages |
-        Where-Object { $null -eq $_.source } |
-        Select-Object -ExpandProperty name |
-        Sort-Object
-
-    $failed = @()
-    foreach ($pkg in $packages) {
-        cargo fmt -p $pkg -- --check
-        if ($LASTEXITCODE -ne 0) {
-            $failed += $pkg
-        }
-    }
-
-    if ($failed.Count -gt 0) {
-        throw "cargo fmt --check failed for package(s): $($failed -join ', ')"
-    }
-
-    Write-Host "cargo fmt --check passed for all $($packages.Count) workspace packages"
-}
+. (Join-Path $PSScriptRoot "workspace_fmt_check.ps1")
 
 function Invoke-LocalCiStep {
     param(

--- a/scripts/workspace_fmt_check.ps1
+++ b/scripts/workspace_fmt_check.ps1
@@ -1,0 +1,54 @@
+# Shared Windows-safe replacement for `cargo fmt --all --check`.
+#
+# Dot-source this file, then call Invoke-WorkspaceFmtCheck. Used by both
+# scripts/admission_guard.ps1 and tools/7hell/run_ci.ps1 so there is exactly
+# one authoritative package-discovery/check mechanism, not two copies that
+# can silently drift apart.
+
+function Invoke-WorkspaceFmtCheck {
+    # `cargo fmt --all --check` (and, on this workspace, even bare
+    # `cargo fmt --check` - its actual default scope is not root-only; see
+    # #1796) spawns rustfmt with every source file's absolute path as a
+    # single argument list. On this workspace (554+ .rs files) that list is
+    # ~60K characters against Windows' ~32K CreateProcess command-line
+    # limit, and the invocation fails with OS error 206 before rustfmt
+    # itself ever runs - deterministically once the package set crosses
+    # that size, regardless of which command triggered it. Loop per package
+    # instead: same coverage (every package still gets checked, none
+    # skipped), just split across multiple invocations that each stay under
+    # the limit, and unaffected by checkout path length.
+    #
+    # The package set comes from the full `cargo metadata` resolution
+    # (not --no-deps, and not a hand-maintained list), filtered to local
+    # (source = null) packages. `cargo fmt --all` covers "all packages, and
+    # also their local path-based dependencies" (per `cargo fmt --help`) -
+    # a broader set than just [workspace.members], since a local path
+    # dependency does not have to be a declared member to be part of that
+    # set (e.g. this repo's own ui-shell-kit is pulled in only as a path
+    # dependency of a member and isn't listed in [workspace.members]).
+    # --no-deps would miss a local path dependency that lives outside the
+    # workspace root's directory tree; filtering the full graph by
+    # source = null does not, matching --all's actual scope exactly.
+    $metadataJson = cargo metadata --format-version 1
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo metadata failed while deriving the workspace package set for fmt check"
+    }
+    $packages = ($metadataJson | ConvertFrom-Json).packages |
+        Where-Object { $null -eq $_.source } |
+        Select-Object -ExpandProperty name |
+        Sort-Object
+
+    $failed = @()
+    foreach ($pkg in $packages) {
+        cargo fmt -p $pkg -- --check
+        if ($LASTEXITCODE -ne 0) {
+            $failed += $pkg
+        }
+    }
+
+    if ($failed.Count -gt 0) {
+        throw "cargo fmt --check failed for package(s): $($failed -join ', ')"
+    }
+
+    Write-Host "cargo fmt --check passed for all $($packages.Count) workspace packages"
+}

--- a/tools/7hell/run_ci.ps1
+++ b/tools/7hell/run_ci.ps1
@@ -8,6 +8,15 @@ function Assert-Success {
     }
 }
 
+# Shared with scripts/admission_guard.ps1: one authoritative fmt-check
+# mechanism, not two copies that can drift apart. See #1796 - bare
+# `cargo fmt --check` is not root-scoped (its actual default scope already
+# reaches the full local-package graph) and hits the same Windows
+# CreateProcess argument-length limit as `cargo fmt --all --check` once the
+# package set is large enough; it only happened to survive on CI's short
+# checkout path.
+. (Join-Path $PSScriptRoot "..\..\scripts\workspace_fmt_check.ps1")
+
 Write-Host "========================================="
 Write-Host "  7hell PCC Qualification Fast Gate      "
 Write-Host "========================================="
@@ -16,8 +25,12 @@ Write-Host ""
 # -----------------------------------------------------------------------------
 # Hell 1
 Write-Host "[ Hell 1 ] Workspace Health..." -ForegroundColor Cyan
-cargo fmt --check
-Assert-Success "cargo fmt failed"
+try {
+    Invoke-WorkspaceFmtCheck
+} catch {
+    Write-Host "FAIL: cargo fmt failed - $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
 cargo check --workspace --all-features
 Assert-Success "cargo check failed"
 Write-Host "PASS: Hell 1" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Fixes #1796. Tooling/CI only — no Semantic language/runtime/verifier/compiler behavior changed.

## Before/after coverage

| | Before | After |
| --- | --- | --- |
| Windows `7hell` (`tools/7hell/run_ci.ps1`, Hell 1) | bare `cargo fmt --check` — crashes with OS error 206 on any checkout path long enough to push its (already broad) file set over the Windows `CreateProcess` argument limit; "worked" only by luck of GitHub Actions' short checkout path | `Invoke-WorkspaceFmtCheck` — every local package (derived from `cargo metadata`, filtered to `source == null`) checked via `cargo fmt -p <pkg> -- --check`, deterministic regardless of checkout path |
| Linux `pr-ready` (`.github/workflows/ci.yml`) | `cargo fmt --all --check` | unchanged |

## Root cause — corrected from the original hypothesis

The initial framing (bare `cargo fmt --check` scopes to the root package only, so Windows CI silently checks less than Linux) turned out to be **wrong**, and I want to be upfront that I disproved my own issue's premise before writing any code, rather than build on it.

Direct bisection on this workspace:

```
cargo fmt --check -p semantic_language                    -> exit 0
cargo fmt --check <all 35 formal [workspace.members]>     -> exit 0
cargo fmt --check <those 35 + ui-shell-kit, 36 total>      -> exit 1, os error 206
cargo fmt --check                              (bare)      -> exit 1, os error 206
```

Bare's crash threshold matches the 36-package (full local dependency graph) scope exactly, not the 35-package scope. So bare `cargo fmt --check`'s actual default is already at least as broad as `cargo fmt --all` — it is **not** root-scoped. The real story: bare and `--all` hit the identical Windows `CreateProcess` argument-length limit already diagnosed in #1790 (~59,735 characters of absolute paths vs. the ~32,767-character limit) — Windows CI has simply never crossed that threshold because GitHub Actions' checkout path (`D:\a\Semantic\Semantic\`) is short enough to keep the same large file set under budget. On a longer path (confirmed: mine), the identical command fails closed rather than silently checking less.

I posted this correction to #1796 (title and body) with the full evidence before implementing, per the "reproduce before changing code" requirement — see the issue for the complete bisection log.

## Repaired invariant

```
Windows 7hell fmt coverage == Linux cargo fmt --all effective package coverage
```

...now true deterministically (not path-length-dependent), via the same proven mechanism from #1794.

## Relationship to #1790 / #1794

`Invoke-WorkspaceFmtCheck` (added in #1794) already solved this exact class of problem for `scripts/admission_guard.ps1`. Rather than re-implement it for `tools/7hell/run_ci.ps1` (which would create two independently-drifting copies), I extracted it into `scripts/workspace_fmt_check.ps1` — a small dot-sourced shared file — and both scripts now call the same function. No `--no-deps`, no hardcoded package list, no change to the underlying coverage logic from #1794 (still full `cargo metadata` filtered to `source == null`, matching `--all`'s actual documented scope, per the hardening #1794's own review round required).

## Files changed

- `scripts/workspace_fmt_check.ps1` — **new**, contains `Invoke-WorkspaceFmtCheck` verbatim (moved from `admission_guard.ps1`)
- `scripts/admission_guard.ps1` — now dot-sources the shared file instead of defining the function inline; behavior unchanged (reconfirmed: still "cargo fmt --check passed for all 36 workspace packages")
- `tools/7hell/run_ci.ps1` — Hell 1 now dot-sources the shared file and calls `Invoke-WorkspaceFmtCheck` (wrapped in `try`/`catch` to preserve this script's existing `"FAIL: <message>"` + `exit 1` convention) instead of bare `cargo fmt --check`

`.github/workflows/ci.yml` is untouched — no evidence found that Linux's `cargo fmt --all --check` needs to change.

## Regression proof

1. **Clean tree, full script:** ran `tools/7hell/run_ci.ps1` end to end — reached `FAST 7HELL GATE PASSED!`, which is only reachable if Hell 1 succeeded (`$ErrorActionPreference = "Stop"` + the new `try`/`catch` would halt the script at Hell 1 on any failure).
2. **Controlled violation:** appended a deliberately misformatted function to `experiments/ui-shell-kit/src/action.rs` — non-root, last-sorted of 36 packages (same deliberate choice as #1794, to prove the loop doesn't stop early).
3. **Caught:** ran the exact Hell 1 fmt logic directly — reported the precise diff and failed with `cargo fmt --check failed for package(s): ui-shell-kit`, propagating a nonzero exit.
4. **Restored:** reverted the file, confirmed zero diff.
5. **Clean tree, after:** reran — `cargo fmt --check passed for all 36 workspace packages` again.
6. Package count comes from `$packages.Count` (`cargo metadata`, evaluated at runtime) — never hardcoded, so it survives future package additions without needing a test update.

## Explicit statement

Production Semantic language/runtime/verifier/compiler code is untouched. This PR touches only PowerShell tooling (`scripts/`, `tools/7hell/`).

## Test plan

- [x] Investigated and corrected the root-cause hypothesis with direct evidence before writing code
- [x] Extracted the #1794 helper into one shared file used by both scripts (no drifting duplicate logic)
- [x] Full `tools/7hell/run_ci.ps1` run: clean tree passes end to end
- [x] `scripts/admission_guard.ps1 -Quick`: unchanged behavior after the extraction
- [x] Regression proof: non-root, last-sorted package violation caught with exact diff, file restored, clean pass reconfirmed
- [x] PowerShell syntax validated for all three changed/new files
- [x] Confirmed no production Rust files changed, Linux CI workflow unchanged
- [x] Reviewer feedback cycle (in progress per repair workflow)

Generated with [Claude Code](https://claude.com/claude-code)
