### PR TITLE
Add Clippy SARIF code scanning workflow

### DIFF
--- a/.github/workflows/clippy-sarif.yml
+++ b/.github/workflows/clippy-sarif.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Install SARIF converters
         run: cargo install --locked clippy-sarif sarif-fmt
       - name: Run Clippy and generate SARIF
-        continue-on-error: true
         run: |
           set -o pipefail
           cargo clippy --workspace --all-targets --all-features --message-format=json \

--- a/.github/workflows/clippy-sarif.yml
+++ b/.github/workflows/clippy-sarif.yml
@@ -1,0 +1,41 @@
+name: Clippy SARIF
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  clippy-sarif:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install system BLAS (required by the turbovec Hub dependency on Linux)
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Install SARIF converters
+        run: cargo install --locked clippy-sarif sarif-fmt
+      - name: Run Clippy and generate SARIF
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo clippy --workspace --all-targets --all-features --message-format=json \
+            | clippy-sarif \
+            | tee clippy-results.sarif \
+            | sarif-fmt
+      - name: Upload Clippy SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: clippy-results.sarif


### PR DESCRIPTION
## What changed

- add a separate `Clippy SARIF` workflow for pushes to `main` and pull requests
- run `cargo clippy --workspace --all-targets --all-features --message-format=json`
- convert Clippy JSON with `clippy-sarif` and `sarif-fmt`
- upload `clippy-results.sarif` through `github/codeql-action/upload-sarif@v4`

## Why

This adds Code Scanning visibility for Clippy findings without changing the existing fail-closed `pr-ready` qualification gate. The SARIF scan is observability-only: lint findings do not replace or weaken `cargo clippy ... -D warnings` in `.github/workflows/ci.yml`.

## Scope

One new workflow file. No CodeQL analysis, audit, coverage, fuzzing, or additional Marketplace actions.

## Validation

- parsed the workflow YAML and asserted the trigger, permissions, action set, Clippy command, SARIF converters, and absence of `-D warnings`
- `git diff --cached --check`
- verified the branch diff contains only `.github/workflows/clippy-sarif.yml`
- verified `.github/workflows/ci.yml` is unchanged from `origin/main`