### PR TITLE
fix(sm-emit): align hello emitter with admission shape

### DIFF
--- a/crates/sm-emit/src/hello_real_semcode.rs
+++ b/crates/sm-emit/src/hello_real_semcode.rs
@@ -30,10 +30,14 @@ pub fn emit_hello_real_semcode_skeleton(
     Ok(HelloRealSemCodeModule { ops })
 }
 
+const CANONICAL_HELLO_ENTRY: &str = "HelloWorld";
+const CANONICAL_HELLO_SYMBOL: &str = "boot";
+const CANONICAL_HELLO_RENDERED_TEXT: &str = "\"Hello, World!\"";
+
 pub fn render_hello_real_semcode_skeleton(
     module: &HelloIrModule,
 ) -> Result<Vec<HelloRealSemCodeOp>, HelloRealSemCodeError> {
-    if module.entry.name != "HelloWorld" {
+    if module.entry.name != CANONICAL_HELLO_ENTRY {
         return Err(HelloRealSemCodeError::UnsupportedShape);
     }
 
@@ -49,20 +53,25 @@ pub fn render_hello_real_semcode_skeleton(
             observation_class: HelloIrObservationClass::Controlled,
         }), HelloIrStmt::CompleteQuad(HelloIrCompleteQuad {
             value: HelloIrQuadLit::T,
-        })] => vec![
-            HelloRealSemCodeOp::DeclareLocalQuad {
-                name: symbol.clone(),
-                value: render_quad(HelloIrQuadLit::T).to_string(),
-            },
-            HelloRealSemCodeOp::RequireQuadEq {
-                name: require_symbol.clone(),
-                expected: render_quad(HelloIrQuadLit::T).to_string(),
-            },
-            HelloRealSemCodeOp::ObserveTextLiteral { text: text.clone() },
-            HelloRealSemCodeOp::CompleteQuad {
-                value: render_quad(HelloIrQuadLit::T).to_string(),
-            },
-        ],
+        })] if symbol == CANONICAL_HELLO_SYMBOL
+            && require_symbol == CANONICAL_HELLO_SYMBOL
+            && text == CANONICAL_HELLO_RENDERED_TEXT =>
+        {
+            vec![
+                HelloRealSemCodeOp::DeclareLocalQuad {
+                    name: symbol.clone(),
+                    value: render_quad(HelloIrQuadLit::T).to_string(),
+                },
+                HelloRealSemCodeOp::RequireQuadEq {
+                    name: require_symbol.clone(),
+                    expected: render_quad(HelloIrQuadLit::T).to_string(),
+                },
+                HelloRealSemCodeOp::ObserveTextLiteral { text: text.clone() },
+                HelloRealSemCodeOp::CompleteQuad {
+                    value: render_quad(HelloIrQuadLit::T).to_string(),
+                },
+            ]
+        }
         _ => return Err(HelloRealSemCodeError::UnsupportedShape),
     };
 

--- a/tests/hello_real_semcode_admission.rs
+++ b/tests/hello_real_semcode_admission.rs
@@ -1,9 +1,14 @@
 use std::path::PathBuf;
 
-use sm_emit::hello_real_semcode::{emit_hello_real_semcode_skeleton, HelloRealSemCodeOp};
+use sm_emit::hello_real_semcode::{
+    emit_hello_real_semcode_skeleton, HelloRealSemCodeError, HelloRealSemCodeOp,
+};
 use sm_front::hello_parser::parse_hello_file;
 use sm_front::hello_sema::validate_hello_file;
