### PR TITLE
fix(sm-emit): mirror canonical format facade

### DIFF
--- a/crates/sm-emit/src/lib.rs
+++ b/crates/sm-emit/src/lib.rs
@@ -1,22 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+// Facade re-export: sm-emit does not own this vocabulary, sm-format does.
+// A glob keeps the two in sync automatically instead of hand-curating an
+// allowlist that silently drifts behind sm-format's canonical exports.
 #[cfg(feature = "std")]
-pub use sm_format::semcode_format::{
-    header_spec_from_magic, read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, read_utf8,
-    supported_headers, write_f64_le, write_i32_le, write_u16_le, write_u32_le, Opcode,
-    SemcodeFormatError, SemcodeHeaderSpec, CAP_ARGS_READ, CAP_CLOCK_READ, CAP_CLOSURE_VALUES,
-    CAP_DEBUG_SYMBOLS, CAP_EVENT_POST, CAP_F64_MATH, CAP_FS_READ, CAP_FS_WRITE, CAP_FX_MATH,
-    CAP_FX_VALUES, CAP_GATE_SURFACE, CAP_MAP_VALUES, CAP_OWNERSHIP_FIELD_PATHS,
-    CAP_OWNERSHIP_PATHS, CAP_PATH_INSPECT, CAP_PRNG, CAP_SEQUENCE_ITERATION, CAP_SEQUENCE_VALUES,
-    CAP_STATE_QUERY, CAP_STATE_UPDATE, CAP_STDERR_WRITE, CAP_STDIN_READ_TEXT, CAP_STDOUT,
-    CAP_STDOUT_WRITE, CAP_TEXT_VALUES, CAP_TIME_DURATION, HEADER_V0, HEADER_V1, HEADER_V10,
-    HEADER_V11, HEADER_V12, HEADER_V13, HEADER_V14, HEADER_V15, HEADER_V16, HEADER_V17, HEADER_V18,
-    HEADER_V2, HEADER_V3, HEADER_V4, HEADER_V5, HEADER_V6, HEADER_V7, HEADER_V8, HEADER_V9, MAGIC0,
-    MAGIC1, MAGIC10, MAGIC11, MAGIC12, MAGIC13, MAGIC14, MAGIC15, MAGIC16, MAGIC17, MAGIC18,
-    MAGIC2, MAGIC3, MAGIC4, MAGIC5, MAGIC6, MAGIC7, MAGIC8, MAGIC9, OWNERSHIP_EVENT_KIND_BORROW,
-    OWNERSHIP_EVENT_KIND_WRITE, OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL,
-    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
-};
+pub use sm_format::semcode_format::*;
 #[cfg(feature = "std")]
 pub use sm_ir::{
     compile_program_to_semcode, compile_program_to_semcode_with_options,

--- a/crates/sm-emit/tests/format_facade.rs
+++ b/crates/sm-emit/tests/format_facade.rs
@@ -1,0 +1,27 @@
+// Regression test for issue #1738: sm-emit's root facade must re-export the
+// complete sm-format ownership-path component vocabulary, not a hand-curated
+// subset that can silently drift behind sm-format's canonical exports.
+//
+// This is an external-consumer integration test (crate boundary, not
+// `use super::*`) so it actually proves the public facade, not just an
+// internal alias.
+
+#[test]
+fn ownership_path_component_vocabulary_is_complete_and_value_identical() {
+    assert_eq!(
+        sm_emit::OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,
+        sm_format::semcode_format::OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX
+    );
+    assert_eq!(
+        sm_emit::OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL,
+        sm_format::semcode_format::OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL
+    );
+    assert_eq!(
+        sm_emit::OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD,
+        sm_format::semcode_format::OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD
+    );
+    assert_eq!(
+        sm_emit::OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX,
+        sm_format::semcode_format::OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX
+    );
+}

--- a/tests/golden_snapshots/public_api/sm_emit_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_emit_lib.txt
@@ -1,6 +1,6 @@
 source: crates/sm-emit/src/lib.rs
 #[cfg(feature = "std")]
-pub use sm_format::semcode_format::{
+pub use sm_format::semcode_format::*;
 #[cfg(feature = "std")]
 pub use sm_ir::{
 #[cfg(feature = "std")]


### PR DESCRIPTION
Closes #1738
Umbrella #1617
Related residual qualification debt: #1808

## Root cause

`crates/sm-emit/src/lib.rs` re-exported `sm_format::semcode_format`'s public vocabulary through a hand-curated allowlist:

```rust
pub use sm_format::semcode_format::{
    header_spec_from_magic, ..., OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL,
    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
};
```

sm-format added two ownership-path component constants — `OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD` and `OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX` — that the manual list was never updated to include. The immediate symptom is two missing constants; the underlying mechanism is that a manually curated re-export list does not automatically follow its canonical owner, so it will drift again on the next addition unless the mechanism itself changes.

## Pre-fix reproduction

Disposable probe (`crates/sm-emit/tests/format_facade_repro_probe.rs`, external-consumer test, removed before commit) referencing both symbols via `sm_emit::...` failed to compile:

```
error[E0425]: cannot find value `OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD` in crate `sm_emit`
 --> crates\sm-emit\tests\format_facade_repro_probe.rs:6:25
error[E0425]: cannot find value `OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX` in crate `sm_emit`
 --> crates\sm-emit\tests\format_facade_repro_probe.rs:7:25
```
while the same two paths resolved fine through `sm_format::semcode_format::...` directly, confirming the gap is in sm-emit's facade, not in sm-format.

## Canonical owner

`crates/sm-format/src/lib.rs` defines `semcode_format` as `pub use crate::local_format::*;`. `local_format.rs` is the sole definer of MAGIC*, CAP_*, HEADER_V*, `OWNERSHIP_*`, `Opcode`, `SemcodeFormatError`, `SemcodeHeaderSpec`, and the `read_*`/`write_*` primitives — sm-format owns this vocabulary concretely; sm-emit is a producer-facing consumer/facade, not a second owner.

## Repair

Replaced the allowlist with:

```rust
#[cfg(feature = "std")]
pub use sm_format::semcode_format::*;
```

This removes the independently maintained sm-format allowlist from sm-emit entirely, rather than merely appending the two names that happened to be missing today — that append-only fix would have left the exact drift mechanism in place for the next addition.

Before adopting the glob: enumerated every `pub` item in `local_format.rs` (19 MAGIC constants, 26 CAP_* bits, ownership tag/kind/component constants, 19 HEADER_V specs, `SemcodeHeaderSpec`, `supported_headers`/`header_spec_from_magic`, `Opcode`, `SemcodeFormatError`, byte read/write helpers) — all of it is legitimate producer-facing format vocabulary. Decoder/verifier-only surface (`DecodeError`, `decode_semcode_envelope`, `MAX_*` limits) lives in the separate `semcode_decode` module, untouched by this glob. Checked for collisions against sm-emit's other root exports (`sm_ir`'s `compile_program_to_semcode*`/`CompileProfile`/`OptLevel`, and the `hello_*` modules) — zero overlap. `cargo check -p sm-emit --all-features` compiles clean.

sm-format itself is untouched (`git diff -- crates/sm-format/` is empty).

## Ownership vocabulary regression

New `crates/sm-emit/tests/format_facade.rs` (external-consumer integration test, crate boundary — not `use super::*`) asserts all four ownership-path component constants resolve through `sm_emit::` and are value-identical to the canonical `sm_format::semcode_format::` item:

```rust
assert_eq!(sm_emit::OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD, sm_format::semcode_format::OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD);
```
...and likewise for `TUPLE_INDEX`, `FIELD_SYMBOL`, `SEQUENCE_INDEX`. No numeric literals are duplicated — every assertion compares against the canonical item itself, so future drift (a missing name or a diverging value) fails this test.

## Public API snapshot

`tests/golden_snapshots/public_api/sm_emit_lib.txt` intentionally changes on one line, regenerated via the existing temp-`#[ignore]`-generator-test discipline (generated, reviewed, generator deleted before commit):

```diff
-pub use sm_format::semcode_format::{
+pub use sm_format::semcode_format::*;
```
No other snapshot file changed.

## #1808 boundary

#1808 (the generic `normalized_public_surface` capture-depth limitation) is **not** fixed here and is out of scope. This repair does have a useful side effect: with a glob re-export, newly-added canonical sm-format names no longer require editing a multi-line sm-emit allowlist to stay exposed — the facade-drift mechanism this issue is about is gone — but the API-inventory scanner's own capture-depth limitation is unrelated and unchanged.

## Validation

- `cargo test -p sm-emit --all-features`: 6/6 pass (5 existing unit tests unmodified + new `format_facade` integration test)
- `cargo test --test public_api_contracts`: 5/5 pass
- `cargo check -p sm-emit --all-features`: clean
- `cargo clippy -p sm-emit --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace --quiet`: 323 test blocks, 0 failed
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1` (Hell 1-5): **PASS**

## Scope

No SemCode bytes, opcode/MAGIC/CAP values, or ownership numeric values changed — this is a pure re-export mechanism change. sm-format was not modified. sm-emit defines zero duplicate/alias constants. #1739, #1740, #1747+, #1808, #1715 not touched.
