### PR TITLE
fix(sm-verify): require debug PCs to reference instructions

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -632,6 +632,19 @@ fn verify_function_code(
                 "debug symbol pc points past the instruction stream",
             ));
         }
+        // #1746 (FA-07-006): range alone does not prove `sym.pc` denotes an
+        // actual instruction boundary - it could land inside a decoded
+        // operand's bytes. Reuse the instruction-start set this same
+        // verification walk already built, exactly like the jump-target
+        // check below does for `InvalidJumpTarget`.
+        if !instr_starts.contains(&sym.pc) {
+            return Err(reject_one(
+                name,
+                VerificationCode::InvalidDebugSection,
+                sym.pc,
+                "debug symbol pc does not land on an instruction boundary",
+            ));
+        }
     }
 
     if debug_symbol_count > 0 {
@@ -2373,6 +2386,144 @@ mod tests {
         assert!(
             verified.functions[0].debug_symbol_count > 1,
             "fixture must exercise a genuinely non-empty debug section"
+        );
+    }
+
+    /// #1746 (FA-07-006) test helper: overwrites the `pc` field of the
+    /// `symbol_index`-th `DBG0` debug-symbol entry in `bytes` in place, via
+    /// the decoded format offsets (`code_offset`, `string_table_end_offset`)
+    /// rather than a raw-byte search. Entry layout after the `DBG0` tag (4
+    /// bytes) and symbol count (2 bytes) is `pc: u32 LE, line: u32,
+    /// col: u16` (10 bytes per entry), matching
+    /// `semcode_decode::parse_string_table_debug_and_ownership`.
+    fn overwrite_debug_symbol_pc(bytes: &mut [u8], symbol_index: usize, new_pc: u32) {
+        let entry_offset = {
+            let (_, functions) = sm_format::semcode_decode::decode_semcode_envelope(bytes)
+                .expect("decode for mutation");
+            let f = &functions[0];
+            f.code_offset + f.string_table_end_offset + 4 + 2 + symbol_index * 10
+        };
+        bytes[entry_offset..entry_offset + 4].copy_from_slice(&new_pc.to_le_bytes());
+    }
+
+    // #1746 (FA-07-006) regression matrix (1/7 and 2/7): a debug-symbol pc
+    // that is numerically in range but lands inside a decoded instruction's
+    // operand bytes - not on an instruction start - must reject. `LOAD_BOOL
+    // dst, val` is a real 4-byte instruction (opcode + 2-byte dst register +
+    // 1-byte bool literal) at instruction offset 0; offsets 1 and 2 are two
+    // distinct interior bytes of its `dst` operand, proving this is a
+    // boundary-membership check (`instr_starts.contains`), not a single
+    // hardcoded interior offset.
+    #[test]
+    fn verifier_rejects_debug_pc_pointing_into_operand_middle_byte() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadBool { dst: 0, val: true },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit");
+        let mut mutated = bytes.clone();
+        overwrite_debug_symbol_pc(&mut mutated, 0, 1);
+        let report = verify_semcode(&mutated)
+            .expect_err("debug pc pointing into the first interior operand byte must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::InvalidDebugSection
+        );
+        assert_eq!(report.diagnostics[0].offset, Some(1));
+    }
+
+    #[test]
+    fn verifier_rejects_debug_pc_pointing_into_operand_final_byte() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadBool { dst: 0, val: true },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit");
+        let mut mutated = bytes.clone();
+        overwrite_debug_symbol_pc(&mut mutated, 0, 2);
+        let report = verify_semcode(&mutated)
+            .expect_err("debug pc pointing into a second interior operand byte must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::InvalidDebugSection
+        );
+        assert_eq!(report.diagnostics[0].offset, Some(2));
+    }
+
+    // #1746 regression matrix (3/7 and 4/7): pc == 0 at the first
+    // instruction, and pc pointing at a later real instruction start, must
+    // both remain accepted - unmutated, genuinely compiler-emitted debug
+    // symbols for a two-instruction function land exactly on the two real
+    // instruction starts (0 and 4).
+    #[test]
+    fn verifier_accepts_debug_pc_at_first_and_later_instruction_starts() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadBool { dst: 0, val: true },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit");
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let pcs: Vec<usize> = functions[0].debug_symbols.iter().map(|s| s.pc).collect();
+        assert_eq!(
+            pcs,
+            vec![0, 4],
+            "fixture must exercise pc=0 (first instruction) and a later instruction start"
+        );
+        let verified =
+            verify_semcode(&bytes).expect("debug pcs on real instruction starts must verify");
+        assert_eq!(verified.functions[0].debug_symbol_count, 2);
+    }
+
+    // #1746 regression matrix (5/7): out-of-range debug pc must still
+    // reject with the existing diagnostic and message, unchanged by the new
+    // boundary check (range is checked first).
+    #[test]
+    fn verifier_rejects_out_of_range_debug_pc() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadBool { dst: 0, val: true },
+                    IrInstr::Ret { src: None },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit");
+        let mut mutated = bytes.clone();
+        overwrite_debug_symbol_pc(&mut mutated, 0, 100);
+        let report = verify_semcode(&mutated).expect_err("out-of-range debug pc must still reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::InvalidDebugSection
+        );
+        assert_eq!(report.diagnostics[0].offset, Some(100));
+        assert_eq!(
+            report.diagnostics[0].message,
+            "debug symbol pc points past the instruction stream"
         );
     }
 

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -636,8 +636,15 @@ fn verify_function_code(
         // actual instruction boundary - it could land inside a decoded
         // operand's bytes. Reuse the instruction-start set this same
         // verification walk already built, exactly like the jump-target
-        // check below does for `InvalidJumpTarget`.
-        if !instr_starts.contains(&sym.pc) {
+        // check below does for `InvalidJumpTarget`. `instr_starts` is
+        // pushed in strictly increasing order (each iteration's `offset` is
+        // read from `cursor` before `cursor` only ever advances further),
+        // so `binary_search` is valid and avoids an O(symbols x
+        // instructions) linear scan - the format permits up to 8,192 debug
+        // symbols per function, so a debug-heavy artifact could otherwise
+        // force a disproportionate amount of verifier CPU per function
+        // (review finding on this PR).
+        if instr_starts.binary_search(&sym.pc).is_err() {
             return Err(reject_one(
                 name,
                 VerificationCode::InvalidDebugSection,

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1435,6 +1435,16 @@ fn validate_function_bytecode(f: &FunctionBytecode) -> Result<(), RuntimeError> 
                 f.name, ds.pc
             )));
         }
+        // #1746 (FA-07-006): mirrors sm-verify's canonical admission check.
+        // `starts` (built above, same instruction walk) already proves
+        // which offsets are real instruction boundaries; range alone does
+        // not rule out a pc landing inside a decoded operand's bytes.
+        if !starts.contains(&ds.pc) {
+            return Err(RuntimeError::BadFormat(format!(
+                "debug pc not on an instruction boundary in '{}': {}",
+                f.name, ds.pc
+            )));
+        }
     }
     for addr in jumps {
         if addr >= instr_len {
@@ -6044,5 +6054,52 @@ mod tests {
                 );
             }
         }