-use sm_ir::hello_ir::lower_hello_checked_file;
+use sm_ir::hello_ir::{
+    lower_hello_checked_file, HelloIrCompleteQuad, HelloIrEntry, HelloIrLocalQuad, HelloIrModule,
+    HelloIrObservationClass, HelloIrObserveText, HelloIrQuadLit, HelloIrRequireQuadEq, HelloIrStmt,
+};
 use sm_verify::hello_real_semcode_admission::{
     admit_controlled_text_observation_shape, admit_hello_real_semcode_skeleton,
     builtin_call_controlled_observation_admission, ControlledObservationAdmissionKind,
@@ -216,5 +221,69 @@ fn hello_real_semcode_controlled_observation_admission_seam_distinguishes_print_
     assert_eq!(
         admit_controlled_text_observation_shape(&render_text_literal("Hello, World!")),
         Ok(ControlledObservationAdmissionKind::ControlledTextLiteral)
+    );
+}
+
+fn hand_built_hello_ir_module(symbol: &str, require_symbol: &str, text: &str) -> HelloIrModule {
+    HelloIrModule {
+        entry: HelloIrEntry {
+            name: "HelloWorld".to_string(),
+            body: vec![
+                HelloIrStmt::LocalQuad(HelloIrLocalQuad {
+                    symbol: symbol.to_string(),
+                    value: HelloIrQuadLit::T,
+                }),
+                HelloIrStmt::RequireQuadEq(HelloIrRequireQuadEq {
+                    symbol: require_symbol.to_string(),
+                    expected: HelloIrQuadLit::T,
+                }),
+                HelloIrStmt::ObserveText(HelloIrObserveText {
+                    text: text.to_string(),
+                    observation_class: HelloIrObservationClass::Controlled,
+                }),
+                HelloIrStmt::CompleteQuad(HelloIrCompleteQuad {
+                    value: HelloIrQuadLit::T,
+                }),
+            ],
+        },
+    }
+}
+
+#[test]
+fn hello_real_semcode_emitter_accepts_hand_built_canonical_module_and_verifier_admits_it() {
+    let module = hand_built_hello_ir_module("boot", "boot", "\"Hello, World!\"");
+    let semcode = emit_hello_real_semcode_skeleton(&module)
+        .expect("hand-built canonical Hello IR should emit real SemCode skeleton");
+    let input = skeleton_to_admission_input(&semcode.ops);
+    assert_eq!(
+        admit_hello_real_semcode_skeleton(&input),
+        HelloRealSemCodeAdmissionDecision::Admit
+    );
+}
+
+#[test]
+fn hello_real_semcode_emitter_rejects_noncanonical_symbol() {
+    let module = hand_built_hello_ir_module("ready", "ready", "\"Hello, World!\"");
+    assert_eq!(
+        emit_hello_real_semcode_skeleton(&module),
+        Err(HelloRealSemCodeError::UnsupportedShape)
+    );
+}
+
+#[test]
+fn hello_real_semcode_emitter_rejects_mismatched_local_and_require_symbols() {
+    let module = hand_built_hello_ir_module("boot", "notboot", "\"Hello, World!\"");
+    assert_eq!(
+        emit_hello_real_semcode_skeleton(&module),
+        Err(HelloRealSemCodeError::UnsupportedShape)
+    );
+}
+
+#[test]
+fn hello_real_semcode_emitter_rejects_noncanonical_controlled_text() {
+    let module = hand_built_hello_ir_module("boot", "boot", "\"Hi\"");
+    assert_eq!(
+        emit_hello_real_semcode_skeleton(&module),
+        Err(HelloRealSemCodeError::UnsupportedShape)
     );
 }


### PR DESCRIPTION
Closes #1740
Umbrella #1617

## Root cause

`crates/sm-emit/src/hello_real_semcode.rs`'s `render_hello_real_semcode_skeleton()` checked only the *structural* shape of a `HelloIrModule` (statement kinds in the right order, quad literals equal to `T`) but never checked that `symbol`, `require_symbol`, or `text` carried the specific canonical *values* the adjacent verifier requires:

```rust
[HelloIrStmt::LocalQuad(HelloIrLocalQuad { symbol, value: HelloIrQuadLit::T }),
 HelloIrStmt::RequireQuadEq(HelloIrRequireQuadEq { symbol: require_symbol, expected: HelloIrQuadLit::T }),
 HelloIrStmt::ObserveText(HelloIrObserveText { text, observation_class: HelloIrObservationClass::Controlled }),
 HelloIrStmt::CompleteQuad(HelloIrCompleteQuad { value: HelloIrQuadLit::T })] => vec![ ...built directly from symbol.clone(), require_symbol.clone(), text.clone()... ],
```

The adjacent verifier (`crates/sm-verify/src/hello_real_semcode_admission.rs`, `admit_hello_real_semcode_skeleton`) *does* require exactly `name == "boot"`, `require_name == "boot"`, and text matching `admit_controlled_text_observation_shape`'s only accepted literal, `"\"Hello, World!\""`. sm-emit could therefore produce a syntactically well-formed `HelloRealSemCodeModule` (e.g. symbol `"ready"`, or text `"\"Hi\""`) that the adjacent verifier predictably rejects.

This is distinct from #1739: #1739 is the byte bridge (one stage later) accepting a broader *text encoding*; #1740 is the typed skeleton producer itself (one stage earlier) admitting noncanonical *symbol/text values*.

## Pre-fix cross-stage reproduction

Hand-constructed `HelloIrModule` values (all IR types are `pub` with `pub` fields, so this is direct, no fixture needed), captured via a throwaway probe later removed:

**CASE 1 — noncanonical symbol** (`symbol`/`require_symbol == "ready"`, text canonical):
```
CASE1 emit_hello_real_semcode_skeleton -> Ok(HelloRealSemCodeModule { ops: [DeclareLocalQuad { name: "ready", ... }, ...] })
CASE1 admit_hello_real_semcode_skeleton -> Reject(UnsupportedShape)
```

