### PR TITLE
test(sm-format): freeze the complete opcode byte ABI

### DIFF
--- a/crates/sm-format/src/lib.rs
+++ b/crates/sm-format/src/lib.rs
@@ -24,31 +24,229 @@ mod tests {
         let _ = std::mem::size_of::<semcode_decode::DecodeError>();
     }
 
+    // #1734 (FA-05-004): `expected_opcode_byte` is an exhaustive match over
+    // every `Opcode` variant (no wildcard `_`), so adding a future variant
+    // without giving it an arm here is a compile-time error - the same
+    // compiler-enforced completeness guarantee `minimum_semcode_revision`
+    // already relies on. `ALL_OPCODES` below is a second, independently
+    // hand-maintained list (kept in the same declaration order as the
+    // `Opcode` enum in `local_format.rs`, for easy visual diffing) driving
+    // the loop that actually exercises `expected_opcode_byte` per variant.
+    //
+    // IMPORTANT, and a known residual gap (adversarial review, #1734): only
+    // `expected_opcode_byte`'s exhaustiveness is compiler-enforced.
+    // `ALL_OPCODES`'s length is a second, independently hand-typed literal
+    // with no structural link to the real enum's variant count - the
+    // length/uniqueness checks below catch a *duplicated* entry masking a
+    // missing one (verified: swapping the array's last entry for a repeat
+    // of an earlier one fails the dedup check), but if a brand-new `Opcode`
+    // variant is added, the compiler forces a new arm into
+    // `expected_opcode_byte` yet does NOT force a corresponding new entry
+    // into `ALL_OPCODES` - the array and this test would keep compiling and
+    // passing green while silently covering only the old variant count.
+    // Closing that fully needs enum-variant reflection (e.g. `strum`'s
+    // `EnumIter`), which is a new dependency and out of scope for this
+    // test-only issue; anyone adding an `Opcode` variant MUST update
+    // `ALL_OPCODES` and its length below by hand, in the same change that
+    // updates `expected_opcode_byte`. `sm-vm`'s pre-existing
+    // `OPCODE_PROFILE_OPCODES: [Opcode; 73]` has this same characteristic.
+    fn expected_opcode_byte(op: semcode_format::Opcode) -> u8 {
+        use semcode_format::Opcode;
+        match op {
+            Opcode::LoadQ => 0x01,
+            Opcode::LoadBool => 0x02,
+            Opcode::LoadI32 => 0x03,
+            Opcode::AddI32 => 0x07,
+            Opcode::SubI32 => 0x08,
+            Opcode::MulI32 => 0x09,
+            Opcode::DivI32 => 0x0a,
+            Opcode::ModI32 => 0x0b,
+            Opcode::ConcatText => 0x0c,
+            Opcode::LoadU32 => 0x06,
+            Opcode::LoadVar => 0x04,
+            Opcode::StoreVar => 0x05,
+            Opcode::QAnd => 0x10,
+            Opcode::QOr => 0x11,
+            Opcode::QNot => 0x12,
+            Opcode::QImpl => 0x13,
+            Opcode::BoolAnd => 0x14,
+            Opcode::BoolOr => 0x15,
+            Opcode::BoolNot => 0x16,
+            Opcode::QTruthAnd => 0x17,
+            Opcode::QTruthOr => 0x18,
+            Opcode::QTruthNot => 0x19,
+            Opcode::QTruthImpl => 0x1a,
+            Opcode::CmpEq => 0x20,
+            Opcode::CmpNe => 0x21,
+            Opcode::CmpI32Lt => 0x22,
+            Opcode::CmpI32Le => 0x23,
+            Opcode::Jmp => 0x30,
+            Opcode::JmpIf => 0x31,
+            Opcode::Call => 0x40,
+            Opcode::Ret => 0x41,
+            Opcode::Assert => 0x42,
+            Opcode::MakeTuple => 0x43,
+            Opcode::TupleGet => 0x44,
+            Opcode::MakeRecord => 0x45,
+            Opcode::RecordGet => 0x46,
+            Opcode::MakeAdt => 0x47,
+            Opcode::AdtTag => 0x48,
+            Opcode::AdtGet => 0x49,
+            Opcode::LoadF64 => 0x50,
+            Opcode::AddF64 => 0x51,
+            Opcode::SubF64 => 0x52,
+            Opcode::MulF64 => 0x53,
+            Opcode::DivF64 => 0x54,
+            Opcode::LoadFx => 0x55,
+            Opcode::AddFx => 0x56,
+            Opcode::SubFx => 0x57,
+            Opcode::MulFx => 0x58,
+            Opcode::DivFx => 0x59,
+            Opcode::LoadText => 0x5a,
+            Opcode::MakeSequence => 0x5b,
+            Opcode::SequenceGet => 0x5c,
+            Opcode::MakeClosure => 0x5d,
+            Opcode::ClosureCall => 0x5e,
+            Opcode::SequenceLen => 0x5f,
+            Opcode::SequenceIsEmpty => 0x67,
+            Opcode::SequenceContains => 0x68,
+            Opcode::SequencePush => 0x69,
+            Opcode::SequencePrepend => 0x6a,
+            Opcode::SequencePop => 0x6b,
+            Opcode::MapEmpty => 0x70,
+            Opcode::MapContains => 0x71,
+            Opcode::MapGet => 0x72,
+            Opcode::MapSet => 0x73,
+            Opcode::RngSeed => 0x74,
+            Opcode::RngNextI32 => 0x75,
+            Opcode::GateRead => 0x60,
+            Opcode::GateWrite => 0x61,
+            Opcode::PulseEmit => 0x62,
+            Opcode::StateQuery => 0x63,
+            Opcode::StateUpdate => 0x64,
+            Opcode::EventPost => 0x65,
+            Opcode::ClockRead => 0x66,
+        }
+    }
+
     #[test]
     fn test_opcode_byte_values_frozen() {
         use semcode_format::Opcode;
 
-        // Ensure existing opcodes haven't shifted
-        assert_eq!(Opcode::QAnd as u8, 0x10);
-        assert_eq!(Opcode::QOr as u8, 0x11);
-        assert_eq!(Opcode::QNot as u8, 0x12);
-        assert_eq!(Opcode::QImpl as u8, 0x13);
-        assert_eq!(Opcode::BoolAnd as u8, 0x14);
-        assert_eq!(Opcode::BoolOr as u8, 0x15);
-        assert_eq!(Opcode::BoolNot as u8, 0x16);
+        const ALL_OPCODES: [Opcode; 73] = [
+            Opcode::LoadQ,
+            Opcode::LoadBool,
+            Opcode::LoadI32,
+            Opcode::AddI32,
+            Opcode::SubI32,
+            Opcode::MulI32,
+            Opcode::DivI32,
+            Opcode::ModI32,
+            Opcode::ConcatText,
+            Opcode::LoadU32,
+            Opcode::LoadVar,
+            Opcode::StoreVar,
+            Opcode::QAnd,
+            Opcode::QOr,
+            Opcode::QNot,
+            Opcode::QImpl,
+            Opcode::BoolAnd,
+            Opcode::BoolOr,
+            Opcode::BoolNot,
+            Opcode::QTruthAnd,
+            Opcode::QTruthOr,
+            Opcode::QTruthNot,
+            Opcode::QTruthImpl,
+            Opcode::CmpEq,
+            Opcode::CmpNe,
+            Opcode::CmpI32Lt,
+            Opcode::CmpI32Le,
+            Opcode::Jmp,
+            Opcode::JmpIf,
+            Opcode::Call,
+            Opcode::Ret,
+            Opcode::Assert,
+            Opcode::MakeTuple,
+            Opcode::TupleGet,
+            Opcode::MakeRecord,
+            Opcode::RecordGet,
+            Opcode::MakeAdt,
+            Opcode::AdtTag,
+            Opcode::AdtGet,
+            Opcode::LoadF64,
+            Opcode::AddF64,
+            Opcode::SubF64,
+            Opcode::MulF64,
+            Opcode::DivF64,
+            Opcode::LoadFx,
+            Opcode::AddFx,
+            Opcode::SubFx,
+            Opcode::MulFx,
+            Opcode::DivFx,
+            Opcode::LoadText,
+            Opcode::MakeSequence,
+            Opcode::SequenceGet,
+            Opcode::MakeClosure,
+            Opcode::ClosureCall,
+            Opcode::SequenceLen,
+            Opcode::SequenceIsEmpty,
+            Opcode::SequenceContains,
+            Opcode::SequencePush,
+            Opcode::SequencePrepend,
+            Opcode::SequencePop,
+            Opcode::MapEmpty,
+            Opcode::MapContains,
+            Opcode::MapGet,
+            Opcode::MapSet,
+            Opcode::RngSeed,
+            Opcode::RngNextI32,
+            Opcode::GateRead,
+            Opcode::GateWrite,
+            Opcode::PulseEmit,
+            Opcode::StateQuery,
+            Opcode::StateUpdate,
+            Opcode::EventPost,
+            Opcode::ClockRead,
+        ];
 
-        // Ensure explicit QTruth opcodes match reserved slots
-        assert_eq!(Opcode::QTruthAnd as u8, 0x17);
-        assert_eq!(Opcode::QTruthOr as u8, 0x18);
-        assert_eq!(Opcode::QTruthNot as u8, 0x19);
-        assert_eq!(Opcode::QTruthImpl as u8, 0x1a);
+        // Independent cross-check that ALL_OPCODES itself wasn't
+        // transcribed with a missing or duplicated variant: 73 entries,
+        // all distinct. This 73 is a hand-typed literal, not derived from
+        // the real Opcode enum - if you're here because this assert just
+        // failed after adding a new Opcode variant, update ALL_OPCODES
+        // (and expected_opcode_byte above) to include it, then update this
+        // literal to match.
+        assert_eq!(
+            ALL_OPCODES.len(),
+            73,
+            "ALL_OPCODES must list every Opcode variant exactly once - if you added a new \
+             Opcode variant, add it to ALL_OPCODES and expected_opcode_byte, then update \
+             this expected count"
+        );
+        let mut seen = std::collections::HashSet::new();
+        for op in ALL_OPCODES {
+            assert!(
+                seen.insert(op),
+                "{op:?} appears more than once in ALL_OPCODES"
+            );
+        }
 
-        // Ensure roundtrip from_byte works
-        assert_eq!(Opcode::from_byte(0x10), Ok(Opcode::QAnd));
-        assert_eq!(Opcode::from_byte(0x17), Ok(Opcode::QTruthAnd));
-        assert_eq!(Opcode::from_byte(0x18), Ok(Opcode::QTruthOr));
-        assert_eq!(Opcode::from_byte(0x19), Ok(Opcode::QTruthNot));
-        assert_eq!(Opcode::from_byte(0x1a), Ok(Opcode::QTruthImpl));
+        // Bidirectional freeze proof for every variant: the enum
+        // discriminant must still match its independently hand-pinned
+        // expected byte, and decoding that byte must still round-trip to
+        // the same variant.
+        for op in ALL_OPCODES {
+            let expected = expected_opcode_byte(op);
+            assert_eq!(
+                op as u8, expected,
+                "{op:?}'s byte value drifted from its frozen pin 0x{expected:02x}"
+            );
+            assert_eq!(
+                Opcode::from_byte(expected),
+                Ok(op),
+                "Opcode::from_byte(0x{expected:02x}) no longer round-trips to {op:?}"
+            );
+        }
     }
 
     // #1732 (FA-05-002) review follow-up: minimum_semcode_revision() is now


