### PR TITLE
fix(semcode): reject ambiguous DBG0 instruction framing

### DIFF
--- a/crates/sm-format/src/semcode_decode.rs
+++ b/crates/sm-format/src/semcode_decode.rs
@@ -49,18 +49,40 @@ pub struct DecodedFunctionEnvelope<'a> {
     pub borrowed_paths: Vec<DecodedAccessPath>,
     pub write_paths: Vec<DecodedAccessPath>,
     pub has_ownership_section: bool,
+    // Whether the `DBG0` sentinel was recognized for this function. This is
+    // a purely structural fact (no opcode/operand knowledge), kept so
+    // callers can tell "no debug section" apart from "an empty debug
+    // section" - both currently produce an empty `debug_symbols`, but only
+    // the latter means the DBG0-sniff branch was taken and
+    // `instr_start_offset` was advanced past it. See #1731: the DBG0
+    // sentinel collides with `TupleGet`'s opcode byte (0x44 = 'D'), so a
+    // producer-emitted instruction stream can coincidentally spell the same
+    // six bytes as an empty DBG0 section. This flag lets sm-verify check,
+    // at its own admission boundary, whether the bytes between the string
+    // table and `instr_start_offset` also form a structurally valid
+    // instruction stream under the alternative (no-DBG0) reading, and
+    // reject as ambiguous if so - without sm-format needing any opcode/
+    // operand-shape knowledge itself.
+    pub has_debug_section: bool,
+    // Cursor position (relative to code_slice) immediately after the
+    // string table, before any DBG0/OWN0 sentinel is sniffed. Always
+    // well-defined; equals `instr_start_offset` when neither section is
+    // present.
+    pub string_table_end_offset: usize,
     pub instr_start_offset: usize, // relative to code_slice
     pub code_slice: &'a [u8],      // the full code block for this function
 }
 
-type StringTableDebugOwnershipParse = (
-    Vec<String>,
-    Vec<DecodedDebugSymbol>,
-    Vec<DecodedAccessPath>,
-    Vec<DecodedAccessPath>,
-    bool,
-    usize,
-);
+struct StringTableDebugOwnershipParse {
+    strings: Vec<String>,
+    debug_symbols: Vec<DecodedDebugSymbol>,
+    borrowed_paths: Vec<DecodedAccessPath>,
+    write_paths: Vec<DecodedAccessPath>,
+    has_ownership_section: bool,
+    has_debug_section: bool,
+    string_table_end_offset: usize,
+    instr_start_offset: usize,
+}
 
 pub fn decode_semcode_envelope<'a>(
     bytes: &'a [u8],
@@ -136,26 +158,21 @@ pub fn decode_semcode_envelope<'a>(
         let code_slice = &bytes[cursor..cursor + code_len];
         cursor += code_len;
 
-        let (
-            strings,
-            debug_symbols,
-            borrowed_paths,
-            write_paths,
-            has_ownership_section,
-            instr_start_offset,
-        ) = parse_string_table_debug_and_ownership(code_offset, code_slice)?;
+        let parsed = parse_string_table_debug_and_ownership(code_offset, code_slice)?;
 
         functions.push(DecodedFunctionEnvelope {
             name,
             name_offset,
             code_offset,
             code_len,
-            strings,
-            debug_symbols,
-            borrowed_paths,
-            write_paths,
-            has_ownership_section,
-            instr_start_offset,
+            strings: parsed.strings,
+            debug_symbols: parsed.debug_symbols,
+            borrowed_paths: parsed.borrowed_paths,
+            write_paths: parsed.write_paths,
+            has_ownership_section: parsed.has_ownership_section,
+            has_debug_section: parsed.has_debug_section,
+            string_table_end_offset: parsed.string_table_end_offset,
+            instr_start_offset: parsed.instr_start_offset,
             code_slice,
         });
     }
@@ -207,8 +224,11 @@ fn parse_string_table_debug_and_ownership(
         strings.push(str_val);
     }
 
+    let string_table_end_offset = cursor;
+    let mut has_debug_section = false;
     let mut debug_symbols = Vec::new();
     if cursor + 4 <= code.len() && &code[cursor..cursor + 4] == b"DBG0" {
+        has_debug_section = true;
         cursor += 4;
         let dbg_count_offset = base_offset + cursor;
         let count =
@@ -362,14 +382,16 @@ fn parse_string_table_debug_and_ownership(
         }
     }
 
-    Ok((
+    Ok(StringTableDebugOwnershipParse {
         strings,
         debug_symbols,
         borrowed_paths,
         write_paths,
         has_ownership_section,
-        cursor,
-    ))
+        has_debug_section,
+        string_table_end_offset,
+        instr_start_offset: cursor,
+    })
 }
 
 #[cfg(test)]

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -40,6 +40,14 @@ pub enum VerificationCode {
     UnknownCallTarget,
     ResourceLimitExceeded,
     CapabilityViolation,
+    /// The byte range immediately after the string table has more than one
+    /// valid canonical structural reading: it can be interpreted as an
+    /// empty/populated `DBG0` debug section AND, independently, as a
+    /// complete, well-formed instruction stream. Verified SemCode must have
+    /// exactly one canonical structural interpretation (see #1731); when
+    /// both readings are structurally valid, admission fails closed rather
+    /// than silently choosing one.
+    AmbiguousInstructionFraming,
 }
 
 #[cfg(feature = "std")]
@@ -406,6 +414,38 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
     verify_semcode_token(bytes).map(|token| token.program.clone())
 }
 
