### PR TITLE
test(public-api): inventory sm-format contract

### DIFF
--- a/tests/golden_snapshots/public_api/sm_format_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_format_lib.txt
@@ -1,0 +1,6 @@
+source: crates/sm-format/src/lib.rs
+#[cfg(feature = "std")]
+pub mod semcode_decode;
+#[cfg(feature = "std")]
+pub mod semcode_format {
+pub use crate::local_format::*;

--- a/tests/golden_snapshots/public_api/sm_format_local_format.txt
+++ b/tests/golden_snapshots/public_api/sm_format_local_format.txt
@@ -1,0 +1,98 @@
+source: crates/sm-format/src/local_format.rs
+pub const MAGIC0: [u8; 8] = *b"SEMCODE0";
+pub const MAGIC1: [u8; 8] = *b"SEMCODE1";
+pub const MAGIC2: [u8; 8] = *b"SEMCODE2";
+pub const MAGIC3: [u8; 8] = *b"SEMCODE3";
+pub const MAGIC4: [u8; 8] = *b"SEMCODE4";
+pub const MAGIC5: [u8; 8] = *b"SEMCODE5";
+pub const MAGIC6: [u8; 8] = *b"SEMCODE6";
+pub const MAGIC7: [u8; 8] = *b"SEMCODE7";
+pub const MAGIC8: [u8; 8] = *b"SEMCODE8";
+pub const MAGIC9: [u8; 8] = *b"SEMCODE9";
+pub const MAGIC10: [u8; 8] = *b"SEMCOD10";
+pub const MAGIC11: [u8; 8] = *b"SEMCOD11";
+pub const MAGIC12: [u8; 8] = *b"SEMCOD12";
+pub const MAGIC13: [u8; 8] = *b"SEMCOD13";
+pub const MAGIC14: [u8; 8] = *b"SEMCOD14";
+pub const MAGIC15: [u8; 8] = *b"SEMCOD15";
+pub const MAGIC16: [u8; 8] = *b"SEMCOD16";
+pub const MAGIC17: [u8; 8] = *b"SEMCOD17";
+pub const MAGIC18: [u8; 8] = *b"SEMCOD18";
+pub const CAP_DEBUG_SYMBOLS: u32 = 1 << 0;
+pub const CAP_F64_MATH: u32 = 1 << 1;
+pub const CAP_GATE_SURFACE: u32 = 1 << 2;
+pub const CAP_FX_VALUES: u32 = 1 << 3;
+pub const CAP_FX_MATH: u32 = 1 << 4;
+pub const CAP_STATE_QUERY: u32 = 1 << 5;
+pub const CAP_STATE_UPDATE: u32 = 1 << 6;
+pub const CAP_EVENT_POST: u32 = 1 << 7;
+pub const CAP_CLOCK_READ: u32 = 1 << 8;
+pub const CAP_TEXT_VALUES: u32 = 1 << 9;
+pub const CAP_SEQUENCE_VALUES: u32 = 1 << 10;
+pub const CAP_CLOSURE_VALUES: u32 = 1 << 11;
+pub const CAP_OWNERSHIP_PATHS: u32 = 1 << 12;
+pub const CAP_OWNERSHIP_FIELD_PATHS: u32 = 1 << 13;
+pub const CAP_SEQUENCE_ITERATION: u32 = 1 << 14;
+pub const CAP_MAP_VALUES: u32 = 1 << 15;
+pub const CAP_PRNG: u32 = 1 << 16;
+pub const CAP_STDOUT: u32 = 1 << 17;
+pub const CAP_ARGS_READ: u32 = 1 << 18;
+pub const CAP_STDIN_READ_TEXT: u32 = 1 << 19;
+pub const CAP_STDOUT_WRITE: u32 = 1 << 20;
+pub const CAP_STDERR_WRITE: u32 = 1 << 21;
+pub const CAP_PATH_INSPECT: u32 = 1 << 22;
+pub const CAP_FS_READ: u32 = 1 << 23;
+pub const CAP_FS_WRITE: u32 = 1 << 24;
+pub const CAP_TIME_DURATION: u32 = 1 << 25;
+pub const OWNERSHIP_SECTION_TAG: [u8; 4] = *b"OWN0";
+pub const OWNERSHIP_EVENT_KIND_BORROW: u8 = 0;
+pub const OWNERSHIP_EVENT_KIND_WRITE: u8 = 1;
+pub const OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX: u8 = 0;
+pub const OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL: u8 = 1;
+pub const OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD: u8 = 2;
+pub const OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemcodeHeaderSpec {
+pub magic: [u8; 8],
+pub epoch: u16,
+pub rev: u16,
+pub capabilities: u32,
+pub const HEADER_V0: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V1: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V2: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V3: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V4: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V5: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V6: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V7: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V8: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V9: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V10: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V11: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V12: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V13: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V14: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V15: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V16: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V17: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub const HEADER_V18: SemcodeHeaderSpec = SemcodeHeaderSpec {
+pub fn supported_headers() -> &'static [SemcodeHeaderSpec] {
+pub fn header_spec_from_magic(magic: &[u8; 8]) -> Option<SemcodeHeaderSpec> {
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Opcode {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemcodeFormatError {
+pub fn byte(self) -> u8 {
+pub fn from_byte(v: u8) -> Result<Self, SemcodeFormatError> {
+pub fn minimum_semcode_revision(self) -> u16 {
+pub fn write_u16_le(out: &mut Vec<u8>, v: u16) {
+pub fn write_u32_le(out: &mut Vec<u8>, v: u32) {
+pub fn write_i32_le(out: &mut Vec<u8>, v: i32) {
+pub fn write_f64_le(out: &mut Vec<u8>, v: f64) {
+pub fn read_u8(bytes: &[u8], i: &mut usize) -> Result<u8, SemcodeFormatError> {
+pub fn read_u16_le(bytes: &[u8], i: &mut usize) -> Result<u16, SemcodeFormatError> {
+pub fn read_u32_le(bytes: &[u8], i: &mut usize) -> Result<u32, SemcodeFormatError> {
+pub fn read_i32_le(bytes: &[u8], i: &mut usize) -> Result<i32, SemcodeFormatError> {
+pub fn read_f64_le(bytes: &[u8], i: &mut usize) -> Result<f64, SemcodeFormatError> {
+pub fn read_utf8(bytes: &[u8], i: &mut usize, len: usize) -> Result<String, SemcodeFormatError> {

--- a/tests/golden_snapshots/public_api/sm_format_semcode_decode.txt
+++ b/tests/golden_snapshots/public_api/sm_format_semcode_decode.txt
@@ -1,0 +1,34 @@
+source: crates/sm-format/src/semcode_decode.rs
+pub const MAX_FUNCTIONS: usize = 1024;
+pub const MAX_STRING_LEN: usize = 1024;
+pub const MAX_STRINGS_PER_FUNCTION: usize = 256;
+pub const MAX_DEBUG_SYMBOLS_PER_FUNCTION: usize = 8192;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedDebugSymbol {
+pub pc: usize,
+pub line: u32,
+pub col: u16,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodedAccessPathComponent {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedAccessPath {
+pub root_symbol_id: u32,
+pub components: Vec<DecodedAccessPathComponent>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedFunctionEnvelope<'a> {
+pub name: String,
+pub name_offset: usize,
+pub code_offset: usize,
+pub code_len: usize,
+pub strings: Vec<String>,
+pub debug_symbols: Vec<DecodedDebugSymbol>,
+pub borrowed_paths: Vec<DecodedAccessPath>,
+pub write_paths: Vec<DecodedAccessPath>,
+pub has_ownership_section: bool,
+pub has_debug_section: bool,
+pub string_table_end_offset: usize,
+pub instr_start_offset: usize, // relative to code_slice
+pub code_slice: &'a [u8], // the full code block for this function
+pub fn decode_semcode_envelope<'a>( bytes: &'a [u8], ) -> Result<(SemcodeHeaderSpec, Vec<DecodedFunctionEnvelope<'a>>), DecodeError> {

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -11,6 +11,18 @@ const PROM_REF_WRAPPERS: &[&str] = &[
 
 const TARGETS: &[(&str, &str)] = &[
     (
+        "crates/sm-format/src/lib.rs",
+        "tests/golden_snapshots/public_api/sm_format_lib.txt",
+    ),
+    (
+        "crates/sm-format/src/local_format.rs",
+        "tests/golden_snapshots/public_api/sm_format_local_format.txt",
+    ),
+    (
+        "crates/sm-format/src/semcode_decode.rs",
+        "tests/golden_snapshots/public_api/sm_format_semcode_decode.txt",
+    ),
+    (
         "crates/sm-ir/src/lib.rs",
         "tests/golden_snapshots/public_api/sm_ir_lib.txt",
     ),


### PR DESCRIPTION
Closes #1733
Umbrella #1617

## Root cause

`tests/public_api_contracts.rs`'s `TARGETS` table covers `sm-ir`, `sm-profile`, `sm-runtime-core`, `sm-verify`, `sm-vm`, `smc-cli`, and several PROMETHEUS/UI crates, but never `sm-format` — the canonical SemCode binary-format authority. A breaking or accidental public API change inside `sm-format` (`MAGIC*`, `HEADER_V*`, `CAP_*` bits, `SemcodeHeaderSpec`, `Opcode`/`Opcode::from_byte`, binary read/write helpers, public decoder envelopes/errors) could leave the public-api-guard fully green.

## Pre-fix reproduction

Added a genuine new public constant to `local_format.rs`, re-ran `cargo test --test public_api_contracts` — `public_api_inventory_matches_checked_in_contract_snapshots` still passed, since `sm-format` was absent from `TARGETS` entirely. Reverted before any further edit.

## Repaired qualification invariant

`sm-format` is now included in the repository's existing checked-in public API inventory at all three physical public source surfaces. Public declaration drift detectable by the existing `normalized_public_surface` mechanism now fails the guard. The pre-existing scanner limitation around enum bodies and multi-line contract values is tracked separately as #1808.

(This is a public Rust API contract drift guard — it does not claim semantic or binary compatibility on its own.)

## Exact sm-format source surfaces now inventoried

- `crates/sm-format/src/lib.rs` → `tests/golden_snapshots/public_api/sm_format_lib.txt`
- `crates/sm-format/src/local_format.rs` → `tests/golden_snapshots/public_api/sm_format_local_format.txt`
- `crates/sm-format/src/semcode_decode.rs` → `tests/golden_snapshots/public_api/sm_format_semcode_decode.txt`

## Why lib.rs alone would have been insufficient

`lib.rs`'s entire public surface is the façade:
```rust
pub mod semcode_decode;
pub mod semcode_format {
    pub use crate::local_format::*;
}
```
Snapshotting only that would freeze the re-export *declarations* while leaving every actual item behind them — `MAGIC*`, `CAP_*`, `SemcodeHeaderSpec`, `Opcode`, the decoder envelope types, etc. — completely unguarded, since the scanner is file-based and does not recursively expand modules or wildcard re-exports. `local_format.rs` (the re-exported format vocabulary) and `semcode_decode.rs` (its own public decoder module) had to be inventoried directly.

Snapshots were generated from the real `normalized_public_surface()` output via a temporary `#[ignore]`d generator test (removed before this commit) — not hand-written — so every line matches actual normalized source exactly.

## Guard-validity mutate/revert evidence

Three separate experiments, each an additive (non-breaking) mutation so the failure is a genuine snapshot-mismatch assertion rather than an unrelated compile error — all reverted before this commit (`git diff` on `crates/sm-format/` is empty):

- **A. `local_format.rs`**: added a new public constant → `public_api_inventory_matches_checked_in_contract_snapshots` **FAILED** (assertion mismatch) → reverted.
- **B. `semcode_decode.rs`**: added a new public constant → **FAILED** → reverted.
- **C. `lib.rs` façade**: added a new public type alias → **FAILED** → reverted.

## Residual / Follow-up

A Codex review on this PR correctly identified that `normalized_public_surface` does not capture enum variant lists or multi-line `pub const`/struct-literal values beyond their opening line — so, for example, changing a `HEADER_V*` constant's `rev`/`capabilities` value, or adding/removing an `Opcode`/`DecodeError` variant, would not currently produce a snapshot diff. This is confirmed to be a **pre-existing, repository-wide characteristic of the scanner itself** (identical, for example, in the pre-existing `sm_verify_lib.txt`/`VerificationCode` snapshot, untouched by this PR) — not something this PR introduces or worsens.

**#1733 closes the complete omission of `sm-format` from `TARGETS`; it does not claim to strengthen the generic scanner's capture depth.** That capture-depth limitation is tracked as a separate, narrow finding: **#1808**. Redesigning `normalized_public_surface` (which would affect all 19 `TARGETS` entries, not just `sm-format`) is explicitly out of scope for this PR.

## Validation

- `cargo test --test public_api_contracts` — 5/5 pass
- `cargo test -p sm-format --all-features` — 19/19 pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `git diff --check` / `git diff --cached --check` — clean
- `cargo fmt --check -p semantic_language` — clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady` — **ADMISSION GUARD PR-READY PASS** (exit 0)

## Scope

`#1733` only. No `sm-format` production behavior, semantics, opcode/header bytes, or ownership changed — test-only diff (1 test file + 3 new snapshot files). `#1735` (7hell claims), `#1755` (sm-verify public submodule inventory), `#1716` (sm-ir wildcard-reexport inventory), and `#1808` (scanner capture-depth, filed from this PR's review) are untouched — not started, not addressed here.

## Review

Codex reviewed this PR and raised one P2 finding (scanner capture depth, see Residual/Follow-up above) — confirmed accurate, tracked as #1808, and the PR body/invariant claim narrowed accordingly rather than silently dismissed or dependency-scope-crept into this PR.

**Left unmerged** — awaiting owner review and explicit merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