### PR DESCRIPTION
## Summary

Closes #1734 (FA-05-004): `test_opcode_byte_values_frozen`'s name and the surrounding "SemCode Format Authority" qualification language (7hell Hell 3, `docs/roadmap/core_quad/qtruth_opcode_reservation.md`'s frozen-byte-ABI claim) implied it proves opcode byte-value stability broadly, but it only checked 11 of the `Opcode` enum's 73 variants (the `QAnd`/`BoolAnd`/`QTruth` logic block).

- **Test-only change** — no production code touched.
- Rewrote the test to be genuinely exhaustive: `expected_opcode_byte`, an independently hand-pinned match with **no wildcard arm**, so adding a future `Opcode` variant without giving it an arm is a compile-time error — the same guarantee `minimum_semcode_revision` already relies on. Combined with a hand-maintained `ALL_OPCODES: [Opcode; 73]` array (same declaration order as the enum, for easy diffing), the test proves **bidirectional** freezing for all 73 variants: `op as u8 == expected` and `Opcode::from_byte(expected) == Ok(op)`.
- **Genuinely verified the guard isn't incidental**, via three temporary mutate-then-revert experiments (all reverted before this commit):
  1. Deleting the `RngNextI32` arm → failed to **compile** (`E0004: non-exhaustive patterns`).
  2. Changing `RngNextI32`'s expected byte `0x75 → 0x76` → failed the **runtime** assertion (`left: 117, right: 118`).
  3. Replacing `ALL_OPCODES`'s last entry (`ClockRead`) with a duplicate `EventPost` (silently dropping `ClockRead`, array length still 73) → failed the **dedup** assertion.
- **One honestly-documented residual gap**, found by an adversarial review pass before this PR was opened: `ALL_OPCODES`'s own completeness isn't compiler-enforced the way `expected_opcode_byte`'s match is — only its length/dedup are checked. A brand-new future opcode variant would force a new match arm but not force a new array entry. Closing that fully needs enum-variant reflection (a new dependency, e.g. `strum`), which is out of scope for this test-only issue. `sm-vm`'s pre-existing `OPCODE_PROFILE_OPCODES: [Opcode; 73]` already has the identical characteristic, so this isn't a new risk class — it's now loudly commented at both the match and the length-assert site so a future contributor can't miss it.

## Test plan

- [x] `cargo test -p sm-format --all-features` — 19/19 pass
- [x] `cargo clippy -p sm-format --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p sm-format` — clean
- [x] Full `scripts/admission_guard.ps1` PR-ready gate — `local_ci passed` (exit 0), run twice (before and after the post-review documentation fix)
- [x] Adversarially reviewed by 3 independent agents (correctness against the real enum source, exhaustiveness-guard validity, no-false-confidence design soundness) before opening; 1 real minor finding confirmed and addressed above, verified refuted-nothing-else

🤖 Generated with [Claude Code](https://claude.com/claude-code)