+/// Returns true if `code[start..]` decodes as a complete, well-formed
+/// instruction stream: every opcode byte is valid, every operand is present
+/// (including count/flag-controlled variable-length operands), and the walk
+/// consumes exactly to `code.len()` with nothing left over.
+///
+/// Reuses `decode_operands` - the same function the normal admission walk
+/// uses - rather than a second, independently-maintained opcode-shape
+/// table. This is deliberate: it means a byte sequence only counts as a
+/// genuine competing interpretation if it would itself be admissible by the
+/// verifier's real rules (including domain checks like canonical bool/quad
+/// literal ranges), not merely "structurally shaped like instructions". A
+/// reading that decode_operands would reject anyway was never a real
+/// alternative meaning to begin with, so it cannot make the artifact
+/// ambiguous.
+#[cfg(feature = "std")]
+fn instruction_stream_parses_fully(name: &str, code: &[u8], start: usize) -> bool {
+    let mut cursor = start;
+    while cursor < code.len() {
+        let offset = cursor - start;
+        let Ok(raw_opcode) = read_u8(code, &mut cursor) else {
+            return false;
+        };
+        let Ok(opcode) = Opcode::from_byte(raw_opcode) else {
+            return false;
+        };
+        if decode_operands(name, code, &mut cursor, offset, opcode).is_err() {
+            return false;
+        }
+    }
+    cursor == code.len()
+}
+
 #[cfg(feature = "std")]
 fn verify_function_code(
     env: &sm_format::semcode_decode::DecodedFunctionEnvelope,
@@ -413,6 +453,26 @@ fn verify_function_code(
     quotas: &RuntimeQuotas,
 ) -> Result<PendingVerifiedFunction, RejectReport> {
     let name = env.name.as_str();
+
+    // #1731 (FA-05-001): the DBG0 sentinel collides with TupleGet's opcode
+    // byte (0x44 = 'D'). If the decoder recognized a DBG0 section, check
+    // whether the same bytes, read from string_table_end_offset with no
+    // metadata-section recognition at all, would ALSO form a complete,
+    // well-formed instruction stream all the way to the end of this
+    // function's code. If both readings are valid, the artifact has more
+    // than one canonical structural interpretation and admission must fail
+    // closed rather than silently keep the DBG0 reading.
+    if env.has_debug_section
+        && instruction_stream_parses_fully(name, env.code_slice, env.string_table_end_offset)
+    {
+        return Err(reject_one(
+            name,
+            VerificationCode::AmbiguousInstructionFraming,
+            env.string_table_end_offset,
+            "byte range is both a valid DBG0 debug section and a valid instruction stream",
+        ));
+    }
+
     let string_count = env.strings.len();
     if string_count > quotas.max_symbol_table {
         return Err(reject_one(
@@ -1899,6 +1959,146 @@ mod tests {
             report.diagnostics[0].code,
             VerificationCode::OperandOutOfBounds
         );
+    }
+
+    // FA-05-001 (#1731): TupleGet's opcode byte (0x44 = 'D') can begin the
+    // exact same six bytes as the DBG0 debug-section sentinel + an empty
+    // debug_symbol_count (`44 42 47 30 00 00` == "DBG0" + 0u16). This exact
+    // IR sequence matches the confirmed Phase A fixture: it makes the
+    // decoder currently reclassify the producer's real first instruction
+    // (TupleGet dst=0x4742) as an empty debug section, hiding a destination
+    // register far outside the verified-local register budget from every
+    // downstream admission check. Both readings of these six bytes are
+    // structurally valid (empty DBG0 metadata, or the start of a real
+    // instruction stream), so admission must fail closed rather than
+    // silently choosing one.
+    #[test]
+    fn verifier_rejects_ambiguous_dbg0_tupleget_collision() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::TupleGet {
+                        dst: 0x4742,
+                        src: 0x0030,
+                        index: 0x6600,
+                    },
+                    IrInstr::Ret { src: None },
+                    IrInstr::ClockRead { dst: 0 },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+
+        // B: byte identity - the emitted instruction stream literally spells
+        // DBG0 where the real TupleGet begins (string table is empty: a
+        // bare 2-byte count=0, so the collision starts at code_slice[2]).
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let env = &functions[0];
+        assert_eq!(&env.code_slice[2..6], b"DBG0");
+
+        // C: decoder reinterpretation - instr_start_offset must currently
+        // land past the fake sentinel + fake empty count (2 + 4 + 2 = 8),
+        // not at the true instruction start (2, right after the empty
+        // string table) - i.e. this is not merely byte-identical, the
+        // shared decoder actually consumes it as metadata today.
+        assert_eq!(env.instr_start_offset, 8);
+
+        // D+E: admission consequence - despite the hidden TupleGet
+        // referencing register 0x4742 (18242), far outside any verified-
+        // local register budget, admission must fail closed rather than
+        // silently accept it.
+        let report = verify_semcode(&bytes).expect_err("must reject ambiguous framing");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::AmbiguousInstructionFraming
+        );
+    }
+
+    // #1731 regression matrix (2/3): a minimal genuine DBG0 section (debug
+    // symbols enabled, one traced instruction) must remain accepted
+    // unchanged - it is not byte-identical to any instruction reading, so
+    // it is not ambiguous. Built via emit_ir_to_semcode (IR-level, not the
+    // source front-end) so this test doesn't depend on the `debug-symbols`
+    // cargo feature being enabled for every invocation this repo uses to
+    // run sm-verify's tests (e.g. 7hell Hell 4 enables sm-ir/profile-rust
+    // only).
+    #[test]
+    fn verifier_accepts_minimal_genuine_debug_section() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![IrInstr::Ret { src: None }],
+                ownership_events: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit");
+        let verified = verify_semcode(&bytes).expect("genuine debug section must verify");
+        assert_eq!(verified.functions.len(), 1);
+        assert!(verified.functions[0].debug_symbol_count > 0);
+    }
+
+    // #1731 regression matrix (4): an ordinary, non-empty DBG0 section
+    // (several traced instructions) must remain accepted unchanged.
+    #[test]
+    fn verifier_accepts_ordinary_debug_section_with_multiple_entries() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadI32 { dst: 0, val: 1 },
+                    IrInstr::LoadI32 { dst: 1, val: 2 },
+                    IrInstr::AddI32 {
+                        dst: 2,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                    IrInstr::Ret { src: Some(2) },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit");
+        let verified = verify_semcode(&bytes).expect("ordinary debug section must verify");
+        assert_eq!(verified.functions.len(), 1);
+        assert!(
+            verified.functions[0].debug_symbol_count > 1,
+            "fixture must exercise a genuinely non-empty debug section"
+        );
+    }
+
+    // #1731 regression matrix (7/8): a truncated DBG0 tag or count must
+    // still hit the existing deterministic malformed-section rejection,
+    // unaffected by the new ambiguity check (which only runs once a full,
+    // successfully-decoded DBG0 section is already present).
+    #[test]
+    fn verifier_rejects_truncated_debug_section_tag() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![IrInstr::Ret { src: None }],
+                ownership_events: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit");
+        // Truncate the artifact to land inside the DBG0 tag/count region,
+        // matching this file's existing truncation-test convention.
+        let mut truncated = bytes.clone();
+        truncated.truncate(truncated.len() - 1);
+        let report =
+            sm_format::semcode_decode::decode_semcode_envelope(&truncated).expect_err("decode");
+        assert!(matches!(
+            report,
+            sm_format::semcode_decode::DecodeError::InvalidDebugSection { .. }
+                | sm_format::semcode_decode::DecodeError::TruncatedFunction { .. }
+        ));
     }
 
     #[test]

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -415,19 +415,32 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
 }
 
 /// Returns true if `code[start..]` decodes as a complete, well-formed
