### PR TITLE
fix(sm-verify): reject reachable function fallthrough

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -56,6 +56,11 @@ pub enum VerificationCode {
     /// header predates the revision whose contract actually admits this
     /// opcode's semantics.
     OpcodeRequiresNewerHeader,
+    /// A control-flow successor reachable from the function entry falls off
+    /// the executable instruction stream instead of reaching another
+    /// instruction boundary or an admitted terminal instruction (`RET`).
+    /// Closed loops remain admissible; this code does not imply termination.
+    ReachableFunctionFallthrough,
 }
 
 #[cfg(feature = "std")]
@@ -547,6 +552,7 @@ fn verify_function_code(
     let instr_start = cursor;
     let instr_len = code.len().saturating_sub(instr_start);
     let mut instr_starts = Vec::new();
+    let mut instruction_successors = Vec::new();
     let mut jump_targets = Vec::new();
     let mut string_refs = Vec::new();
     let mut max_register: Option<usize> = None;
@@ -577,6 +583,23 @@ fn verify_function_code(
             ),
         })?;
         let refs = decode_operands(name, code, &mut cursor, offset, opcode, true)?;
+        let next_offset = cursor - instr_start;
+        let jump_target = refs.jump_targets.first().copied();
+        let successors = match (opcode, jump_target) {
+            (Opcode::Ret, _) => InstructionSuccessors::None,
+            (Opcode::Jmp, Some(target)) => InstructionSuccessors::One(target),
+            (Opcode::JmpIf, Some(target)) => InstructionSuccessors::Two(target, next_offset),
+            (Opcode::Jmp | Opcode::JmpIf, None) => {
+                return Err(reject_one(
+                    name,
+                    VerificationCode::InvalidJumpTarget,
+                    offset,
+                    "jump instruction has no decoded target",
+                ));
+            }
+            _ => InstructionSuccessors::One(next_offset),
+        };
+        instruction_successors.push(successors);
         let min_rev = opcode.minimum_semcode_revision();
         if header.rev < min_rev {
             return Err(reject_one(
@@ -654,6 +677,8 @@ fn verify_function_code(
         }
     }
 
+    verify_reachable_control_flow(name, instr_len, &instr_starts, &instruction_successors)?;
+
     let mut call_targets = Vec::new();
     for (offset, sid, usage) in string_refs {
         if sid >= string_count {
@@ -698,6 +723,56 @@ fn verify_function_code(
         call_targets,
         has_ownership_section,
     })
+}
+
+#[cfg(feature = "std")]
+enum InstructionSuccessors {
+    None,
+    One(usize),
+    Two(usize, usize),
+}
+
+#[cfg(feature = "std")]
+fn verify_reachable_control_flow(
+    function: &str,
+    instr_len: usize,
+    instr_starts: &[usize],
+    instruction_successors: &[InstructionSuccessors],
+) -> Result<(), RejectReport> {
+    let mut pending = vec![0usize];
+    let mut reachable = HashSet::new();
+
+    while let Some(offset) = pending.pop() {
+        if !reachable.insert(offset) {
+            continue;
+        }
+        if offset == instr_len {
+            return Err(reject_one(
+                function,
+                VerificationCode::ReachableFunctionFallthrough,
+                offset,
+                "reachable control flow falls off the end of the instruction stream",
+            ));
+        }
+        let index = instr_starts.binary_search(&offset).map_err(|_| {
+            reject_one(
+                function,
+                VerificationCode::ReachableFunctionFallthrough,
+                offset,
+                "reachable control-flow successor is not an instruction boundary",
+            )
+        })?;
+        match &instruction_successors[index] {
+            InstructionSuccessors::None => {}
+            InstructionSuccessors::One(successor) => pending.push(*successor),
+            InstructionSuccessors::Two(first, second) => {
+                pending.push(*first);
+                pending.push(*second);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Decodes one instruction's operands, advancing `cursor` past its full byte
@@ -1381,6 +1456,158 @@ mod tests {
         compile_program_to_semcode, compile_program_to_semcode_with_options_debug,
         emit_ir_to_semcode, CompileProfile, IrFunction, IrInstr, OptLevel,
     };
+
+    fn emit_test_function(instrs: Vec<IrInstr>) -> Vec<u8> {
+        emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs,
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit test function")
+    }
+
+    #[test]
+    fn verifier_rejects_reachable_ordinary_instruction_fallthrough() {
+        let bytes = emit_test_function(vec![IrInstr::LoadBool { dst: 0, val: true }]);
+        let report =
+            verify_semcode(&bytes).expect_err("reachable LOAD_BOOL followed by EOF must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::ReachableFunctionFallthrough
+        );
+        assert_eq!(report.diagnostics[0].offset, Some(4));
+    }
+
+    #[test]
+    fn verifier_rejects_empty_instruction_stream() {
+        let bytes = emit_test_function(Vec::new());
+        let report =
+            verify_semcode(&bytes).expect_err("empty executable instruction stream must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::ReachableFunctionFallthrough
+        );
+        assert_eq!(report.diagnostics[0].offset, Some(0));
+    }
+
+    #[test]
+    fn verifier_rejects_conditional_branch_with_eof_fallthrough() {
+        let bytes = emit_test_function(vec![
+            IrInstr::LoadBool { dst: 0, val: true },
+            IrInstr::Label {
+                name: "branch".to_string(),
+            },
+            IrInstr::JmpIf {
+                cond: 0,
+                label: "branch".to_string(),
+            },
+        ]);
+        let report = verify_semcode(&bytes)
+            .expect_err("conditional branch with a reachable EOF successor must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::ReachableFunctionFallthrough
+        );
+    }
+
+    #[test]
+    fn verifier_accepts_function_ending_in_ret() {
+        let bytes = emit_test_function(vec![IrInstr::Ret { src: None }]);
+        verify_semcode(&bytes).expect("RET is a terminal instruction");
+    }
+
+    #[test]
+    fn verifier_accepts_unconditional_jump_to_valid_return_boundary() {
+        let bytes = emit_test_function(vec![
+            IrInstr::Jmp {
+                label: "return".to_string(),
+            },
+            IrInstr::LoadBool { dst: 0, val: true },
+            IrInstr::Label {
+                name: "return".to_string(),
+            },
+            IrInstr::Ret { src: None },
+        ]);
+        verify_semcode(&bytes).expect("JMP has only its valid explicit target as successor");
+    }
+
+    #[test]
+    fn verifier_accepts_structurally_closed_infinite_loop() {
+        let bytes = emit_test_function(vec![
+            IrInstr::Label {
+                name: "loop".to_string(),
+            },
+            IrInstr::Jmp {
+                label: "loop".to_string(),
+            },
+            IrInstr::LoadBool { dst: 0, val: true },
+        ]);
+        verify_semcode(&bytes)
+            .expect("closed reachable control flow may leave trailing fallthrough unreachable");
+    }
+
+    #[test]
+    fn verifier_preserves_call_and_closure_call_fallthrough() {
+        let direct_call = emit_ir_to_semcode(
+            &[
+                IrFunction {
+                    name: "helper".to_string(),
+                    instrs: vec![IrInstr::Ret { src: None }],
+                    ownership_events: Vec::new(),
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    instrs: vec![
+                        IrInstr::Call {
+                            dst: None,
+                            name: "helper".to_string(),
+                            args: Vec::new(),
+                        },
+                        IrInstr::Ret { src: None },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+            ],
+            false,
+        )
+        .expect("emit direct call");
+        verify_semcode(&direct_call).expect("CALL returns to the decoded next instruction");
+
+        let closure_call = emit_ir_to_semcode(
+            &[
+                IrFunction {
+                    name: "helper".to_string(),
+                    instrs: vec![IrInstr::Ret { src: None }],
+                    ownership_events: Vec::new(),
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    instrs: vec![
+                        IrInstr::MakeClosure {
+                            dst: 0,
+                            name: "helper".to_string(),
+                            captures: Vec::new(),
+                        },
+                        IrInstr::LoadBool { dst: 1, val: true },
+                        IrInstr::ClosureCall {
+                            dst: None,
+                            closure: 0,
+                            arg: 1,
+                        },
+                        IrInstr::Ret { src: None },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+            ],
+            false,
+        )
+        .expect("emit closure call");
+        verify_semcode(&closure_call)
+            .expect("CLOSURE_CALL returns to the decoded next instruction");
+    }
 
     #[test]
     fn verifier_accepts_valid_semcode() {

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -351,6 +351,9 @@ Current SemCode admission validates:
   `## Opcode Vocabulary And Header Identity`)
 - operand shape validity
 - jump-target validity
+- reachable control-flow closure: every successor reachable from function
+  entry is another instruction boundary or an admitted terminal condition;
+  end-of-stream fallthrough is not admissible
 - executable-target validity: direct calls resolve to declared functions or
   admitted builtins, while closures resolve only to declared functions
 - register-budget validity against the runtime contract

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -43,6 +43,7 @@ Current SemCode verification checks include:
 - opcode/header-revision consistency
 - operand shape validity
 - jump-target validity
+- reachable control-flow closure (no end-of-stream fallthrough)
 - string and debug reference validity
 - register-budget validity
 - call-target validity
@@ -63,7 +64,7 @@ without turning this document into a stable bytecode ISA promise.
 | Effect-oriented host-boundary families such as `GateRead`, `GateWrite`, and `PulseEmit` | Admitted only when the emitted contract matches the required capability envelope | Capability-gated / host-boundary | These opcodes do not define capability policy semantics by themselves. |
 | Ownership transport payloads admitted through `OWN0` | Admitted structurally only when the ownership transport slice is present and well formed | Header and capability consistency required | This covers the currently documented tuple-only and direct record-field ownership transport slices. |
 | Unknown, unsupported, or malformed opcode encodings | Rejected | N/A | Rejection must happen before a successful VM execution path. |
-| Opcode streams that fail operand, jump-target, call-target, closure-function-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | Direct calls may resolve to declared functions or admitted builtins; closure targets must resolve to declared functions. These are verifier admission failures, not successful runtime executions. |
+| Opcode streams that fail operand, jump-target, reachable-control-flow, call-target, closure-function-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | Direct calls may resolve to declared functions or admitted builtins; closure targets must resolve to declared functions. These are verifier admission failures, not successful runtime executions. |
 
 Current ownership-specific structural checks for ownership transport include:
 
@@ -186,6 +187,34 @@ rather than a second, independently-maintained opcode-shape table.
 `OWN0`'s tag byte (`0x4F`) is not a currently valid opcode, so this specific
 ambiguity does not apply to ownership-section recognition.
 
+## Reachable Control-Flow Closure
+
+For every function, the verifier reuses the instruction boundaries, decoded
+next offsets, and explicit jump targets collected by its normal instruction
+walk. Starting at instruction offset zero, it admits only reachable successors
+with these VM-derived rules:
+
+- `RET` is terminal and has no successor
+- `JMP` has only its explicit jump target
+- `JMP_IF` has its explicit jump target and the decoded next instruction
+- every other opcode, including `CALL` and `CLOSURE_CALL`, has the decoded next
+  instruction as its successor
+
+The two call forms are fallthrough operations structurally because the VM saves
+the decoded next PC before entering the callee and resumes there after `RET`.
+
+Every reachable successor must be an instruction start. A successor equal to
+the end of the executable instruction stream is rejected with
+`VerificationCode::ReachableFunctionFallthrough`; an empty executable stream is
+the same defect at entry offset zero. Existing explicit jump-target range and
+instruction-boundary checks remain independently enforced as
+`InvalidJumpTarget`.
+
+This proves structural control-flow closure, not program termination. A closed
+infinite loop is admissible, and an ordinary trailing instruction may fall
+through if it is unreachable from function entry. The verifier does not require
+the final encoded instruction to be `RET`.
+
 ## Contract Rule
 
 Standard execution uses the chain:
@@ -222,6 +251,10 @@ Verifier rejection must preserve:
 - the failing verification code
 - enough function or offset context to debug the failure
 - deterministic diagnostics for the same input artifact
+
+`ReachableFunctionFallthrough` specifically means that control flow reachable
+from function entry can advance to the end of the executable instruction
+stream without first reaching an admitted terminal instruction.
 
 ## Verified Execution Rule
 

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -159,6 +159,66 @@ fn public_api_inventory_matches_checked_in_contract_snapshots() {
     }
 }
 
+fn verification_code_contract_name(code: sm_verify::VerificationCode) -> &'static str {
+    use sm_verify::VerificationCode;
+
+    match code {
+        VerificationCode::BadHeader => "BadHeader",
+        VerificationCode::UnsupportedVersion => "UnsupportedVersion",
+        VerificationCode::TruncatedFunction => "TruncatedFunction",
+        VerificationCode::InvalidFunctionName => "InvalidFunctionName",
+        VerificationCode::DuplicateFunction => "DuplicateFunction",
+        VerificationCode::InvalidStringTable => "InvalidStringTable",
+        VerificationCode::InvalidDebugSection => "InvalidDebugSection",
+        VerificationCode::InvalidOwnershipSection => "InvalidOwnershipSection",
+        VerificationCode::UnknownOpcode => "UnknownOpcode",
+        VerificationCode::OperandOutOfBounds => "OperandOutOfBounds",
+        VerificationCode::InvalidJumpTarget => "InvalidJumpTarget",
+        VerificationCode::InvalidStringReference => "InvalidStringReference",
+        VerificationCode::InvalidRegisterReference => "InvalidRegisterReference",
+        VerificationCode::UnknownCallTarget => "UnknownCallTarget",
+        VerificationCode::ResourceLimitExceeded => "ResourceLimitExceeded",
+        VerificationCode::CapabilityViolation => "CapabilityViolation",
+        VerificationCode::AmbiguousInstructionFraming => "AmbiguousInstructionFraming",
+        VerificationCode::OpcodeRequiresNewerHeader => "OpcodeRequiresNewerHeader",
+        VerificationCode::ReachableFunctionFallthrough => "ReachableFunctionFallthrough",
+    }
+}
+
+#[test]
+fn verification_code_variants_match_public_contract() {
+    use sm_verify::VerificationCode;
+
+    let variants = [
+        VerificationCode::BadHeader,
+        VerificationCode::UnsupportedVersion,
+        VerificationCode::TruncatedFunction,
+        VerificationCode::InvalidFunctionName,
+        VerificationCode::DuplicateFunction,
+        VerificationCode::InvalidStringTable,
+        VerificationCode::InvalidDebugSection,
+        VerificationCode::InvalidOwnershipSection,
+        VerificationCode::UnknownOpcode,
+        VerificationCode::OperandOutOfBounds,
+        VerificationCode::InvalidJumpTarget,
+        VerificationCode::InvalidStringReference,
+        VerificationCode::InvalidRegisterReference,
+        VerificationCode::UnknownCallTarget,
+        VerificationCode::ResourceLimitExceeded,
+        VerificationCode::CapabilityViolation,
+        VerificationCode::AmbiguousInstructionFraming,
+        VerificationCode::OpcodeRequiresNewerHeader,
+        VerificationCode::ReachableFunctionFallthrough,
+    ];
+
+    for variant in variants {
+        assert_eq!(
+            verification_code_contract_name(variant),
+            format!("{variant:?}")
+        );
+    }
+}
+
 #[test]
 fn prom_refs_forbidden_impl_surface_is_absent() {
     let path = "crates/prom-refs/src/lib.rs";


### PR DESCRIPTION
Closes #1745

Umbrella: #1617

## Root cause

`verify_function_code()` decoded each instruction and validated explicit jump targets, but it did not prove that control flow reachable from function entry remained inside the executable instruction stream. Sequentially decodable bytecode could therefore reach `code.len()` and still receive `VerifiedSemCode`; the VM later rejected the same artifact at its defensive `pc >= instr_rel_len` guard as `RuntimeError::BadFormat`.

## Pre-fix reproduction

Before the repair, a disposable regression harness demonstrated all three facts:

- `LOAD_BOOL r0, true` followed by EOF was admitted by `verify_semcode()`.
- An empty executable instruction stream was admitted by `verify_semcode()`.
- Executing the admitted non-empty artifact reached `RuntimeError::BadFormat("pc out of range in 'main': 4")`.

The reproduction passed 3/3 assertions against unmodified `main`. The permanent rejection tests were then added first and failed exactly the three intended cases before the implementation (87 existing tests passed, 3 new tests failed).

## Repaired invariant

`VerifiedSemCode` now proves that every control-flow successor reachable from function entry is either a valid decoded instruction start or an admitted terminal condition. A reachable end-of-stream fallthrough is rejected deterministically as `VerificationCode::ReachableFunctionFallthrough` before the token is issued.

The verifier reuses the instruction starts, decoded next offsets, and jump targets collected by its existing instruction walk; it does not introduce a second bytecode decoder.

## CFG rule

The successor classification is derived from the current VM implementation:

- `RET`: terminal, no successor.
- `JMP`: explicit target only.
- `JMP_IF`: explicit target plus decoded next instruction.
- Every other opcode, including `CALL` and `CLOSURE_CALL`: decoded next instruction.

Existing explicit jump range and instruction-boundary checks remain intact and retain `InvalidJumpTarget` diagnostics.

This is a structural closure proof, not a termination proof. Closed infinite loops remain valid, unreachable trailing instructions do not create reachable fallthrough, and the verifier does not require the final encoded instruction to be `RET`.

## Regression matrix

- REJECT reachable ordinary instruction followed by EOF.
- REJECT empty executable instruction stream.
- REJECT conditional branch with a valid explicit branch and EOF fallthrough.
- ACCEPT a normal function ending in `RET`.
- ACCEPT an unconditional jump to a valid return instruction boundary.
- ACCEPT a structurally closed infinite loop with unreachable trailing fallthrough.
- ACCEPT valid `CALL` and `CLOSURE_CALL` fallthrough to `RET`.
- Preserve the existing invalid jump-target tests and diagnostics.
- Guard the complete public `VerificationCode` variant vocabulary, including `ReachableFunctionFallthrough`.

Tests build SemCode through the IR emitter; they do not search for raw-byte coincidences.

## Validation

- `cargo test -p sm-verify --features sm-ir/profile-rust,sm-ir/profile-logos,sm-ir/debug-symbols --lib` — PASS, 90/90.
- `cargo test -p sm-vm --lib` — PASS, 69/69.
- `cargo test --test public_api_contracts` — PASS, 5/5.
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS.
- `git diff --check` and `git diff --cached --check` — PASS.
- Repository Windows-safe all-workspace formatting gate (`Invoke-WorkspaceFmtCheck`) — PASS for all 36 packages.
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady` — PASS (workspace check, clippy, all-package format check, full workspace tests, public API contracts).

The literal one-shot `cargo fmt --all -- --check` was also attempted in the original worktree, a substituted drive path, and a disposable short worktree; Cargo failed before rustfmt with Windows `os error 206` because the aggregate argument list exceeds the platform command-line limit. The repository's authoritative per-package Windows-safe equivalent passed all 36 packages and is the formatter used by `-PRReady`.

## Scope

This PR repairs FA-07-005 / #1745 only: verifier-owned reachable control-flow closure, focused verifier regressions, the narrow public diagnostic contract guard, and minimum SemCode/verifier specification updates. It does not change the VM or remove its defensive PC bounds check.

#1746 debug-PC validation, #1750 builtin/function resolution, #1756 definite register assignment, #1770 register representation, #1771 MAP_GET behavior, pending-policy findings, ownership findings, and all other findings are untouched. No termination proof, CFG optimization, dead-code elimination, VM refactor, or unrelated cleanup is included.