### PR TITLE
fix(sm-verify): reject dangling closure targets

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -662,7 +662,7 @@ fn verify_function_code(
                 format!("{usage} uses missing string id s{sid}"),
             ));
         }
-        if usage == "call target" {
+        if matches!(usage, "call target" | "closure function name") {
             call_targets.push((offset, env.strings[sid].clone()));
         }
     }
@@ -2303,6 +2303,30 @@ mod tests {
             .expect("helper string");
         bytes[helper_pos..helper_pos + b"helper".len()].copy_from_slice(b"gh0st!");
         let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::UnknownCallTarget
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_unknown_closure_target() {
+        let mut bytes = compile_program_to_semcode(
+            "fn main() { let add: Closure(f64 -> f64) = (x => x + 1.0); add(2.0); return; }",
+        )
+        .expect("compile");
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let (closure_name_offset, closure_name_len) = functions
+            .iter()
+            .find(|function| function.name.starts_with("__closure_"))
+            .map(|function| (function.name_offset + 2, function.name.len()))
+            .expect("closure function");
+        let replacement = "x".repeat(closure_name_len);
+        bytes[closure_name_offset..closure_name_offset + closure_name_len]
+            .copy_from_slice(replacement.as_bytes());
+
+        let report = verify_semcode(&bytes).expect_err("must reject dangling closure target");
         assert_eq!(
             report.diagnostics[0].code,
             VerificationCode::UnknownCallTarget

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -370,24 +370,26 @@ pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectR
         .map(|function| function.verified.name.as_str())
         .collect::<HashSet<_>>();
     for function in &pending_functions {
-        for (offset, callee) in &function.call_targets {
+        for (offset, callee, allows_builtin) in &function.call_targets {
             if known_functions.contains(callee.as_str()) {
                 continue;
             }
 
-            if let Some(required_capabilities) = builtin_call_required_capabilities(callee) {
-                if header.capabilities & required_capabilities != required_capabilities {
-                    diagnostics.push(diag(
-                        VerificationCode::CapabilityViolation,
-                        Some(function.verified.name.clone()),
-                        Some(*offset),
-                        format!(
-                            "builtin call target '{}' requires capability bits 0x{required_capabilities:08x}",
-                            callee
-                        ),
-                    ));
+            if *allows_builtin {
+                if let Some(required_capabilities) = builtin_call_required_capabilities(callee) {
+                    if header.capabilities & required_capabilities != required_capabilities {
+                        diagnostics.push(diag(
+                            VerificationCode::CapabilityViolation,
+                            Some(function.verified.name.clone()),
+                            Some(*offset),
+                            format!(
+                                "builtin call target '{}' requires capability bits 0x{required_capabilities:08x}",
+                                callee
+                            ),
+                        ));
+                    }
+                    continue;
                 }
-                continue;
             }
 
             diagnostics.push(diag(
@@ -662,8 +664,12 @@ fn verify_function_code(
                 format!("{usage} uses missing string id s{sid}"),
             ));
         }
-        if matches!(usage, "call target" | "closure function name") {
-            call_targets.push((offset, env.strings[sid].clone()));
+        match usage {
+            "call target" => call_targets.push((offset, env.strings[sid].clone(), true)),
+            "closure function name" => {
+                call_targets.push((offset, env.strings[sid].clone(), false));
+            }
+            _ => {}
         }
     }
 
@@ -1329,7 +1335,7 @@ struct OperandRefs {
 #[cfg(feature = "std")]
 struct PendingVerifiedFunction {
     verified: VerifiedFunction,
-    call_targets: Vec<(usize, String)>,
+    call_targets: Vec<(usize, String, bool)>,
     has_ownership_section: bool,
 }
 
@@ -2327,6 +2333,33 @@ mod tests {
             .copy_from_slice(replacement.as_bytes());
 
         let report = verify_semcode(&bytes).expect_err("must reject dangling closure target");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::UnknownCallTarget
+        );
+    }
+
+    #[test]
+    fn verifier_rejects_builtin_closure_target() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadF64 { dst: 0, val: 1.0 },
+                    IrInstr::MakeClosure {
+                        dst: 1,
+                        name: "sqrt".to_string(),
+                        captures: Vec::new(),
+                    },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+
+        let report = verify_semcode(&bytes).expect_err("must reject builtin closure target");
         assert_eq!(
             report.diagnostics[0].code,
             VerificationCode::UnknownCallTarget

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -351,7 +351,8 @@ Current SemCode admission validates:
   `## Opcode Vocabulary And Header Identity`)
 - operand shape validity
 - jump-target validity
-- executable function-target validity for direct calls and closures
+- executable-target validity: direct calls resolve to declared functions or
+  admitted builtins, while closures resolve only to declared functions
 - register-budget validity against the runtime contract
 - string and debug reference validity
 - capability consistency between actual usage and emitted contract

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -351,7 +351,7 @@ Current SemCode admission validates:
   `## Opcode Vocabulary And Header Identity`)
 - operand shape validity
 - jump-target validity
-- call-target validity
+- executable function-target validity for direct calls and closures
 - register-budget validity against the runtime contract
 - string and debug reference validity
 - capability consistency between actual usage and emitted contract

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -63,7 +63,7 @@ without turning this document into a stable bytecode ISA promise.
 | Effect-oriented host-boundary families such as `GateRead`, `GateWrite`, and `PulseEmit` | Admitted only when the emitted contract matches the required capability envelope | Capability-gated / host-boundary | These opcodes do not define capability policy semantics by themselves. |
 | Ownership transport payloads admitted through `OWN0` | Admitted structurally only when the ownership transport slice is present and well formed | Header and capability consistency required | This covers the currently documented tuple-only and direct record-field ownership transport slices. |
 | Unknown, unsupported, or malformed opcode encodings | Rejected | N/A | Rejection must happen before a successful VM execution path. |
-| Opcode streams that fail operand, jump-target, call-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | These are verifier admission failures, not successful runtime executions. |
+| Opcode streams that fail operand, jump-target, call-target, closure-function-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | These are verifier admission failures, not successful runtime executions. |
 
 Current ownership-specific structural checks for ownership transport include:
 

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -63,7 +63,7 @@ without turning this document into a stable bytecode ISA promise.
 | Effect-oriented host-boundary families such as `GateRead`, `GateWrite`, and `PulseEmit` | Admitted only when the emitted contract matches the required capability envelope | Capability-gated / host-boundary | These opcodes do not define capability policy semantics by themselves. |
 | Ownership transport payloads admitted through `OWN0` | Admitted structurally only when the ownership transport slice is present and well formed | Header and capability consistency required | This covers the currently documented tuple-only and direct record-field ownership transport slices. |
 | Unknown, unsupported, or malformed opcode encodings | Rejected | N/A | Rejection must happen before a successful VM execution path. |
-| Opcode streams that fail operand, jump-target, call-target, closure-function-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | These are verifier admission failures, not successful runtime executions. |
+| Opcode streams that fail operand, jump-target, call-target, closure-function-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | Direct calls may resolve to declared functions or admitted builtins; closure targets must resolve to declared functions. These are verifier admission failures, not successful runtime executions. |
 
 Current ownership-specific structural checks for ownership transport include:
 


### PR DESCRIPTION
## Summary

- route `MakeClosure` function-name references through executable-target validation
- require closure targets to resolve to declared SemCode functions
- preserve the existing direct-`CALL` exemption for admitted builtins
- document the direct-call versus closure-target distinction

Closes #1744 (`FA-07-004`).

## Root cause

`decode_operands` already classified the operand as `closure function name`, but `verify_function_code` only promoted references labelled `call target` into the program-level known-target check. The string reference was therefore structurally valid while its executable target could remain unresolved until VM execution.

The first repair reused the existing target gate. Review then exposed a second distinction inside that gate: direct `CALL` may execute admitted builtins, while `CLOSURE_CALL` always resolves through a VM function frame. The final code retains that target kind so the builtin exemption applies only to direct calls.

## Regression

Two focused regressions now cover the boundary:

- a real closure program whose emitted helper-function name is mutated while the `MakeClosure` target remains unchanged
- a crafted `MakeClosure("sqrt")` artifact carrying the builtin's required capability

Both were accepted before their respective fixes and now fail with `VerificationCode::UnknownCallTarget`. Positive direct builtin calls and valid closure execution remain accepted.

## Validation

- `cargo test -p sm-verify --features sm-ir/profile-rust,sm-ir/profile-logos,sm-ir/debug-symbols --lib` — 83 passed
- `cargo test -p sm-vm --features disasm --lib vm_runs_first_class_closure_direct_invocation_path` — passed
- focused direct builtin-call acceptance test — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `git diff --check` — passed
- full GitHub CI on final HEAD — passed
- Codex review on final HEAD — clean

## Scope

Only `sm-verify` and the two verifier/SemCode specification lines are changed. No VM/runtime behavior changes for valid artifacts, no new dependency, and no fallback path.