### PR TITLE
docs(7hell): align qualification claims with runners

### DIFF
--- a/docs/roadmap/pcc/7hell_mini_runner.md
+++ b/docs/roadmap/pcc/7hell_mini_runner.md
@@ -13,8 +13,11 @@ This is **not** a full release qualification tool (which would cover packaging, 
 ### Hell 1 — Workspace Health
 Proves the basic structural health of the codebase.
 - Checks formatting (`cargo fmt --check`)
-- Ensures the entire workspace compiles without warnings or errors (`cargo check`)
-- Validates that the entire general test suite passes (`cargo test`)
+- Ensures the entire workspace compiles under the runner's configured feature
+  contour (`cargo check --workspace --all-features`)
+- Does **not** execute the workspace test suite. Hell 1 is a compile-health
+  gate only; later gates run targeted per-crate test lanes (see Hell 3-6
+  below), not the general `cargo test --workspace` suite.
 
 ### Hell 2 — Trust Boundary Guards
 Proves that critical lower-level crates do not acquire forbidden dependencies on higher-level abstractions.
@@ -49,5 +52,27 @@ Proves the end-to-end frontend compiler pipeline works correctly up to the binar
 Proves that architectural documentation matches code reality.
 - Checks that `adt_payload_ownership_matrix.md`, `adt_payload_ownership_slice_closeout.md`, and `adt_payload_ownership_paths.md` are present and up to date.
 
+## Qualification Boundary
+
+A 7hell PASS proves only the commands and targeted qualification lanes
+actually executed by the gates above (workspace compile-health, targeted
+per-crate tests for `sm-format`/`sm-verify`/`sm-vm`, and the other named
+checks). It does **not** imply that the entire workspace test suite passed.
+
+Workspace-wide tests (`cargo test --workspace ...`) are a separate
+qualification lane. In hosted CI they are currently executed by the
+`test-std` job (`cargo test --workspace --all-targets --quiet` and
+`cargo test --workspace --doc --quiet`), not by any 7hell gate. A 7hell PASS
+alone must not be cited as proof that the complete workspace test suite
+passed.
+
 ## Usage
-Run the scripts in `tools/7hell/` (either `run.ps1` for Windows or `run.sh` for Linux/macOS). The scripts will fail-fast at the first broken gate.
+Run the scripts in `tools/7hell/`:
+
+- `run.ps1` (Windows) and `run.sh` (Linux/macOS) are the full local 7hell
+  runners and execute all 7 gates above.
+- `run_ci.ps1` is the fast CI qualification contour and currently executes
+  only Hell 1 through Hell 5 - it does not include Hell 6 (Source to SemCode
+  Smoke) or Hell 7 (PCC Documentation Integrity).
+
+The scripts will fail-fast at the first broken gate.

--- a/docs/roadmap/pcc/pr_1185_ci_7hell_platform_contour_audit.md
+++ b/docs/roadmap/pcc/pr_1185_ci_7hell_platform_contour_audit.md
@@ -75,8 +75,9 @@ surface that is currently included by the 7hell workspace-wide build.
 
 > **Correction (FA-05-005 / #1735):** the bullet below originally claimed both
 > runners start with `cargo check --workspace --all-features` *and*
-> `cargo test --workspace --all-features`. Neither runner has ever executed a
-> workspace-wide `cargo test`; Hell 1 is `cargo fmt --check` followed by
+> `cargo test --workspace --all-features`. At the audited runner state, and
+> still on current main, neither runner executes a workspace-wide
+> `cargo test`; Hell 1 is `cargo fmt --check` followed by
 > `cargo check --workspace --all-features` only. This section is corrected in
 > place rather than silently rewritten, since the document's own finding (the
 > Linux `winit` failure path) depends only on the `cargo check` command and is
@@ -87,8 +88,9 @@ The two runners are structurally similar:
 
 - both run the same Hell 1 / Hell 2 / Hell 3 / Hell 4 / Hell 5 / Hell 6 / Hell
   7 sequence;
-- both start with `cargo check --workspace --all-features` (not a workspace
-  `cargo test`);
+- both run `cargo fmt --check` followed by
+  `cargo check --workspace --all-features`; neither runs a workspace-wide
+  `cargo test`;
 - both include the same trust-boundary and SemCode checks.
 
 The differences are platform and shell:

--- a/docs/roadmap/pcc/pr_1185_ci_7hell_platform_contour_audit.md
+++ b/docs/roadmap/pcc/pr_1185_ci_7hell_platform_contour_audit.md
@@ -73,12 +73,22 @@ surface that is currently included by the 7hell workspace-wide build.
 
 ## 4. `run.ps1` vs `run.sh`
 
+> **Correction (FA-05-005 / #1735):** the bullet below originally claimed both
+> runners start with `cargo check --workspace --all-features` *and*
+> `cargo test --workspace --all-features`. Neither runner has ever executed a
+> workspace-wide `cargo test`; Hell 1 is `cargo fmt --check` followed by
+> `cargo check --workspace --all-features` only. This section is corrected in
+> place rather than silently rewritten, since the document's own finding (the
+> Linux `winit` failure path) depends only on the `cargo check` command and is
+> unaffected by this correction. See `docs/roadmap/pcc/7hell_mini_runner.md`
+> for the current, accurate Hell 1 description.
+
 The two runners are structurally similar:
 
 - both run the same Hell 1 / Hell 2 / Hell 3 / Hell 4 / Hell 5 / Hell 6 / Hell
   7 sequence;
-- both start with `cargo check --workspace --all-features` and
-  `cargo test --workspace --all-features`;
+- both start with `cargo check --workspace --all-features` (not a workspace
+  `cargo test`);
 - both include the same trust-boundary and SemCode checks.
 
 The differences are platform and shell:


### PR DESCRIPTION
Closes #1735
Umbrella #1617

## Root cause

`docs/roadmap/pcc/7hell_mini_runner.md` claimed Hell 1 "Validates that the entire general test suite passes (`cargo test`)". `docs/roadmap/pcc/pr_1185_ci_7hell_platform_contour_audit.md` separately claimed both `run.ps1` and `run.sh` "start with `cargo check --workspace --all-features` and `cargo test --workspace --all-features`". Neither claim is true of any current runner.

## Current executable evidence

Directly inspected all three runner scripts on current main (not inferred from job names):

| Runner | Hell 1 commands |
|---|---|
| `tools/7hell/run.sh` | `cargo fmt --check` → `cargo check --workspace --all-features` |
| `tools/7hell/run.ps1` | `cargo fmt --check` → `cargo check --workspace --all-features` |
| `tools/7hell/run_ci.ps1` | `Invoke-WorkspaceFmtCheck` → `cargo check --workspace --all-features` |

None execute a workspace-wide `cargo test`. `run_ci.ps1` additionally only covers Hell 1 through Hell 5 (no Hell 6/7) — confirmed by inspection, so the mini-runner doc's Usage section no longer overclaims parity between it and the two full local runners.

Workspace-wide tests are already a separate, real qualification lane: hosted CI's `test-std` job runs `cargo test --workspace --all-targets --quiet` and `cargo test --workspace --doc --quiet` — not `--all-features` (stated precisely, not restated from the false claim).

## Pre-fix false claim

- `7hell_mini_runner.md` Hell 1: "Validates that the entire general test suite passes (`cargo test`)" — no runner does this.
- `pr_1185_ci_7hell_platform_contour_audit.md` §4: "both start with `cargo check --workspace --all-features` and `cargo test --workspace --all-features`" — the `cargo test` half is false.

## Repaired qualification invariant

A 7hell PASS proves only the commands and targeted qualification lanes actually executed by the selected 7hell runner. It does not imply that the entire workspace test suite passed unless that runner actually executed it.

## 7hell vs test-std responsibility split

All 7hell runners prove formatting/workspace compile health and the Hell 1–5 targeted qualification lanes (trust-boundary guards, `sm-format`/`sm-verify`/`sm-vm` isolated tests).

The full local runners (`run.ps1` and `run.sh`) additionally execute Hell 6 (Source to SemCode Smoke, including the PCC negative-diagnostic harnesses) and Hell 7 (PCC Documentation Integrity).

The hosted `pcc-qualification-7hell` CI job runs on `windows-latest` via the fast `run_ci.ps1` contour and therefore proves Hell 1–5 only — it does not exercise Hell 6/7. (A separate `7hell-full.yml` workflow does run the full `run.ps1`, all 7 gates, but only on manual `workflow_dispatch` or a nightly cron — it does not run on pull requests and did not run on this PR.)

Workspace-wide test evidence is attributed to the separate CI `test-std` job, which is the only place `cargo test --workspace` actually runs today.

**No 7hell runner or CI behavior changed.** This PR repairs the evidence claim so documentation no longer attributes workspace-test coverage to a gate that does not execute it.

## Files changed

- `docs/roadmap/pcc/7hell_mini_runner.md` — corrected Hell 1's description; added a "Qualification Boundary" section; corrected the Usage section to distinguish `run.ps1`/`run.sh` (full 7-gate local runners) from `run_ci.ps1` (fast CI contour, Hell 1-5 only).
- `docs/roadmap/pcc/pr_1185_ci_7hell_platform_contour_audit.md` — corrected the false command bullet in place with an explicit dated correction note, preserving the document's historical DRAFT/AUDIT status; its actual finding (the Linux `winit` dependency path) is unaffected since it depends only on the `cargo check` command. The correction note is scoped to what was actually verified (the audited runner state and current main), not a claim about the runners' entire history.

Repository-wide search for `cargo test --workspace --all-features` found 20 files; the other 18 (`core_trust_freeze_checklist.md`, various PCC ownership matrices/audits, etc.) list it as a standalone validation-checklist item alongside 7hell — an accurate record of commands the author separately ran, not an attribution claim — confirmed by inspecting each one's surrounding context, so left untouched.

## Validation

- Repository-wide search after edits: no remaining active statement claims Hell 1/7hell executes a complete workspace `cargo test` suite.
- `git diff --check` / `git diff --cached --check` — clean
- `cargo test --test public_api_contracts` — 5/5 pass (cheap repo guard, no public API touched by this PR)
- `cargo check --workspace --all-features` (Hell 1's actual command) — clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady` — **ADMISSION GUARD PR-READY PASS** (exit 0; includes the 7hell smoke invocations and full workspace test suite)
- Direct `tools/7hell/run.ps1` / `run.sh` invocation hits the repo's pre-existing, already-tracked Windows-only `cargo fmt --all` path-length limitation (`os error 206`) at the Hell 1 fmt step — confirmed unrelated to this docs-only change (identical failure reproduces on unmodified `main`); `admission_guard.ps1`'s Windows-safe per-package fmt path is unaffected and passed.
- Hosted CI: `pcc-qualification-7hell` (Windows, `run_ci.ps1`, Hell 1-5) passed on both runners; `test-std` (workspace-wide tests) passed independently. Neither result is cited here as evidence for the other's scope, to avoid recreating the defect being fixed.

## Scope

`#1735` only. No `sm-format`/Semantic runtime or compiler behavior changed. No 7hell runner or CI workflow file changed. `#1808`, `#1755`, `#1716`, `#1737`-`#1740`, `#1747`+ are untouched — not started, not addressed here.

## Review

Codex quota may be unavailable — if a new valid finding is raised, it will be triaged per this campaign's standard practice (fix if in-scope and mechanical, file a narrow follow-up under #1617 if separate, narrow this PR's claims if necessary) rather than silently dismissed or scope-crept.

**Left unmerged** — awaiting owner review and explicit merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