-/// instruction stream: every opcode byte is valid, every operand is present
-/// (including count/flag-controlled variable-length operands), and the walk
-/// consumes exactly to `code.len()` with nothing left over.
+/// instruction stream: every opcode byte is valid, every operand's byte
+/// shape is fully present (including count/flag-controlled variable-length
+/// operands), and the walk consumes exactly to `code.len()` with nothing
+/// left over.
 ///
-/// Reuses `decode_operands` - the same function the normal admission walk
-/// uses - rather than a second, independently-maintained opcode-shape
-/// table. This is deliberate: it means a byte sequence only counts as a
-/// genuine competing interpretation if it would itself be admissible by the
-/// verifier's real rules (including domain checks like canonical bool/quad
-/// literal ranges), not merely "structurally shaped like instructions". A
-/// reading that decode_operands would reject anyway was never a real
-/// alternative meaning to begin with, so it cannot make the artifact
-/// ambiguous.
+/// This is a STRUCTURAL question only - it must not depend on whether the
+/// resulting operand *values* happen to be semantically canonical (e.g. a
+/// bool literal byte of 2, or a presence flag of 5). Ambiguous framing is a
+/// fact about the bytes' shape: a decoder that doesn't apply the verifier's
+/// current canonical-domain policy (an older tool version, a disassembler,
+/// a different implementation) could still read this range as instructions.
+/// Coupling "was this ambiguous" to "is sm-verify's semantic policy today
+/// willing to admit the alternative reading" would make the one-canonical-
+/// interpretation invariant depend on semantic policy instead of being a
+/// decoder-level fact, and would silently keep the DBG0 reading whenever
+/// the competing instruction reading merely contains a non-canonical
+/// literal - exactly the kind of hidden-content risk #1731 exists to close.
+///
+/// Reuses `decode_operands` - the same function, same opcode-shape match,
+/// that the normal admission walk uses - with canonical-domain enforcement
+/// turned off via its `enforce_canonical_domains` parameter, rather than a
+/// second, independently-maintained opcode-shape table. Every byte read and
+/// every count/flag-controlled branch is identical to the semantic-
+/// admission walk; only the four inline out-of-domain rejections (LOAD_Q,
+/// LOAD_BOOL, CALL/CLOSURE_CALL dst-present flag, RET src-present flag) are
+/// skipped here.
 #[cfg(feature = "std")]
 fn instruction_stream_parses_fully(name: &str, code: &[u8], start: usize) -> bool {
     let mut cursor = start;
@@ -439,7 +452,7 @@ fn instruction_stream_parses_fully(name: &str, code: &[u8], start: usize) -> boo
         let Ok(opcode) = Opcode::from_byte(raw_opcode) else {
             return false;
         };
-        if decode_operands(name, code, &mut cursor, offset, opcode).is_err() {
+        if decode_operands(name, code, &mut cursor, offset, opcode, false).is_err() {
             return false;
         }
     }
@@ -553,7 +566,7 @@ fn verify_function_code(
                 err.to_string(),
             ),
         })?;
-        let refs = decode_operands(name, code, &mut cursor, offset, opcode)?;
+        let refs = decode_operands(name, code, &mut cursor, offset, opcode, true)?;
         jump_targets.extend(refs.jump_targets);
         string_refs.extend(refs.string_refs);
         used_caps |= refs.required_capabilities;
@@ -660,6 +673,29 @@ fn verify_function_code(
     })
 }
 