**CASE 2 — noncanonical text** (`symbol`/`require_symbol == "boot"`, text `"\"Hi\""`):
```
CASE2 emit_hello_real_semcode_skeleton -> Ok(HelloRealSemCodeModule { ops: [..., ObserveTextLiteral { text: "\"Hi\"" }, ...] })
CASE2 admit_hello_real_semcode_skeleton -> Reject(NonTextObservation)
```

## Canonical Hello shape

No neutral shared Hello-contract-owning crate exists to reuse; the canonical values live independently in sm-emit's producer and sm-verify's admission function today (by design — sm-emit does not depend on sm-verify and vice versa). This repair keeps that boundary and simply teaches sm-emit's producer the same canonical values sm-verify already enforces:

- entry name `"HelloWorld"` (already checked pre-fix, unchanged)
- local/require symbol `"boot"`
- controlled observation text `"\"Hello, World!\""` (rendered/quoted form)
- quad literal `T` (already enforced structurally, unchanged)

## Repair

`render_hello_real_semcode_skeleton()`'s match arm gained an inline value guard using three small local constants (`CANONICAL_HELLO_ENTRY`, `CANONICAL_HELLO_SYMBOL`, `CANONICAL_HELLO_RENDERED_TEXT`), falling through to the existing `Err(HelloRealSemCodeError::UnsupportedShape)` arm on mismatch. No new error variant. No new crate dependency in either direction (`sm-emit` still only imports `sm_ir::hello_ir`; `crates/sm-verify/` has zero diff).

## Producer/admission seam regression

Added to `tests/hello_real_semcode_admission.rs` (the existing cross-layer seam that already imports both `sm_emit` and `sm_verify`):
- `hello_real_semcode_emitter_accepts_hand_built_canonical_module_and_verifier_admits_it` — canonical hand-built IR: emitter `Ok`, verifier `Admit`.
- `hello_real_semcode_emitter_rejects_noncanonical_symbol` — symbol/require `"ready"`: emitter `Err(UnsupportedShape)` — proves rejection happens inside sm-emit itself, before the shape ever reaches admission.
- `hello_real_semcode_emitter_rejects_mismatched_local_and_require_symbols` — local `"boot"`, require `"notboot"`: emitter `Err(UnsupportedShape)`.
- `hello_real_semcode_emitter_rejects_noncanonical_controlled_text` — text `"\"Hi\""`: emitter `Err(UnsupportedShape)`.

sm-emit and sm-verify still contain independent local checks — these tests are the qualification seam preventing their admitted shapes from silently diverging again, not a claim that they share one code object.

## Preserved canonical output

The canonical fixture (`tests/fixtures/pending/hello/positive_hello_verbose_directional.sm`) produces a byte-identical `HelloRealSemCodeModule` and downstream provisional observation bytes to before — confirmed by re-running `hello_real_semcode_admission_accepts_canonical_skeleton` and `hello_observation_byte_bridge_emits_gated_provisional_representation` (including its exact expected `CONST_TEXT #0 "Hello, World!"` byte-block assertion) unmodified.

## Validation

- `cargo test --test hello_real_semcode_admission`: 9/9 pass (5 pre-existing + 4 new)
- `cargo test --test hello_observation_byte_emission`: 4/4 pass (downstream byte bridge unaffected)
- `cargo test -p sm-emit --all-features`: pass
- `cargo test --test public_api_contracts`: 5/5 pass, **zero snapshot changes**
- `cargo clippy -p sm-emit --all-targets --all-features -- -D warnings`: clean
- `cargo clippy -p sm-verify --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1` (Hell 1-5, including sm-verify's full negative corpus): **PASS**

Note: `cargo test -p sm-verify --all-features` in isolation (as literally listed in the task's own command list) shows 57/94 failures with "RustLike profile is disabled at compile time" — reproduced identically on unmodified main via `git stash` before concluding it's unrelated. `tools/7hell/run_ci.ps1` deliberately runs sm-verify with `--features sm-ir/profile-rust` (not plain `--all-features`, which doesn't transitively enable a dependency's opt-in feature), and with that flag all 94 tests pass, as shown above. This is a pre-existing feature-flag-composition quirk, not caused by this PR.

Three independent adversarial review lenses (semantic, boundary, qualification) were run against the committed diff before push — all three PASSed cleanly, including explicit confirmation this branch is based on clean main and not stacked on #1739's branch.

## Repaired invariant

The provisional typed Hello producer no longer emits symbolic shapes that are predictably outside the adjacent verifier skeleton's canonical admission contract. This does not claim production SemCode support.

## Scope

`crates/sm-verify/` untouched. No new cross-crate dependency. No public API signature or snapshot changes. `#1739` (independent, separate PR), `#1747+`, `#1808`, `#1715` untouched.
