### PR TITLE
fix(sm-format): make untrusted offset arithmetic checked

### DIFF
--- a/crates/sm-format/src/local_format.rs
+++ b/crates/sm-format/src/local_format.rs
@@ -688,30 +688,44 @@ pub fn write_f64_le(out: &mut Vec<u8>, v: f64) {
     out.extend_from_slice(&v.to_le_bytes());
 }
 
-pub fn read_u8(bytes: &[u8], i: &mut usize) -> Result<u8, SemcodeFormatError> {
-    if *i >= bytes.len() {
+/// #1736 (FA-05-006): shared bounds-check primitive for every low-level
+/// reader below. Uses `checked_add`, never raw `+`, so a maliciously large
+/// `start` (e.g. a cursor advanced by an attacker-controlled length field)
+/// cannot wrap past `usize::MAX` and produce a false in-bounds result -
+/// which is exactly how the pre-fix `*i + width > bytes.len()` comparison
+/// could be defeated on 32-bit targets.
+fn checked_read_end(
+    bytes_len: usize,
+    start: usize,
+    width: usize,
+) -> Result<usize, SemcodeFormatError> {
+    let end = start
+        .checked_add(width)
+        .ok_or(SemcodeFormatError::UnexpectedEof)?;
+    if end > bytes_len {
         return Err(SemcodeFormatError::UnexpectedEof);
     }
+    Ok(end)
+}
+
+pub fn read_u8(bytes: &[u8], i: &mut usize) -> Result<u8, SemcodeFormatError> {
+    let end = checked_read_end(bytes.len(), *i, 1)?;
     let v = bytes[*i];
-    *i += 1;
+    *i = end;
     Ok(v)
 }
 
 pub fn read_u16_le(bytes: &[u8], i: &mut usize) -> Result<u16, SemcodeFormatError> {
-    if *i + 2 > bytes.len() {
-        return Err(SemcodeFormatError::UnexpectedEof);
-    }
-    let v = u16::from_le_bytes([bytes[*i], bytes[*i + 1]]);
-    *i += 2;
+    let end = checked_read_end(bytes.len(), *i, 2)?;
+    let v = u16::from_le_bytes(bytes[*i..end].try_into().unwrap());
+    *i = end;
     Ok(v)
 }
 
 pub fn read_u32_le(bytes: &[u8], i: &mut usize) -> Result<u32, SemcodeFormatError> {
-    if *i + 4 > bytes.len() {
-        return Err(SemcodeFormatError::UnexpectedEof);
-    }
-    let v = u32::from_le_bytes([bytes[*i], bytes[*i + 1], bytes[*i + 2], bytes[*i + 3]]);
-    *i += 4;
+    let end = checked_read_end(bytes.len(), *i, 4)?;
+    let v = u32::from_le_bytes(bytes[*i..end].try_into().unwrap());
+    *i = end;
     Ok(v)
 }
 
@@ -720,22 +734,118 @@ pub fn read_i32_le(bytes: &[u8], i: &mut usize) -> Result<i32, SemcodeFormatErro
 }
 
 pub fn read_f64_le(bytes: &[u8], i: &mut usize) -> Result<f64, SemcodeFormatError> {
-    if *i + 8 > bytes.len() {
-        return Err(SemcodeFormatError::UnexpectedEof);
-    }
-    let mut raw = [0u8; 8];
-    raw.copy_from_slice(&bytes[*i..*i + 8]);
-    *i += 8;
-    Ok(f64::from_le_bytes(raw))
+    let end = checked_read_end(bytes.len(), *i, 8)?;
+    let v = f64::from_le_bytes(bytes[*i..end].try_into().unwrap());
+    *i = end;
+    Ok(v)
 }
 
 pub fn read_utf8(bytes: &[u8], i: &mut usize, len: usize) -> Result<String, SemcodeFormatError> {
-    if *i + len > bytes.len() {
-        return Err(SemcodeFormatError::UnexpectedEof);
-    }
-    let s = std::str::from_utf8(&bytes[*i..*i + len])
+    let end = checked_read_end(bytes.len(), *i, len)?;
+    let s = std::str::from_utf8(&bytes[*i..end])
         .map_err(|_| SemcodeFormatError::InvalidUtf8)?
         .to_string();
-    *i += len;
+    *i = end;
     Ok(s)
+}
+
+// #1736 (FA-05-006): regression coverage for the checked-arithmetic repair.
+// Before the fix, `*i + width > bytes.len()` used raw addition, so a cursor
+// near `usize::MAX` (reachable from an attacker-controlled cursor/length on
+// any target, and trivially reachable from an ordinary u32 length field on a
+// 32-bit target) could wrap past zero and pass the bounds check, producing
+// an out-of-range slice index panic instead of a decode error.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_u8_rejects_cursor_near_usize_max_without_panicking() {
+        let bytes = [1u8, 2, 3];
+        let mut i = usize::MAX - 1;
+        assert_eq!(
+            read_u8(&bytes, &mut i),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn read_u16_le_rejects_cursor_near_usize_max_without_panicking() {
+        let bytes = [1u8, 2, 3];
+        let mut i = usize::MAX - 1;
+        assert_eq!(
+            read_u16_le(&bytes, &mut i),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn read_u32_le_rejects_cursor_near_usize_max_without_panicking() {
+        let bytes = [1u8, 2, 3];
+        let mut i = usize::MAX - 1;
+        assert_eq!(
+            read_u32_le(&bytes, &mut i),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn read_f64_le_rejects_cursor_near_usize_max_without_panicking() {
+        let bytes = [1u8, 2, 3];
+        let mut i = usize::MAX - 1;
+        assert_eq!(
+            read_f64_le(&bytes, &mut i),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn read_utf8_rejects_overflowing_cursor_plus_len_without_panicking() {
+        let bytes = [1u8, 2, 3];
+        let mut i = 1usize;
+        assert_eq!(
+            read_utf8(&bytes, &mut i, usize::MAX),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn ordinary_reads_still_succeed_and_advance_cursor() {
+        let bytes: Vec<u8> = vec![
+            0x42, 0x01, 0x02, 0x03, 0x04, 1, 2, 3, 4, 5, 6, 7, 8, b'h', b'i',
+        ];
+        let mut i = 0usize;
+        assert_eq!(read_u8(&bytes, &mut i), Ok(0x42));
+        assert_eq!(i, 1);
+        assert_eq!(read_u32_le(&bytes, &mut i), Ok(0x04030201));
+        assert_eq!(i, 5);
+        assert_eq!(
+            read_f64_le(&bytes, &mut i),
+            Ok(f64::from_le_bytes([1, 2, 3, 4, 5, 6, 7, 8]))
+        );
+        assert_eq!(i, 13);
+        assert_eq!(read_utf8(&bytes, &mut i, 2), Ok("hi".to_string()));
+        assert_eq!(i, 15);
+    }
+
+    #[test]
+    fn ordinary_truncation_is_still_rejected() {
+        let bytes = [0u8, 1];
+        assert_eq!(
+            read_u16_le(&bytes, &mut 1),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+        assert_eq!(
+            read_u32_le(&bytes, &mut 0),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+        assert_eq!(
+            read_f64_le(&bytes, &mut 0),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+        assert_eq!(
+            read_utf8(&bytes, &mut 0, 3),
+            Err(SemcodeFormatError::UnexpectedEof)
+        );
+    }
 }

--- a/crates/sm-format/src/semcode_decode.rs
+++ b/crates/sm-format/src/semcode_decode.rs
@@ -147,16 +147,15 @@ pub fn decode_semcode_envelope<'a>(
                 msg: "missing function code length",
             })? as usize;
 
-        if cursor + code_len > bytes.len() {
-            return Err(DecodeError::TruncatedFunction {
+        let code_end =
+            checked_end(cursor, code_len, bytes.len()).ok_or(DecodeError::TruncatedFunction {
                 offset: cursor,
                 msg: "function code out of bounds",
-            });
-        }
+            })?;
 
         let code_offset = cursor;
-        let code_slice = &bytes[cursor..cursor + code_len];
-        cursor += code_len;
+        let code_slice = &bytes[cursor..code_end];
+        cursor = code_end;
 
         let parsed = parse_string_table_debug_and_ownership(code_offset, code_slice)?;
 
@@ -180,12 +179,42 @@ pub fn decode_semcode_envelope<'a>(
     Ok((header, functions))
 }
 
+/// #1736 (FA-05-006): `diag_offset(base_offset, cursor)` for a diagnostic error-offset
+/// field only - every call site here is already inside an error-construction
+/// closure triggered by an already-failed `read_*` call, so this value never
+/// gates an accept/reject decision. `saturating_add` (rather than raw `+`)
+/// avoids ever panicking while building an error message; unlike the real
+/// bounds-check arithmetic in `checked_read_end` and
+/// `decode_semcode_envelope` - where wrapping/saturating is banned because
+/// it could hide an out-of-bounds read behind a false-accept - saturating
+/// here only affects a cosmetic offset field after rejection has already
+/// been decided by the failed `read_*` call.
+fn diag_offset(base_offset: usize, cursor: usize) -> usize {
+    base_offset.saturating_add(cursor)
+}
+
+/// #1736 (FA-05-006): the one shared, width-independent bounds-check
+/// primitive for every real accept/reject decision in this file - the
+/// function `code_len` check and the `DBG0`/`OWN0` section tag-sniffs below.
+/// Mirrors `local_format.rs`'s `checked_read_end`, but returns `Option`
+/// rather than a format-specific `Result` since each call site here maps
+/// the `None` case to its own distinct `DecodeError` variant (or, for the
+/// tag-sniffs, treats it as "optional section absent" - see the doc comment
+/// on the `DBG0` check below for why that is not a rejection). Always uses
+/// `checked_add`, never raw `+`, so a `cursor`/`len` combination that would
+/// overflow `usize` (reachable from `code_len`, a fully attacker-controlled
+/// `u32` field, on a 32-bit target) is treated exactly like an ordinary
+/// out-of-bounds length, never a wrapped false-accept.
+fn checked_end(cursor: usize, len: usize, total: usize) -> Option<usize> {
+    cursor.checked_add(len).filter(|&end| end <= total)
+}
+
 fn parse_string_table_debug_and_ownership(
     base_offset: usize,
     code: &[u8],
 ) -> Result<StringTableDebugOwnershipParse, DecodeError> {
     let mut cursor = 0usize;
-    let string_count_offset = base_offset + cursor;
+    let string_count_offset = diag_offset(base_offset, cursor);
     let count = read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidStringTable {
         offset: string_count_offset,
         msg: "missing string table header",
@@ -193,7 +222,7 @@ fn parse_string_table_debug_and_ownership(
 
     if count > MAX_STRINGS_PER_FUNCTION {
         return Err(DecodeError::ResourceLimit {
-            offset: base_offset + cursor,
+            offset: diag_offset(base_offset, cursor),
             msg: format!(
                 "too many strings in function: {} (max {})",
                 count, MAX_STRINGS_PER_FUNCTION
@@ -203,7 +232,7 @@ fn parse_string_table_debug_and_ownership(
 
     let mut strings = Vec::with_capacity(count);
     for _ in 0..count {
-        let len_offset = base_offset + cursor;
+        let len_offset = diag_offset(base_offset, cursor);
         let len = read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidStringTable {
             offset: len_offset,
             msg: "missing string length",
@@ -211,14 +240,14 @@ fn parse_string_table_debug_and_ownership(
 
         if len > MAX_STRING_LEN {
             return Err(DecodeError::InvalidStringTable {
-                offset: base_offset + cursor,
+                offset: diag_offset(base_offset, cursor),
                 msg: "string too long in function string table",
             });
         }
 
         let str_val =
             read_utf8(code, &mut cursor, len).map_err(|_| DecodeError::InvalidStringTable {
-                offset: base_offset + cursor,
+                offset: diag_offset(base_offset, cursor),
                 msg: "invalid utf8 in string table",
             })?;
         strings.push(str_val);
@@ -227,10 +256,20 @@ fn parse_string_table_debug_and_ownership(
     let string_table_end_offset = cursor;
     let mut has_debug_section = false;
     let mut debug_symbols = Vec::new();
-    if cursor + 4 <= code.len() && &code[cursor..cursor + 4] == b"DBG0" {
+    // #1736: `checked_end` here only guards the lookahead slice read
+    // (`&code[cursor..end]`) against an out-of-bounds panic - it does NOT
+    // gate accept/reject. A `None`/non-matching result means "no DBG0 tag
+    // here", which is the ordinary, successful case for a function with no
+    // debug section: the block below is skipped and decoding proceeds to
+    // `Ok(...)`. Genuine corruption of a section that IS present (a
+    // truncated count or entry) is still caught deterministically by the
+    // `read_*` calls inside the block, same as everywhere else in this file.
+    let dbg_tag_end = checked_end(cursor, 4, code.len());
+    let is_dbg0 = dbg_tag_end.is_some_and(|end| &code[cursor..end] == b"DBG0");
+    if is_dbg0 {
         has_debug_section = true;
-        cursor += 4;
-        let dbg_count_offset = base_offset + cursor;
+        cursor = dbg_tag_end.expect("is_dbg0 implies dbg_tag_end is Some");
+        let dbg_count_offset = diag_offset(base_offset, cursor);
         let count =
             read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
                 offset: dbg_count_offset,
@@ -239,7 +278,7 @@ fn parse_string_table_debug_and_ownership(
 
         if count > MAX_DEBUG_SYMBOLS_PER_FUNCTION {
             return Err(DecodeError::ResourceLimit {
-                offset: base_offset + cursor,
+                offset: diag_offset(base_offset, cursor),
                 msg: format!(
                     "too many debug symbols: {} (max {})",
                     count, MAX_DEBUG_SYMBOLS_PER_FUNCTION
@@ -249,7 +288,7 @@ fn parse_string_table_debug_and_ownership(
 
         debug_symbols.reserve(count);
         for _ in 0..count {
-            let entry_offset = base_offset + cursor;
+            let entry_offset = diag_offset(base_offset, cursor);
             let pc =
                 read_u32_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
                     offset: entry_offset,
@@ -257,12 +296,12 @@ fn parse_string_table_debug_and_ownership(
                 })? as usize;
             let line =
                 read_u32_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
-                    offset: base_offset + cursor,
+                    offset: diag_offset(base_offset, cursor),
                     msg: "missing debug line",
                 })?;
             let col =
                 read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
-                    offset: base_offset + cursor,
+                    offset: diag_offset(base_offset, cursor),
                     msg: "missing debug col",
                 })?;
             debug_symbols.push(DecodedDebugSymbol { pc, line, col });
@@ -272,10 +311,14 @@ fn parse_string_table_debug_and_ownership(
     let mut borrowed_paths = Vec::new();
     let mut write_paths = Vec::new();
     let mut has_ownership_section = false;
-    if cursor + 4 <= code.len() && code[cursor..cursor + 4] == OWNERSHIP_SECTION_TAG {
+    // #1736: same "lookahead probe, not a rejection" semantics as the DBG0
+    // check above - see its doc comment.
+    let own_tag_end = checked_end(cursor, OWNERSHIP_SECTION_TAG.len(), code.len());
+    let is_own0 = own_tag_end.is_some_and(|end| code[cursor..end] == OWNERSHIP_SECTION_TAG);
+    if is_own0 {
         has_ownership_section = true;
-        cursor += OWNERSHIP_SECTION_TAG.len();
-        let own_count_offset = base_offset + cursor;
+        cursor = own_tag_end.expect("is_own0 implies own_tag_end is Some");
+        let own_count_offset = diag_offset(base_offset, cursor);
         let count =
             read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidOwnershipSection {
                 offset: own_count_offset,
@@ -285,7 +328,7 @@ fn parse_string_table_debug_and_ownership(
         borrowed_paths.reserve(count);
         write_paths.reserve(count);
         for _ in 0..count {
-            let entry_offset = base_offset + cursor;
+            let entry_offset = diag_offset(base_offset, cursor);
             let kind =
                 read_u8(code, &mut cursor).map_err(|_| DecodeError::InvalidOwnershipSection {
                     offset: entry_offset,
@@ -293,13 +336,13 @@ fn parse_string_table_debug_and_ownership(
                 })?;
             let root_symbol_id = read_u32_le(code, &mut cursor).map_err(|_| {
                 DecodeError::InvalidOwnershipSection {
-                    offset: base_offset + cursor,
+                    offset: diag_offset(base_offset, cursor),
                     msg: "missing ownership path root",
                 }
             })?;
             let component_count = read_u16_le(code, &mut cursor).map_err(|_| {
                 DecodeError::InvalidOwnershipSection {
-                    offset: base_offset + cursor,
+                    offset: diag_offset(base_offset, cursor),
                     msg: "missing ownership path component count",
                 }
             })? as usize;
@@ -308,7 +351,7 @@ fn parse_string_table_debug_and_ownership(
             for _ in 0..component_count {
                 let component_kind = read_u8(code, &mut cursor).map_err(|_| {
                     DecodeError::InvalidOwnershipSection {
-                        offset: base_offset + cursor,
+                        offset: diag_offset(base_offset, cursor),
                         msg: "missing ownership path component kind",
                     }
                 })?;
@@ -316,7 +359,7 @@ fn parse_string_table_debug_and_ownership(
                     OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX => {
                         let index = read_u16_le(code, &mut cursor).map_err(|_| {
                             DecodeError::InvalidOwnershipSection {
-                                offset: base_offset + cursor,
+                                offset: diag_offset(base_offset, cursor),
                                 msg: "missing ownership tuple index",
                             }
                         })?;
@@ -325,7 +368,7 @@ fn parse_string_table_debug_and_ownership(
                     OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL => {
                         let field = read_u32_le(code, &mut cursor).map_err(|_| {
                             DecodeError::InvalidOwnershipSection {
-                                offset: base_offset + cursor,
+                                offset: diag_offset(base_offset, cursor),
                                 msg: "missing ownership field symbol",
                             }
                         })?;
@@ -334,13 +377,13 @@ fn parse_string_table_debug_and_ownership(
                     OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD => {
                         let variant = read_u32_le(code, &mut cursor).map_err(|_| {
                             DecodeError::InvalidOwnershipSection {
-                                offset: base_offset + cursor,
+                                offset: diag_offset(base_offset, cursor),
                                 msg: "missing ownership adt payload variant",
                             }
                         })?;
                         let index = read_u16_le(code, &mut cursor).map_err(|_| {
                             DecodeError::InvalidOwnershipSection {
-                                offset: base_offset + cursor,
+                                offset: diag_offset(base_offset, cursor),
                                 msg: "missing ownership adt payload index",
                             }
                         })?;
@@ -349,7 +392,7 @@ fn parse_string_table_debug_and_ownership(
                     OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX => {
                         let index = read_u32_le(code, &mut cursor).map_err(|_| {
                             DecodeError::InvalidOwnershipSection {
-                                offset: base_offset + cursor,
+                                offset: diag_offset(base_offset, cursor),
                                 msg: "missing ownership sequence index",
                             }
                         })?;
@@ -357,7 +400,7 @@ fn parse_string_table_debug_and_ownership(
                     }
                     _ => {
                         return Err(DecodeError::InvalidOwnershipSection {
-                            offset: base_offset + cursor,
+                            offset: diag_offset(base_offset, cursor),
                             msg: "unsupported ownership path component kind",
                         });
                     }
@@ -374,7 +417,7 @@ fn parse_string_table_debug_and_ownership(
                 }),
                 _ => {
                     return Err(DecodeError::InvalidOwnershipSection {
-                        offset: base_offset + cursor,
+                        offset: diag_offset(base_offset, cursor),
                         msg: "unsupported ownership event kind",
                     });
                 }
@@ -416,6 +459,104 @@ mod tests {
         bytes.extend_from_slice(&(code.len() as u32).to_le_bytes());
         bytes.extend_from_slice(&code);
         bytes
+    }
+
+    // #1736 (FA-05-006): before the fix, `cursor + code_len` (a fully
+    // attacker-controlled u32 field) used raw addition, so a huge claimed
+    // code length could wrap `cursor` past zero on a 32-bit target and
+    // build a slice whose end sits before its start - an out-of-range slice
+    // index panic, not a decode error. This is the exact artifact shape
+    // that reproduced `slice index starts at 18 but ends at 2` under
+    // `cargo test --target i686-pc-windows-msvc --release`.
+    #[test]
+    fn decode_rejects_code_len_that_would_overflow_cursor_arithmetic() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC0);
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(b"main");
+        bytes.extend_from_slice(&0xFFFFFFF0u32.to_le_bytes());
+        let err = decode_semcode_envelope(&bytes).expect_err("must reject, never panic");
+        assert!(matches!(err, DecodeError::TruncatedFunction { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_debug_section_with_truncated_count_deterministically() {
+        let mut code = Vec::new();
+        code.extend_from_slice(&0u16.to_le_bytes()); // empty string table
+        code.extend_from_slice(b"DBG0");
+        code.push(0x01); // truncated debug-symbol count (needs 2 bytes)
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC0);
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(b"main");
+        bytes.extend_from_slice(&(code.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&code);
+
+        let err = decode_semcode_envelope(&bytes).expect_err("must reject, never panic");
+        assert!(matches!(err, DecodeError::InvalidDebugSection { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_ownership_section_with_truncated_count_deterministically() {
+        let mut code = Vec::new();
+        code.extend_from_slice(&0u16.to_le_bytes()); // empty string table
+        code.extend_from_slice(&OWNERSHIP_SECTION_TAG);
+        code.push(0x01); // truncated ownership-path count (needs 2 bytes)
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC0);
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(b"main");
+        bytes.extend_from_slice(&(code.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&code);
+
+        let err = decode_semcode_envelope(&bytes).expect_err("must reject, never panic");
+        assert!(matches!(err, DecodeError::InvalidOwnershipSection { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_string_table_entry_length_over_the_max() {
+        let mut code = Vec::new();
+        code.extend_from_slice(&1u16.to_le_bytes()); // one string table entry
+        code.extend_from_slice(&(MAX_STRING_LEN as u16 + 1).to_le_bytes()); // too long
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC0);
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(b"main");
+        bytes.extend_from_slice(&(code.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&code);
+
+        let err = decode_semcode_envelope(&bytes).expect_err("must reject, never panic");
+        assert!(matches!(err, DecodeError::InvalidStringTable { .. }));
+    }
+
+    // #1736 (FA-05-006): width-independent regression coverage for
+    // `checked_end`, the one shared primitive backing the `code_len` check
+    // and the `DBG0`/`OWN0` tag-sniffs. Forcing `cursor` to `usize::MAX - 1`
+    // directly exercises the overflow path on every target width, including
+    // ordinary 64-bit CI - unlike `decode_rejects_code_len_that_would_overflow_cursor_arithmetic`
+    // above, whose `code_len` is bounded to `u32` and so can only overflow a
+    // small starting `cursor` on an actual 32-bit target. This closes the
+    // gap without depending on a manual `--target i686-pc-windows-msvc` run
+    // (still genuinely verified once; see the PR/issue evidence) ever being
+    // repeated to catch a regression.
+    #[test]
+    fn checked_end_rejects_cursor_near_usize_max_on_any_target_width() {
+        assert_eq!(checked_end(usize::MAX - 1, 4, 100), None);
+        assert_eq!(checked_end(usize::MAX - 1, usize::MAX, 100), None);
+    }
+
+    #[test]
+    fn checked_end_still_accepts_ordinary_in_bounds_input() {
+        assert_eq!(checked_end(4, 4, 100), Some(8));
+        assert_eq!(checked_end(96, 4, 100), Some(100));
+    }
+
+    #[test]
+    fn checked_end_still_rejects_ordinary_truncation() {
+        assert_eq!(checked_end(97, 4, 100), None);
     }
 
     #[test]

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -2847,6 +2847,25 @@ mod tests {
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);
     }
 
+    // #1736 (FA-05-006): before the sm-format checked-arithmetic repair, this
+    // exact artifact shape (a claimed function code length that overflows
+    // cursor arithmetic) could panic inside `decode_semcode_envelope` on a
+    // 32-bit target instead of surfacing as a `RejectReport` - i.e. the
+    // verifier boundary was not actually panic-safe against malformed input.
+    #[test]
+    fn verify_semcode_token_rejects_overflowing_code_length_without_panicking() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&sm_format::semcode_format::MAGIC0);
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(b"main");
+        bytes.extend_from_slice(&0xFFFFFFF0u32.to_le_bytes());
+        let report = verify_semcode_token(&bytes).expect_err("must reject, never panic");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::TruncatedFunction
+        );
+    }
+
     #[test]
     fn verified_semcode_token_keeps_original_bytes() {
         let src = "fn main() { return; }";

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -377,6 +377,46 @@ Current `SEMCOD12` format extension in this slice:
 Execution semantics for admitted ownership payload are specified separately in
 `runtime_ownership.md`.
 
+### Offset Arithmetic Must Stay Inside The Result Model
+
+Every cursor/length computation in the `sm-format` decoder
+(`local_format.rs`'s low-level readers, and `semcode_decode.rs`'s function
+`code_len` check and its `DBG0`/`OWN0` section tag-sniffs) that could
+produce an out-of-bounds slice uses `checked_add`, never a raw `+`. A fully
+attacker-controlled length field (function `code_len`, or a per-string
+`len` consumed from the string table) combined with an already-advanced
+cursor must never be able to wrap past `usize::MAX` and produce a false
+in-bounds result - on any target width, including 32-bit, where a `u32`
+length field can realistically overflow `usize` arithmetic. Loop trip
+counts (string/debug-symbol/ownership-path counts, and ownership
+component counts) never participate in this cursor arithmetic themselves -
+each loop iteration's individual field read is independently bounds-checked
+- so an oversized count cannot overflow anything; it only causes however
+many extra `read_*` calls the loop makes, each still subject to the same
+checked arithmetic.
+
+For the function `code_len` check specifically, an overflow is always
+treated as "the claimed length cannot possibly fit" and rejected with the
+same structural decode error (`DecodeError::TruncatedFunction`) the
+ordinary bounds check already produces; it is never silently wrapped,
+saturated, or ignored. The `DBG0`/`OWN0` tag-sniffs use the identical
+checked-arithmetic pattern, but for a different purpose: they are a
+lookahead probe for an *optional* section, not an accept/reject gate. A
+failed probe - whether from overflow, an ordinary out-of-bounds lookahead,
+or (the common case) simply because the function has no debug/ownership
+section - means "section absent," and decoding proceeds normally; it does
+not, by itself, produce a decode error. Genuine corruption of a section
+that IS present (a truncated count or entry once the tag has matched) is
+still caught deterministically by the ordinary `read_*` calls inside that
+section's parsing, same as everywhere else in this file. The checked
+arithmetic's job in the tag-sniff is narrower than in the `code_len` check:
+only to prevent the lookahead read itself from panicking, not to gate
+whether the artifact is accepted.
+
+Diagnostic-only offset values reported inside an already-failed read's
+error message (i.e. values that do not themselves gate acceptance) may
+saturate instead, since no accept/reject decision depends on them.
+
 ## Backward Compatibility Rule
 
 The following changes require a SemCode version review:


### PR DESCRIPTION
## Summary

Closes #1736 (FA-05-006): `decode_semcode_envelope`'s function `code_len` bounds check, `local_format.rs`'s five low-level readers (`read_u8`/`read_u16_le`/`read_u32_le`/`read_f64_le`/`read_utf8`), and the `DBG0`/`OWN0` section tag-sniffs all used raw `+` on attacker-controlled length fields. On a 32-bit target, a tiny malformed artifact can choose a near-`u32::MAX` `code_len` so the cursor addition wraps `usize`, producing an out-of-range slice-index panic instead of a deterministic decode error.

- **Genuinely reproduced**, not simulated: installed `i686-pc-windows-msvc` and confirmed the exact pre-fix panic (`slice index starts at 18 but ends at 2`) on a real 32-bit release build; post-fix the same artifact returns `Err(TruncatedFunction)`.
- **Fix**: every real bounds-check site now goes through a `checked_add`-based primitive (`checked_read_end` in `local_format.rs`; `checked_end` in `semcode_decode.rs`) that fails closed on overflow, mapping it to the same error the ordinary out-of-bounds case already produces.
- **One deliberate, narrow exception**: `diag_offset` uses `saturating_add` for diagnostic-only error-offset fields that never gate accept/reject (every call site is already inside an error-construction closure triggered by an already-failed `read_*` call). Confirmed by an independent rule-compliance review pass that no call site's result influences an accept/reject decision.
- **Regression coverage is width-independent**: rather than relying solely on a manual 32-bit run, tests force the cursor to `usize::MAX - 1` directly, so the exact overflow path is exercised on ordinary 64-bit CI too (`checked_end_rejects_cursor_near_usize_max_on_any_target_width`, plus the `local_format.rs` reader-level equivalents).
- Updated `docs/spec/semcode.md`'s Structural Contract with a new subsection documenting the invariant, including the distinction between the `code_len` check (a real accept/reject gate) and the `DBG0`/`OWN0` tag-sniffs (a lookahead probe for an optional section — a failed probe means "section absent," not rejection).

This PR's diff was adversarially reviewed by 5 independent agents (correctness, completeness, test-coverage, spec-accuracy, no-fallback-rule-compliance) before being opened; 4 real findings were confirmed and fixed pre-push (2 test-coverage gaps closed via the new width-independent tests above, 2 spec-doc inaccuracies corrected), 1 stylistic nitpick was independently refuted.

## Test plan

- [x] `cargo test -p sm-format --all-features` — 19/19 pass
- [x] `cargo test -p sm-format --target i686-pc-windows-msvc --release` — 19/19 pass, including genuine 32-bit reproduction/fix confirmation
- [x] `cargo test -p sm-verify --all-features --features sm-ir/profile-rust` — 81/81 pass, including a new `verify_semcode_token`-boundary panic-safety test
- [x] `cargo test -p sm-ir` — 104/104 pass
- [x] `cargo test -p sm-vm --all-features` — 23/23 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` (per-package) — clean
- [x] `cargo check --workspace --all-features` / `--no-default-features` — clean
- [x] Full `scripts/admission_guard.ps1` PR-ready gate — `local_ci passed` (exit 0), twice (before and after the post-review fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)