+/// Decodes one instruction's operands, advancing `cursor` past its full byte
+/// shape (including count/flag-controlled variable-length fields).
+///
+/// `enforce_canonical_domains` separates two distinct concerns that this
+/// function used to conflate:
+///
+/// - STRUCTURAL SHAPE: opcode recognition, operand byte widths, and
+///   presence/count-controlled byte lengths - always applied, regardless of
+///   the flag. This is what determines whether a byte range decodes as a
+///   complete instruction stream at all.
+/// - SEMANTIC ADMISSION: canonical literal value domains (`LOAD_Q`,
+///   `LOAD_BOOL`) and canonical presence-flag domains (`CALL`,
+///   `CLOSURE_CALL`, `RET`) - applied only when `enforce_canonical_domains`
+///   is `true`.
+///
+/// Normal verifier admission (the real instruction-stream walk in
+/// `verify_function_code`) must enforce both, so it passes `true`. The
+/// `#1731` ambiguity probe (`instruction_stream_parses_fully`) must decide
+/// only whether an alternative byte-level *framing* exists at all - a
+/// non-canonical operand value doesn't make an otherwise complete
+/// instruction-shaped reading any less structurally real - so it passes
+/// `false`. This keeps both concerns on one shared opcode-shape match
+/// rather than duplicating it.
 #[cfg(feature = "std")]
 fn decode_operands(
     function: &str,
@@ -667,6 +703,7 @@ fn decode_operands(
     cursor: &mut usize,
     offset: usize,
     opcode: Opcode,
+    enforce_canonical_domains: bool,
 ) -> Result<OperandRefs, RejectReport> {
     let invalid =
         |msg: &str| reject_one(function, VerificationCode::OperandOutOfBounds, offset, msg);
@@ -681,7 +718,7 @@ fn decode_operands(
             let dst = read_u16_le(code, cursor).map_err(|_| invalid("truncated dst register"))?;
             mark_reg(dst);
             let literal = read_u8(code, cursor).map_err(|_| invalid("truncated quad literal"))?;
-            if literal > 3 {
+            if enforce_canonical_domains && literal > 3 {
                 return Err(invalid("non-canonical quad literal: must be 0..=3"));
             }
         }
@@ -689,7 +726,7 @@ fn decode_operands(
             let dst = read_u16_le(code, cursor).map_err(|_| invalid("truncated dst register"))?;
             mark_reg(dst);
             let literal = read_u8(code, cursor).map_err(|_| invalid("truncated bool literal"))?;
-            if literal > 1 {
+            if enforce_canonical_domains && literal > 1 {
                 return Err(invalid("non-canonical bool literal: must be 0 or 1"));
             }
         }
@@ -1037,7 +1074,7 @@ fn decode_operands(
         Opcode::ClosureCall => {
             let has_dst_flag =
                 read_u8(code, cursor).map_err(|_| invalid("truncated closure-call dst flag"))?;
-            if has_dst_flag > 1 {
+            if enforce_canonical_domains && has_dst_flag > 1 {
                 return Err(invalid(
                     "non-canonical closure-call dst flag: must be 0 or 1",
                 ));
@@ -1134,7 +1171,7 @@ fn decode_operands(
         Opcode::Call => {
             let has_dst_flag =
                 read_u8(code, cursor).map_err(|_| invalid("truncated call destination flag"))?;
-            if has_dst_flag > 1 {
+            if enforce_canonical_domains && has_dst_flag > 1 {
                 return Err(invalid(
                     "non-canonical call destination flag: must be 0 or 1",
                 ));
@@ -1215,7 +1252,7 @@ fn decode_operands(
         }
         Opcode::Ret => {
             let has_src = read_u8(code, cursor).map_err(|_| invalid("truncated return flag"))?;
-            if has_src > 1 {
+            if enforce_canonical_domains && has_src > 1 {
                 return Err(invalid("non-canonical return flag: must be 0 or 1"));
             }
             if has_src != 0 {
@@ -2101,6 +2138,77 @@ mod tests {
         ));
     }
 
+    // #1731 review follow-up: the ambiguity probe must be a purely
+    // STRUCTURAL question (opcode recognized, every operand's byte shape
+    // present, stream consumes exactly to the end) and must NOT be gated on
+    // whether the alternative reading's operand *values* are semantically
+    // canonical. Before this fix, `instruction_stream_parses_fully` reused
+    // `decode_operands` with full canonical-domain enforcement, so an
+    // alternative reading that was shape-complete but contained one
+    // non-canonical literal (out-of-domain, not out-of-space) was wrongly
+    // treated as "not a real competing interpretation" and the DBG0 reading
+    // was silently kept.
+    //
+    // Fixture: reuses the exact #1731 TupleGet collision (dst=0x4742,
+    // src=0x0030 spell `DBG0` + an empty debug_symbol_count, exactly like
+    // `verifier_rejects_ambiguous_dbg0_tupleget_collision` above), followed
+    // by a genuine `LoadBool{dst:0, val:true}` whose literal byte is then
+    // hand-patched from canonical `1` to non-canonical `0xff`. This does not
+    // change any operand's byte width (the literal is always exactly one
+    // byte regardless of its value), so the alternative reading - decoding
+    // the whole buffer from the start, ignoring the `DBG0` sniff entirely -
+    // remains fully shape-complete: `TupleGet{..}; LoadBool{dst:0,
+    // literal:0xff}; Ret{None}`, consuming every byte to the end, with one
+    // non-canonical literal.
+    //
+    // What the `DBG0` reading's own (byte-shifted, effectively garbled)
+    // instruction decode would produce is irrelevant here: the ambiguity
+    // check runs before that decode is ever attempted, so this test only
+    // needs the alternative reading to be genuinely shape-complete.
+    #[test]
+    fn verifier_rejects_ambiguous_framing_even_when_alternate_reading_has_non_canonical_operand() {
+        let mut bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::TupleGet {
+                        dst: 0x4742,
+                        src: 0x0030,
+                        index: 0x6600,
+                    },
+                    IrInstr::LoadBool { dst: 0, val: true },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+
+        let (_, code_start, _) = function_code_span(&bytes, "main");
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let env = &functions[0];
+        assert!(env.has_debug_section);
+        assert_eq!(&env.code_slice[2..6], b"DBG0");
+
+        // TupleGet is 7 bytes (opcode + dst + src + index); LoadBool's
+        // literal is the 4th byte of the instruction right after it
+        // (opcode + dst(2) + literal).
+        let literal_pos = code_start + env.string_table_end_offset + 7 + 1 + 2;
+        assert_eq!(
+            bytes[literal_pos], 1,
+            "must be patching LoadBool's literal byte"
+        );
+        bytes[literal_pos] = 0xff;
+
+        let report = verify_semcode(&bytes).expect_err("must reject ambiguous framing");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::AmbiguousInstructionFraming
+        );
+    }
+
     #[test]
     fn verifier_rejects_unknown_call_target() {
         let mut bytes =
@@ -2603,8 +2711,15 @@ mod tests {
             if decoded == opcode {
                 matches.push(instr_offset);
             }
-            decode_operands(function_name, code, &mut cursor, instr_offset, decoded)
-                .expect("decode operands");
+            decode_operands(
+                function_name,
+                code,
+                &mut cursor,
+                instr_offset,
+                decoded,
+                true,
+            )
+            .expect("decode operands");
         }
 
         let relative = *matches.get(occurrence).unwrap_or_else(|| {

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -684,9 +684,21 @@ fn verify_function_code(
 ///   the flag. This is what determines whether a byte range decodes as a
 ///   complete instruction stream at all.
 /// - SEMANTIC ADMISSION: canonical literal value domains (`LOAD_Q`,
-///   `LOAD_BOOL`) and canonical presence-flag domains (`CALL`,
-///   `CLOSURE_CALL`, `RET`) - applied only when `enforce_canonical_domains`
-///   is `true`.
+///   `LOAD_BOOL`), canonical presence-flag domains (`CALL`,
+///   `CLOSURE_CALL`, `RET`), and canonical arity/cardinality domains
+///   (`MAKE_TUPLE` arity `>= 2`, `MAKE_RECORD` slot count `>= 1`) - applied
+///   only when `enforce_canonical_domains` is `true`. In every one of these
+///   cases the count or flag byte itself is read unconditionally and always
+///   determines how many further operand bytes follow (there is no
+///   width-affecting difference between a canonical and non-canonical
+///   value), so disabling this enforcement never changes byte-shape
+///   consumption - only whether an out-of-domain value is rejected.
+///
+/// Every other rejection in this function's match arms is a truncation /
+/// missing-bytes error from a failed `read_*` call - i.e. genuinely
+/// structural (unknown opcode is rejected by the caller before this
+/// function is even entered; every remaining path here fails only on
+/// missing/truncated operand bytes).
 ///
 /// Normal verifier admission (the real instruction-stream walk in
 /// `verify_function_code`) must enforce both, so it passes `true`. The
@@ -805,7 +817,7 @@ fn decode_operands(
             mark_reg(dst);
             let count =
                 read_u16_le(code, cursor).map_err(|_| invalid("truncated tuple arity"))? as usize;
-            if count < 2 {
+            if enforce_canonical_domains && count < 2 {
                 return Err(invalid("tuple literal arity must be at least 2"));
             }
             for _ in 0..count {
@@ -825,7 +837,7 @@ fn decode_operands(
             let count = read_u16_le(code, cursor)
                 .map_err(|_| invalid("truncated record slot count"))?
                 as usize;
-            if count == 0 {
+            if enforce_canonical_domains && count == 0 {
                 return Err(invalid("record literal must encode at least one slot"));
             }
             for _ in 0..count {
@@ -2201,6 +2213,56 @@ mod tests {
             "must be patching LoadBool's literal byte"
         );
         bytes[literal_pos] = 0xff;
+
+        let report = verify_semcode(&bytes).expect_err("must reject ambiguous framing");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::AmbiguousInstructionFraming
+        );
+    }
+
+    // #1731 review follow-up (round 2): `MAKE_TUPLE`'s arity-`>=2` check and
+    // `MAKE_RECORD`'s slot-count-`>=1` check are cardinality/value-domain
+    // constraints, not byte-shape constraints - the count field itself is
+    // always read unconditionally and always determines how many further
+    // item-register bytes follow, regardless of whether that count value is
+    // semantically canonical. They must be gated on
+    // `enforce_canonical_domains` exactly like the literal/flag checks
+    // above, or the same silent-ambiguity gap reopens for any alternative
+    // reading built around a too-small tuple/record.
+    //
+    // Fixture: the exact #1731 TupleGet collision, followed by a genuine
+    // `MakeTuple{dst:0, items:[5]}` - arity 1, non-canonical (`< 2`) but
+    // fully shape-complete (the count field legitimately says "one item
+    // follows", and one item follows).
+    #[test]
+    fn verifier_rejects_ambiguous_framing_with_non_canonical_maketuple_arity() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::TupleGet {
+                        dst: 0x4742,
+                        src: 0x0030,
+                        index: 0x6600,
+                    },
+                    IrInstr::MakeTuple {
+                        dst: 0,
+                        items: vec![5],
+                    },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let env = &functions[0];
+        assert!(env.has_debug_section);
+        assert_eq!(&env.code_slice[2..6], b"DBG0");
 
         let report = verify_semcode(&bytes).expect_err("must reject ambiguous framing");
         assert_eq!(

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -40,11 +40,16 @@ immediately after the preceding section - there is no explicit
 presence-flag or length-prefixed section table.
 
 A byte sequence that is simultaneously valid as `DBG0` debug-section framing
-and as executable instruction framing is non-canonical. Admission (`sm-verify`)
-rejects such an artifact rather than silently choosing one reading, because
-doing so could hide otherwise-invalid instruction content (e.g. a
-register reference outside the verified-local budget) inside what gets
-reclassified as metadata. See #1731 and `docs/spec/verifier.md`.
+and as executable instruction framing is non-canonical. "Executable
+instruction framing" here is a structural question - opcode recognition and
+operand byte shape - independent of whether the resulting operand values
+are themselves semantically canonical; a competing reading is not exempted
+from this rule merely because it also contains a non-canonical literal.
+Admission (`sm-verify`) rejects such an artifact rather than silently
+choosing one reading, because doing so could hide otherwise-invalid
+instruction content (e.g. a register reference outside the verified-local
+budget) inside what gets reclassified as metadata. See #1731 and
+`docs/spec/verifier.md`.
 
 `OWN0`'s tag byte (`0x4F`) is not a currently valid opcode, so it cannot
 collide with the start of an instruction the way `DBG0`'s tag byte (`0x44`

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -27,6 +27,30 @@ verifier-admitted VM execution.
 The VM is not the primary structural admission gate.
 `sm-verify` is the required admission stage for standard SemCode execution.
 
+## Canonical Structural Framing
+
+A canonical SemCode function encoding must have exactly one unambiguous
+structural interpretation.
+
+Per function, the code block is: a length-delimited string table, then an
+optional tagged `DBG0` debug section, then an optional tagged `OWN0`
+ownership section, then the instruction stream running to the end of the
+code block. `DBG0` and `OWN0` are recognized by sniffing a fixed 4-byte tag
+immediately after the preceding section - there is no explicit
+presence-flag or length-prefixed section table.
+
+A byte sequence that is simultaneously valid as `DBG0` debug-section framing
+and as executable instruction framing is non-canonical. Admission (`sm-verify`)
+rejects such an artifact rather than silently choosing one reading, because
+doing so could hide otherwise-invalid instruction content (e.g. a
+register reference outside the verified-local budget) inside what gets
+reclassified as metadata. See #1731 and `docs/spec/verifier.md`.
+
+`OWN0`'s tag byte (`0x4F`) is not a currently valid opcode, so it cannot
+collide with the start of an instruction the way `DBG0`'s tag byte (`0x44`
+= `TupleGet`) can; this ambiguity is specific to `DBG0`, not a general
+property of the tagged-section scheme.
+
 ## Versioned Header Family
 
 Current supported header family:

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -116,9 +116,11 @@ SEMANTIC admission:
   presence/count-controlled byte lengths, evaluated to determine only
   whether a complete instruction stream exists at all
 - semantic admission: canonical literal value domains (`LOAD_Q`,
-  `LOAD_BOOL`) and canonical presence-flag domains (`CALL`, `CLOSURE_CALL`,
-  `RET`), which remain a separate, later concern applied only to whichever
-  single reading admission actually accepts
+  `LOAD_BOOL`), canonical presence-flag domains (`CALL`, `CLOSURE_CALL`,
+  `RET`), and canonical arity/cardinality domains (`MAKE_TUPLE` arity
+  `>= 2`, `MAKE_RECORD` slot count `>= 1`), which remain a separate, later
+  concern applied only to whichever single reading admission actually
+  accepts
 
 The alternative reading only needs to be structurally complete to count as
 a genuine competing interpretation - a non-canonical operand value (for

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -107,11 +107,33 @@ table, with no metadata-section recognition at all - would also form a
 complete, well-formed instruction stream to the end of the function's code.
 If both readings are valid, admission fails closed with
 `AmbiguousInstructionFraming` rather than silently keeping the `DBG0`
-reading. This check reuses the verifier's own operand decoder for the
-alternative reading rather than a second, independently-maintained
-opcode-shape table; a reading that the verifier's own operand decoder would
-itself reject was never a genuine competing interpretation; only completed,
-independently-admissible parses count as ambiguous.
+reading.
+
+This is a purely STRUCTURAL question, deliberately kept separate from
+SEMANTIC admission:
+
+- structural framing: opcode recognition, operand byte shape, and
+  presence/count-controlled byte lengths, evaluated to determine only
+  whether a complete instruction stream exists at all
+- semantic admission: canonical literal value domains (`LOAD_Q`,
+  `LOAD_BOOL`) and canonical presence-flag domains (`CALL`, `CLOSURE_CALL`,
+  `RET`), which remain a separate, later concern applied only to whichever
+  single reading admission actually accepts
+
+The alternative reading only needs to be structurally complete to count as
+a genuine competing interpretation - a non-canonical operand value (for
+example an out-of-domain literal byte) does not make an otherwise
+shape-complete instruction reading any less structurally real, and does not
+exempt an artifact from the ambiguity check. Gating ambiguity detection on
+today's semantic admission policy would make the one-canonical-
+interpretation invariant depend on that policy instead of being a
+decoder-level fact, and would silently keep the `DBG0` reading whenever the
+competing instruction reading merely contained a non-canonical literal.
+
+This check reuses the verifier's own operand-shape decoder for the
+alternative reading - the same function, same opcode-shape match, that
+semantic admission uses, with canonical-domain enforcement turned off -
+rather than a second, independently-maintained opcode-shape table.
 
 `OWN0`'s tag byte (`0x4F`) is not a currently valid opcode, so this specific
 ambiguity does not apply to ownership-section recognition.

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -38,6 +38,7 @@ Current SemCode verification checks include:
 - header validity
 - supported version validity
 - function and section integrity
+- canonical (unambiguous) instruction framing
 - opcode validity
 - operand shape validity
 - jump-target validity
@@ -88,6 +89,32 @@ A byte outside the canonical domain for its field is rejected at admission
 (`OperandOutOfBounds`), not normalized downstream. This narrows the
 previously admitted surface: byte values outside these domains that an
 earlier verifier accepted are no longer admissible.
+
+## Canonical Instruction Framing
+
+A canonical SemCode function encoding must have exactly one unambiguous
+structural interpretation (see `docs/spec/semcode.md`).
+
+The `DBG0` debug-section tag is recognized by sniffing a fixed 4-byte
+sequence, and its first byte (`0x44`) is also `TupleGet`'s opcode byte, so a
+producer-emitted instruction stream can coincidentally spell the same bytes
+as `DBG0` framing. A byte sequence that is simultaneously valid as `DBG0`
+metadata and as a complete instruction stream is non-canonical.
+
+The verifier detects this by checking, whenever a `DBG0` section was
+recognized, whether the same bytes - read from immediately after the string
+table, with no metadata-section recognition at all - would also form a
+complete, well-formed instruction stream to the end of the function's code.
+If both readings are valid, admission fails closed with
+`AmbiguousInstructionFraming` rather than silently keeping the `DBG0`
+reading. This check reuses the verifier's own operand decoder for the
+alternative reading rather than a second, independently-maintained
+opcode-shape table; a reading that the verifier's own operand decoder would
+itself reject was never a genuine competing interpretation; only completed,
+independently-admissible parses count as ambiguous.
+
+`OWN0`'s tag byte (`0x4F`) is not a currently valid opcode, so this specific
+ambiguity does not apply to ownership-section recognition.
 
 ## Contract Rule
 


### PR DESCRIPTION
Fixes #1731

## Base

Base SHA: `c6336eb3f0414f95b9ec302b4e466fa35e10f0ce` (current `main` at the time this branch was cut).

## The collision (concrete bytes)

Six bytes: `44 42 47 30 00 00`.

- **Producer-intended interpretation**: the first real instruction of the function, `TupleGet { dst: 0x4742, src: 0x0030, index: 0x6600 }`. Opcode byte `0x44` = `TupleGet`; the following bytes encode `dst`/`src`/`index`.
- **Current (buggy) decoder interpretation**: the exact same six bytes also read as the `DBG0` debug-section tag (`44 42 47 30` = ASCII `"DBG0"`) followed by a little-endian `u16` `debug_symbol_count = 0` — i.e. an empty debug section. Because the shared decoder sniffs `DBG0` by raw 4-byte match immediately after the string table, with no presence flag or length prefix, it takes this second reading unconditionally when it matches, silently reclassifying the producer's real instruction as metadata.

In the regression fixture (empty string table, so the collision starts at `code_slice[2]`), this makes `instr_start_offset` land at byte `8` (`2` string-table bytes + `4` fake tag + `2` fake count) instead of the true instruction start at byte `2`. The hidden `TupleGet` references destination register `0x4742` (18242) — far outside any verified-local register budget — and every downstream admission check (register-budget validity in particular) never sees it, because the bytes were reclassified as debug metadata before those checks run.

## Violated invariant

`docs/spec/semcode.md`'s (new) canonical-structural-framing rule: a canonical SemCode function encoding must have **exactly one** unambiguous structural interpretation. These six bytes have two independently valid readings, so admitting either one silently is a violation of that invariant, not a matter of picking the "right" one.

## Chosen repair: fail-closed ambiguity detection

No wire-format change. When the shared decoder recognizes a `DBG0` section for a function, the verifier additionally checks whether the *same byte range* — starting right after the string table, with **no** metadata-section recognition applied at all — would **also** parse as a complete, well-formed instruction stream running to the end of the function's code block. If both readings are structurally valid, admission fails closed with a new `VerificationCode::AmbiguousInstructionFraming` rather than silently keeping the `DBG0` reading.

### Why no wire-format bump

- The byte layout, header family, and producer output are all unchanged. No producer needs to emit anything differently.
- Every previously-admitted *unambiguous* artifact (real debug sections, real instruction streams that don't collide with `DBG0`) is admitted identically to before — verified directly by the compatibility audit below and by the two added "must still accept" regression tests.
- Only byte streams that were already structurally self-contradictory (two valid readings of the same range) change outcome, and they change from "silently admitted under one arbitrary reading" to "rejected" — which is the correct outcome for an artifact that never had a single canonical interpretation to begin with. This is an admission-time tightening, not a format migration.

### Exact structural algorithm

1. `sm-format`'s decoder already knows, per function, whether it recognized a `DBG0` section (`has_debug_section`) and the cursor offset immediately after the string table, before any section sniffing (`string_table_end_offset`). Both are new, purely structural fields added to `DecodedFunctionEnvelope` (mirroring the existing `has_ownership_section` field).
2. In `sm-verify::verify_function_code`, if `has_debug_section` is true, call `instruction_stream_parses_fully(name, code_slice, string_table_end_offset)`.
3. That function walks the byte range from `string_table_end_offset` to the end of the code block, decoding one opcode + operands at a time via the verifier's own `Opcode::from_byte` + `decode_operands(..., enforce_canonical_domains: false)`, and returns `true` only if that walk consumes the range exactly with every opcode recognized and every operand's byte shape present.
4. If it returns `true`, the range is ambiguous (both a valid `DBG0` reading and a valid instruction-stream *framing* exist) → reject with `AmbiguousInstructionFraming` at `string_table_end_offset`. Otherwise, the `DBG0` reading is the only valid structural reading → proceed as before.

The ambiguity check is a **structural** question only — opcode recognition, operand byte widths, and count/flag-controlled byte lengths — deliberately independent of whether the resulting operand *values* are semantically canonical. This separation was tightened across two review rounds (see "Review history" below): reviewer feedback correctly identified that treating "would `decode_operands` accept this outright" as the ambiguity test conflated structural framing with semantic admission policy, letting a shape-complete alternative reading with one non-canonical value (e.g. an out-of-domain literal, or a too-small tuple/record arity) slip past the ambiguity check and keep the `DBG0` reading.

### Why no duplicate opcode-shape table

`instruction_stream_parses_fully` reuses `sm-verify`'s existing `decode_operands` — the exact same function, same opcode-shape match, that the normal instruction-stream verification pass calls — via a new `enforce_canonical_domains: bool` parameter, instead of introducing a second, independently-maintained table of opcode/operand shapes anywhere. `enforce_canonical_domains` gates only the small number of inline value-domain checks (`LOAD_Q`/`LOAD_BOOL` literal range, `CALL`/`CLOSURE_CALL`/`RET` presence-flag range, `MAKE_TUPLE`/`MAKE_RECORD` arity range) that don't affect byte-shape consumption; every truncation/missing-bytes rejection remains unconditional in both modes. Normal semantic admission passes `true`; the ambiguity probe passes `false`. This keeps opcode-shape knowledge in exactly one place while cleanly separating the two concerns.

## Compatibility audit

Scanned all 21 locally available `.smc` artifacts (fixtures + goldens) in the working tree: **0** have a `DBG0` section at all, so **0** are affected by this change in any way. Full zero-impact on every currently tracked artifact.

## Review history

Two review rounds surfaced real gaps in the initial structural/semantic separation, both fixed in this PR (not deferred):

- **Round 1**: the initial `instruction_stream_parses_fully` called `decode_operands` with full canonical-domain enforcement, so an alternative reading that was shape-complete but contained one non-canonical *literal* (`LOAD_Q`/`LOAD_BOOL` out-of-domain, or a `CALL`/`CLOSURE_CALL`/`RET` presence flag out-of-domain) was wrongly treated as "not a real competing interpretation." Fixed by adding `enforce_canonical_domains: bool` to `decode_operands` and gating those four checks on it; the ambiguity probe passes `false`, normal admission passes `true`.
- **Round 2**: the same conflation remained for `MAKE_TUPLE`'s arity-`>= 2` check and `MAKE_RECORD`'s slot-count-`>= 1` check — cardinality constraints, not byte-shape constraints (the count field is always read unconditionally and always determines how many item-register bytes follow, regardless of whether that count is itself canonical). Fixed the same way, gated on `enforce_canonical_domains`. An exhaustive audit of every rejection site in `decode_operands` (grep-verified, not sampled) confirms these six checks (`LOAD_Q`, `LOAD_BOOL`, `CALL`, `CLOSURE_CALL`, `RET`, `MAKE_TUPLE`, `MAKE_RECORD`) were the *only* non-truncation rejections in the function; every other `Err` site is a truncated/missing-bytes error from a failed `read_*` call, and unknown-opcode is rejected by the caller before `decode_operands` is even entered. In structural mode, only unknown opcode, missing/truncated operand bytes, or (for `MAKE_TUPLE`/`MAKE_RECORD`/`MAKE_SEQUENCE`/`CALL`/`MAKE_ADT`/`MAKE_CLOSURE`) an impossible count-controlled byte traversal can make the structural walk fail.

## Regression matrix

6 new tests added to `crates/sm-verify/src/lib.rs`, all built at the IR level via `emit_ir_to_semcode` (not the source front-end) so they don't depend on cargo feature gates that vary between invocations:

1. `verifier_rejects_ambiguous_dbg0_tupleget_collision` — reproduces the exact #1731 fixture; asserts byte identity with `DBG0` (B), the current decoder's wrong `instr_start_offset == 8` (C), and that `verify_semcode` now rejects with `AmbiguousInstructionFraming` (D+E).
2. `verifier_accepts_minimal_genuine_debug_section` — a real, minimal debug section (one instruction, debug symbols on) must still be accepted; not byte-identical to any instruction reading, so not ambiguous.
3. `verifier_accepts_ordinary_debug_section_with_multiple_entries` — an ordinary, multi-instruction debug section must still be accepted unchanged.
4. `verifier_rejects_truncated_debug_section_tag` — a truncated `DBG0` tag must still be rejected the same way it was before (`InvalidDebugSection`/`TruncatedFunction`), i.e. this change doesn't alter unrelated truncation handling.
5. `verifier_rejects_ambiguous_framing_even_when_alternate_reading_has_non_canonical_operand` (round 1 regression) — the #1731 `TupleGet` collision followed by a genuine `LoadBool{val:true}` whose literal byte is then hand-patched to a non-canonical `0xff`; confirmed RED against the pre-round-1-fix commit (rejected via `UnknownOpcode`, not `AmbiguousInstructionFraming`), now green.
6. `verifier_rejects_ambiguous_framing_with_non_canonical_maketuple_arity` (round 2 regression) — the #1731 `TupleGet` collision followed by a genuine `MakeTuple{items:[5]}` (arity 1, non-canonical); confirmed RED against the pre-round-2-fix code (also rejected via `UnknownOpcode`), now green.

Full suite: **75/75** `sm-verify` tests pass, validated under two feature contexts: full-workspace feature unification (`cargo test --workspace -p sm-verify --lib`) and the exact feature combination the Windows 7hell qualification gate (Hell 4) uses (`--all-features --features sm-ir/profile-rust`). `sm-format` (4/4) and the full workspace test run are also green. The full `tools/7hell/run_ci.ps1` qualification gate and the PR-ready admission guard both pass end to end after every round.

## Specs changed

- `docs/spec/semcode.md` — new `## Canonical Structural Framing` section (after `## Purpose`) stating the one-canonical-interpretation invariant, describing the `DBG0`/`TupleGet` collision, and the `OWN0` exemption.
- `docs/spec/verifier.md` — new `## Canonical Instruction Framing` section (after `## Canonical Operand Value Domains`) describing the check mechanism and the `decode_operands`-reuse rationale, plus a `canonical (unambiguous) instruction framing` bullet added to `## Verification Scope`.

## OWN0 confirmation

`OWN0`'s tag byte (`0x4F`) is not a valid opcode, so it cannot collide with the start of an instruction the way `DBG0`'s tag byte (`0x44` = `TupleGet`) can. This ambiguity is specific to `DBG0`; `OWN0` recognition and the ownership-transport contract are completely unchanged by this PR.

## Shared canonical envelope confirmation

`sm-verify` and `sm-vm` continue to consume the exact same `DecodedFunctionEnvelope` produced by `sm-format`'s single decoder. The two new fields (`has_debug_section`, `string_table_end_offset`) are purely structural additions read only by the new verifier check; nothing about how `sm-vm` consumes an already-verified artifact changes, and there is still exactly one decode path shared by both crates.

## Production files changed

- `crates/sm-format/src/semcode_decode.rs` — adds `has_debug_section` and `string_table_end_offset` to `DecodedFunctionEnvelope`; converts the internal parse-result tuple to a named struct to avoid a positional bool/usize mixup.
- `crates/sm-verify/src/lib.rs` — adds `VerificationCode::AmbiguousInstructionFraming`, adds `instruction_stream_parses_fully`, and wires the check into `verify_function_code`.

## Non-goals

- No changes beyond #1731 / FA-05-001. #1732 and any other Phase A finding are explicitly out of scope for this PR.
- No VM fail-open repairs — this is an admission-layer (`sm-verify`) change only.
- No UI changes.
- No dependency upgrades.
- No wire-format/header version bump — established above as unnecessary for this repair.
- No broad refactor of `sm-format`/`sm-verify` beyond the minimal structural additions described.
