### PR TITLE
test(public-api): inventory sm-emit contract

### DIFF
--- a/tests/golden_snapshots/public_api/sm_emit_hello_observation_bytes.txt
+++ b/tests/golden_snapshots/public_api/sm_emit_hello_observation_bytes.txt
@@ -1,0 +1,12 @@
+source: crates/sm-emit/src/hello_observation_bytes.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloObservationByteModule {
+pub records: Vec<HelloObservationByteRecord>,
+pub format_status: &'static str,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloObservationByteRecord {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloObservationByteEmissionError {
+pub fn emit_hello_observation_bytes_from_real_semcode_skeleton( module: &HelloRealSemCodeModule, ) -> Result<HelloObservationByteModule, HelloObservationByteEmissionError> {
+pub fn emit_hello_observation_bytes_gated( module: &HelloRealSemCodeModule, ) -> Result<HelloObservationByteModule, HelloObservationByteEmissionError> {
+pub fn render_hello_observation_bytes_gated( module: &HelloRealSemCodeModule, ) -> Result<Vec<u8>, HelloObservationByteEmissionError> {

--- a/tests/golden_snapshots/public_api/sm_emit_hello_real_semcode.txt
+++ b/tests/golden_snapshots/public_api/sm_emit_hello_real_semcode.txt
@@ -1,0 +1,11 @@
+source: crates/sm-emit/src/hello_real_semcode.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloRealSemCodeModule {
+pub ops: Vec<HelloRealSemCodeOp>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloRealSemCodeOp {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloRealSemCodeError {
+pub fn emit_hello_real_semcode_skeleton( module: &HelloIrModule, ) -> Result<HelloRealSemCodeModule, HelloRealSemCodeError> {
+pub fn render_hello_real_semcode_skeleton( module: &HelloIrModule, ) -> Result<Vec<HelloRealSemCodeOp>, HelloRealSemCodeError> {
+pub fn render_hello_real_semcode_skeleton_text( module: &HelloIrModule, ) -> Result<Vec<String>, HelloRealSemCodeError> {

--- a/tests/golden_snapshots/public_api/sm_emit_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_emit_lib.txt
@@ -1,0 +1,9 @@
+source: crates/sm-emit/src/lib.rs
+#[cfg(feature = "std")]
+pub use sm_format::semcode_format::{
+#[cfg(feature = "std")]
+pub use sm_ir::{
+#[cfg(feature = "std")]
+pub mod hello_real_semcode;
+#[cfg(feature = "std")]
+pub mod hello_observation_bytes;

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -11,6 +11,18 @@ const PROM_REF_WRAPPERS: &[&str] = &[
 
 const TARGETS: &[(&str, &str)] = &[
     (
+        "crates/sm-emit/src/lib.rs",
+        "tests/golden_snapshots/public_api/sm_emit_lib.txt",
+    ),
+    (
+        "crates/sm-emit/src/hello_real_semcode.rs",
+        "tests/golden_snapshots/public_api/sm_emit_hello_real_semcode.txt",
+    ),
+    (
+        "crates/sm-emit/src/hello_observation_bytes.rs",
+        "tests/golden_snapshots/public_api/sm_emit_hello_observation_bytes.txt",
+    ),
+    (
         "crates/sm-format/src/lib.rs",
         "tests/golden_snapshots/public_api/sm_format_lib.txt",
     ),


### PR DESCRIPTION
Closes #1737
Umbrella #1617
Residual scanner limitation: #1808

## Root cause

`tests/public_api_contracts.rs`'s `TARGETS` table covers `sm-ir`, `sm-profile`, `sm-runtime-core`, `sm-verify`, `sm-vm`, `smc-cli`, and several PROMETHEUS/UI crates, but never `sm-emit` — the producer-facing SemCode emission facade. Its public surface exposes the canonical producer entrypoints (`compile_program_to_semcode`, `compile_program_to_semcode_with_options`, `compile_program_to_semcode_with_options_debug`, `emit_ir_to_semcode`) plus a manual re-export of `sm-format`'s binary vocabulary and two public modules (`hello_real_semcode`, `hello_observation_bytes`) with their own structs/enums/functions. None of this participates in the checked-in public API snapshots today.

## Pre-fix reproduction

For each of the three sm-emit source files, added a genuine new public item, re-ran `cargo test --test public_api_contracts` — `public_api_inventory_matches_checked_in_contract_snapshots` passed every time, since `sm-emit` was entirely absent from `TARGETS`. Reverted before any further edit.

## Physical sm-emit surfaces inventoried

- `crates/sm-emit/src/lib.rs` → `tests/golden_snapshots/public_api/sm_emit_lib.txt`
- `crates/sm-emit/src/hello_real_semcode.rs` → `tests/golden_snapshots/public_api/sm_emit_hello_real_semcode.txt`
- `crates/sm-emit/src/hello_observation_bytes.rs` → `tests/golden_snapshots/public_api/sm_emit_hello_observation_bytes.txt`

**Why `lib.rs` alone is insufficient**: the crate publicly exposes two source modules (`hello_real_semcode`, `hello_observation_bytes`) whose own public declarations — structs (`HelloRealSemCodeModule`, `HelloObservationByteModule`), enums (`HelloRealSemCodeOp`, `HelloRealSemCodeError`, `HelloObservationByteRecord`, `HelloObservationByteEmissionError`), and functions (`emit_hello_real_semcode_skeleton`, `render_hello_real_semcode_skeleton`, `emit_hello_observation_bytes_gated`, etc.) — are part of the crate's public surface but are not visible from `lib.rs`'s text at all (the scanner is file-based and does not recursively expand `pub mod` declarations). Snapshotting only `lib.rs` would freeze the two `pub mod` declaration lines while leaving everything behind them completely unguarded.

Snapshots were generated from the real `normalized_public_surface()` output via a temporary `#[ignore]`d generator test (removed before this commit) — not hand-written. Reviewed manually: each snapshot contains only what the scanner genuinely observes today, with no hand-added continuation lines for `lib.rs`'s multi-line `pub use` blocks or any enum's variant list.

## Repaired qualification invariant

sm-emit is now registered in the repository's existing checked-in public API inventory at all three physical public source surfaces. Public declaration drift detectable by the existing `normalized_public_surface` mechanism now fails `public-api-guard`.

The pre-existing generic scanner capture-depth limitation remains tracked separately in #1808 and is **not** fixed here.

## Known residual / #1808

Ran the explicit residual probe required by this issue: added a genuine new public re-export member (`compile_program_to_ir`, a real, valid `sm_ir` export) as a *continuation line* inside `lib.rs`'s existing multi-line `pub use sm_ir::{ ... };` block. This compiled cleanly (proving it's a real public-surface addition, not a typo) and `public_api_inventory_matches_checked_in_contract_snapshots` **stayed green** — confirming the #1808 scanner-depth limitation (only a multi-line non-function item's opening line is captured) applies to sm-emit too, exactly as expected, and is explicitly **not** addressed by this PR. Reverted before commit.

## Mutate-revert guard evidence

Three separate post-fix experiments, each an additive (non-breaking) mutation so the failure is a genuine snapshot-mismatch assertion rather than an unrelated compile error — all reverted before this commit (`git diff` on `crates/sm-emit/` is empty):

- **`lib.rs`**: added a new public type alias → `public_api_inventory_matches_checked_in_contract_snapshots` **FAILED** → reverted.
- **`hello_real_semcode.rs`**: added a new public function → **FAILED** → reverted.
- **`hello_observation_bytes.rs`**: added a new public function → **FAILED** → reverted.

## Validation

- `cargo test --test public_api_contracts` — 5/5 pass
- `cargo test -p sm-emit --all-features` — 5/5 pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `git diff --check` / `git diff --cached --check` — clean
- `cargo fmt --check -p semantic_language` — clean
- `cargo check --workspace --all-features` (Hell 1's actual command) — clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady` — **ADMISSION GUARD PR-READY PASS** (exit 0; includes the 7hell smoke invocations and full workspace test suite)

## Scope

`#1737` only. No `sm-emit` production behavior, SemCode emission, header selection/promotion, or ownership transport changed — test-only diff (1 test file + 3 new snapshot files). `#1808` is untouched and not fixed. `#1738`, `#1739`, `#1740`, and `#1747`+ are untouched — not started, not addressed here.

## Review

Codex quota unavailable — not requested; the owner will review manually.

**Left unmerged** — awaiting owner review and explicit merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)