### PR TITLE
fix(sm-emit): reject unquoted hello observation text

### DIFF
--- a/crates/sm-emit/src/hello_observation_bytes.rs
+++ b/crates/sm-emit/src/hello_observation_bytes.rs
@@ -110,7 +110,8 @@ fn validate_and_extract_controlled_text(
             && expected == "T"
             && complete_value == "T" =>
         {
-            let text = strip_rendered_text(text);
+            let text = strip_rendered_text(text)
+                .ok_or(HelloObservationByteEmissionError::UnsupportedShape)?;
             if is_forbidden_host_output(text) {
                 return Err(HelloObservationByteEmissionError::ForbiddenHostOutput);
             }
@@ -123,10 +124,9 @@ fn validate_and_extract_controlled_text(
     }
 }
 
-fn strip_rendered_text(text: &str) -> &str {
-    text.strip_prefix('"')
-        .and_then(|value| value.strip_suffix('"'))
-        .unwrap_or(text)
+fn strip_rendered_text(text: &str) -> Option<&str> {
+    let value = text.strip_prefix('"')?;
+    value.strip_suffix('"')
 }
 
 fn is_forbidden_host_output(text: &str) -> bool {

--- a/tests/hello_observation_byte_emission.rs
+++ b/tests/hello_observation_byte_emission.rs
@@ -155,3 +155,41 @@ fn hello_observation_byte_emission_rejects_non_hello_text() {
         HelloObservationByteEmissionError::UnsupportedShape,
     );
 }
+
+#[test]
+fn hello_observation_byte_emission_rejects_raw_unquoted_text() {
+    let module = canonical_real_semcode();
+
+    let mut mutated = module.clone();
+    if let HelloRealSemCodeOp::ObserveTextLiteral { text } = &mut mutated.ops[2] {
+        *text = "Hello, World!".to_string();
+    }
+
+    assert_reject(
+        &mutated,
+        HelloObservationByteEmissionError::UnsupportedShape,
+    );
+}
+
+// Defense-in-depth coverage for the #1739 adversarial matrix (malformed
+// one-sided quoting). Note this case already rejected pre-fix too: the old
+// `.unwrap_or(text)` fallback returns the ORIGINAL text unchanged when
+// stripping fails, and the stray leading quote keeps it from ever matching
+// bare CANONICAL_HELLO_TEXT. It is not a discriminating regression test —
+// `hello_observation_byte_emission_rejects_raw_unquoted_text` above is the
+// one that actually reproduces the #1739 gap (fully-unquoted text has no
+// stray characters, so the old fallback let it slip through as canonical).
+#[test]
+fn hello_observation_byte_emission_rejects_one_sided_quote_text() {
+    let module = canonical_real_semcode();
+
+    let mut mutated = module.clone();
+    if let HelloRealSemCodeOp::ObserveTextLiteral { text } = &mut mutated.ops[2] {
+        *text = "\"Hello, World!".to_string();
+    }
+
+    assert_reject(
+        &mutated,
+        HelloObservationByteEmissionError::UnsupportedShape,
+    );
+}


### PR DESCRIPTION
Closes #1739
Umbrella #1617

## Root cause

`crates/sm-emit/src/hello_observation_bytes.rs`'s private `strip_rendered_text` helper:

```rust
fn strip_rendered_text(text: &str) -> &str {
    text.strip_prefix('"')
        .and_then(|value| value.strip_suffix('"'))
        .unwrap_or(text)
}
```

fell back to the original, unmodified text whenever quote-stripping failed. Because of that fallback, fully-unquoted raw text (`Hello, World!`, no quote characters) is left unchanged by the failed strip and then happens to already equal `CANONICAL_HELLO_TEXT` — so it was silently accepted as if it had been the canonical quoted form.

The adjacent verifier (`crates/sm-verify/src/hello_real_semcode_admission.rs`, `admit_controlled_text_observation_shape`) does no such normalization — it matches only the literal `"\"Hello, World!\""` (quote characters included) and rejects everything else as `NonTextObservation`. The byte bridge was therefore broader than its adjacent admission contract.

## Pre-fix reproduction

Confirmed with real command output (not just code reading), using a throwaway probe later removed:

```
PROBE emit_result = Ok(HelloObservationByteModule { ... })
PROBE render_result = Ok([...CONST_TEXT #0 "Hello, World!"...])
```
for `ObserveTextLiteral.text = "Hello, World!"` (no quote characters) — both `emit_hello_observation_bytes_gated` and `render_hello_observation_bytes_gated` succeeded pre-fix.

Independently confirmed the verifier rejects the identical raw spelling:
```
PROBE admit_controlled_text_observation_shape(raw) = Err(NonTextObservation)
PROBE admit_hello_real_semcode_skeleton(raw) = Reject(NonTextObservation)
```

## Adjacent verifier contract

`sm-verify`'s `admit_controlled_text_observation_shape` requires the exact rendered/quoted spelling `"\"Hello, World!\""` and was **not modified** by this PR — this repair is entirely on the producer (sm-emit) side, fail-closed, never loosening the verifier.

## Fail-closed repair

```rust
fn strip_rendered_text(text: &str) -> Option<&str> {
    let value = text.strip_prefix('"')?;
    value.strip_suffix('"')
}
```
and the call site now propagates failure instead of silently falling back:
```rust
let text = strip_rendered_text(text)
    .ok_or(HelloObservationByteEmissionError::UnsupportedShape)?;
```
This happens before the forbidden-host-output check and the canonical-text equality check, so malformed/unquoted input can never reach either downstream check unchanged. No new error variant was needed — `UnsupportedShape` (already existing) is sufficient.

## Regression matrix

| Input | Before | After |
|---|---|---|
| `"\"Hello, World!\""` (quoted canonical) | Ok | Ok (unchanged — `hello_observation_byte_bridge_emits_gated_provisional_representation`) |
| `Hello, World!` (raw unquoted) | **Ok (bug)** | **Err(UnsupportedShape)** — new test `hello_observation_byte_emission_rejects_raw_unquoted_text`, genuinely discriminates pre/post-fix |
| `"\"Hi\""`-style quoted-but-wrong text | Err(UnsupportedShape) | Err(UnsupportedShape) — unchanged, pre-existing `hello_observation_byte_emission_rejects_non_hello_text` |
| `"\"stdout\""`, `"\"print\""`, etc. (quoted host markers) | Err(ForbiddenHostOutput) / Err(StdoutNotAllowed) etc. per marker | unchanged — pre-existing `hello_observation_byte_emission_rejects_host_output_markers` |
| `"Hello, World!` (leading quote only, malformed) | Err(UnsupportedShape) — *already* rejected pre-fix by coincidence (stray leading quote keeps the unwrap_or fallback from ever matching bare canonical text) | Err(UnsupportedShape) — new test `hello_observation_byte_emission_rejects_one_sided_quote_text` |

**Self-review finding, addressed:** an independent adversarial qualification pass flagged that the one-sided-quote test above does not actually discriminate pre-fix vs. post-fix behavior (it was already correctly rejected before this fix, for an unrelated reason — the leftover stray quote character). This is accurate. The test is legitimate defense-in-depth coverage required by the adversarial matrix, but it is not proof of the fix; `hello_observation_byte_emission_rejects_raw_unquoted_text` is the one genuine regression test for the #1739 gap. A code comment was added directly above the test making this explicit so it isn't misread as regression evidence in the future.

## Invariant

The provisional observation-byte bridge now requires the same canonical rendered/quoted Hello text representation required by adjacent verifier admission. Raw unquoted text is rejected rather than normalized into an admissible form.

## Validation

- `cargo test --test hello_observation_byte_emission`: 6/6 pass
- `cargo test -p sm-emit --all-features`: pass
- `cargo test --test hello_real_semcode_admission`: 5/5 pass (verifier's own suite, untouched, still green)
- `cargo test --test public_api_contracts`: 5/5 pass, **zero snapshot changes**
- `cargo clippy -p sm-emit --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1` (Hell 1-5): **PASS**

Three independent adversarial review lenses (semantic, boundary, qualification) were run against the committed diff before push; semantic and boundary PASSed cleanly, qualification's finding is addressed above.

## Scope

`crates/sm-verify/` untouched. No new error variant. No public API signature or snapshot changes. `#1740`, `#1747+`, `#1808`, `#1715` untouched.