+    }
+
+    // #1746 (FA-07-006): mirrors sm-verify's own regression coverage for the
+    // same structural invariant, exercised here through `run_semcode` - the
+    // raw path that calls `parse_semcode`/`validate_function_bytecode`
+    // directly without going through `sm-verify` admission at all, so this
+    // check is this path's only structural gate against a malformed debug
+    // pc, not merely a redundant defense-in-depth mirror.
+    #[test]
+    fn vm_rejects_debug_pc_pointing_into_operand_byte() {
+        let src = r#"
+            fn main() {
+                let x: bool = true;
+                return;
+            }
+        "#;
+        let bytes = sm_emit::compile_program_to_semcode_with_options_debug(
+            src,
+            sm_emit::CompileProfile::RustLike,
+            sm_emit::OptLevel::O0,
+            true,
+        )
+        .expect("compile with debug symbols");
+
+        let entry_offset = {
+            let (_, functions) =
+                sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+            let f = &functions[0];
+            assert_eq!(
+                f.debug_symbols.iter().map(|s| s.pc).collect::<Vec<_>>(),
+                vec![0, 4, 9],
+                "fixture must have real instruction-start debug pcs before mutation"
+            );
+            f.code_offset + f.string_table_end_offset + 4 + 2
+        };
+        let mut mutated = bytes.clone();
+        // First debug entry's pc: overwrite 0 -> 1, landing inside
+        // LOAD_BOOL's 2-byte `dst` operand (instruction 0 spans bytes 0..4),
+        // not on any instruction start (0, 4, 9).
+        mutated[entry_offset..entry_offset + 4].copy_from_slice(&1u32.to_le_bytes());
+
+        let err =
+            run_semcode(&mutated).expect_err("debug pc pointing into an operand byte must reject");
+        assert!(
+            matches!(err, RuntimeError::BadFormat(ref msg) if msg.contains("debug pc not on an instruction boundary")),
+            "unexpected error: {err:?}"
+        );
     }
 }

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -215,6 +215,20 @@ infinite loop is admissible, and an ordinary trailing instruction may fall
 through if it is unreachable from function entry. The verifier does not require
 the final encoded instruction to be `RET`.
 
+## Debug Reference Validity
+
+A `DBG0` debug symbol's `pc` must reference a decoded instruction boundary,
+not merely fall within the executable byte range. The verifier reuses the
+same `instr_starts` set collected during its normal instruction walk (the
+same authority the jump-target boundary check above already relies on) - it
+does not run a second decoder or infer boundaries from opcode-byte scanning.
+A `pc` that is numerically less than the instruction stream length but lands
+inside a decoded instruction's operand bytes is rejected with
+`VerificationCode::InvalidDebugSection`, the same code already used for an
+out-of-range `pc`. This proves only that a debug reference denotes a real
+instruction boundary; it does not claim source-line fidelity, debugger
+correctness, or any stronger metadata semantics than that structural fact.
+
 ## Contract Rule
 
 Standard execution uses the chain:


### PR DESCRIPTION
Closes #1746
Umbrella #1617

## Root cause

`sm-verify`'s debug-symbol validation loop proved only `sym.pc < instr_len` (numerically in range), never `sym.pc ∈ instr_starts` (actually on a decoded instruction boundary). A debug pc pointing into the middle of a multi-byte instruction's operand bytes was admitted as a valid debug location.

## Pre-fix reproduction

A `LOAD_BOOL dst, val` instruction (opcode + 2-byte `dst` register + 1-byte literal, 4 bytes; `instr_starts = [0, 4]`) with its debug symbol's `pc` mutated via **decoded format offsets** (not raw-byte search) from `0` to `2` — squarely inside the `dst` operand, not an instruction start — was accepted by `verify_semcode` on real `main` before this fix.

## Repaired invariant

The debug-symbol validation loop now also checks `instr_starts.contains(&sym.pc)`, reusing the same instruction-start set this same verification walk already collects — exactly like the jump-target check right below it does for `InvalidJumpTarget`. No second decoder, no opcode-byte scanning.

## Why range-only validation was insufficient

Range alone (`pc < instr_len`) only proves the byte offset is somewhere inside the function's code; it says nothing about whether that offset is where an instruction actually *starts*. Any interior byte of a multi-byte operand satisfies the range check while denoting no real instruction boundary at all.

## Diagnostic

Reused the existing `VerificationCode::InvalidDebugSection` (undocumented, already doing the same dual duty — range *and* structural validity — that `InvalidJumpTarget` does for jump targets). No new public diagnostic variant, so no public API contract guard update was needed (`verification_code_variants_match_public_contract` still passes unchanged).

## Regression matrix

- 2 distinct interior-byte rejections (offsets 1 and 2 of the same operand) proving boundary-**membership** semantics, not a hardcoded single offset
- pc=0 (first instruction) and a later real instruction start both still accepted
- out-of-range pc still rejects with its existing message, unchanged
- ordinary genuine debug sections and #1745's reachable-control-flow behavior both re-verified unaffected by the full existing suite (94/94 sm-verify tests pass)

## sm-vm

`validate_function_bytecode` had the identical bug shape (range check only, with the instruction-start `HashSet` already built two lines above by the same function). Mirrored the fix there too — **this is not merely a defense-in-depth duplicate of sm-verify's admission**: `run_semcode` (and `run_semcode_with_entry`/`_config`) call `parse_semcode` directly, bypassing `sm-verify` entirely, so this check is that raw path's *only* structural gate against a malformed debug pc. Added one dedicated regression test exercising this exact path (70/70 sm-vm tests pass).

## Validation results

- `cargo test -p sm-verify --features sm-ir/profile-rust,sm-ir/profile-logos,sm-ir/debug-symbols --lib` — 94/94 pass
- `cargo test -p sm-vm --lib` — 70/70 pass
- `cargo test --test public_api_contracts` — 5/5 pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `git diff --check` / `git diff --cached --check` — clean
- `cargo fmt` (per-package, Windows-safe) — clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady` — **ADMISSION GUARD PR-READY PASS** (exit 0)

## Scope

In scope only: `crates/sm-verify/src/lib.rs` (fix + regression matrix), `crates/sm-vm/src/semcode_vm.rs` (mechanical mirror + one test), `docs/spec/verifier.md` (one new precise subsection). No changes to #1745's CFG proof, #1750/#1756/#1770/#1771, ownership findings, instruction decoding, debug format, or VM execution semantics.

## Review

Codex review is unavailable (quota exhausted) — not requested. Self-reviewed the full diff line-by-line against the issue before pushing; every changed line traces to this root cause, its regression tests, the mechanical `sm-vm` mirror, or the minimal spec update.

**Left unmerged** — awaiting owner review and explicit merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)