### PR TITLE
fix(sm-verify): reject forbidden hello host channels

### DIFF
--- a/crates/sm-verify/src/hello_pending_admission.rs
+++ b/crates/sm-verify/src/hello_pending_admission.rs
@@ -19,6 +19,7 @@ pub struct HelloPendingPolicyInput {
 pub enum HelloPendingPolicyReason {
     MissingObservationCapability,
     StdoutNotDefaultSink,
+    GenericIoNotAllowed,
     AuditRequiredButUnavailable,
     NondeterministicSinkConfiguration,
     UnsupportedOperationKind,
@@ -62,10 +63,18 @@ pub fn evaluate_hello_pending_policy(input: &HelloPendingPolicyInput) -> HelloPe
         };
     }
 
-    if matches!(input.requested_host_channel.as_deref(), Some("stdout")) {
-        return HelloPendingPolicyResult::Deny {
-            reason: HelloPendingPolicyReason::StdoutNotDefaultSink,
-        };
+    match input.requested_host_channel.as_deref() {
+        Some("stdout") => {
+            return HelloPendingPolicyResult::Deny {
+                reason: HelloPendingPolicyReason::StdoutNotDefaultSink,
+            };
+        }
+        Some("print") | Some("io.write") | Some("file") | Some("network") | Some("stdin") => {
+            return HelloPendingPolicyResult::Deny {
+                reason: HelloPendingPolicyReason::GenericIoNotAllowed,
+            };
+        }
+        _ => {}
     }
 
     if input.audit_policy == "required" && !input.audit_available {

--- a/tests/hello_isolated_policy_harness.rs
+++ b/tests/hello_isolated_policy_harness.rs
@@ -147,6 +147,7 @@ fn denial_reason_from_pending(reason: HelloPendingPolicyReason) -> &'static str 
     match reason {
         HelloPendingPolicyReason::MissingObservationCapability => "missing_observation_capability",
         HelloPendingPolicyReason::StdoutNotDefaultSink => "stdout_not_default_sink",
+        HelloPendingPolicyReason::GenericIoNotAllowed => "generic_io_not_allowed",
         HelloPendingPolicyReason::AuditRequiredButUnavailable => "audit_required_but_unavailable",
         HelloPendingPolicyReason::NondeterministicSinkConfiguration => {
             "nondeterministic_sink_configuration"

--- a/tests/hello_pending_verifier_admission.rs
+++ b/tests/hello_pending_verifier_admission.rs
@@ -111,6 +111,8 @@ fn hello_pending_verifier_admission_evaluates_all_policy_fixtures() {
             reason: HelloPendingPolicyReason::MissingObservationCapability,
         },
     );
+    // Preservation, not a new regression: stdout keeps its own distinct
+    // diagnostic and is not folded into GenericIoNotAllowed.
     assert_admission(
         "tests/fixtures/pending/hello_policy/negative_stdout_fallback.toml",
         HelloPendingPolicyResult::Deny {
@@ -178,6 +180,27 @@ fn hello_pending_verifier_admission_rejects_both_unsupported_with_operation_kind
             reason: HelloPendingPolicyReason::UnsupportedOperationKind,
         }
     );
+}
+
+#[test]
+fn hello_pending_verifier_admission_rejects_forbidden_host_channels() {
+    // The controlled-observation contract excludes six host channels.
+    // stdout gets its own diagnostic (covered above); the remaining five
+    // are generic-IO denials.
+    for channel in ["print", "io.write", "file", "network", "stdin"] {
+        let mut input = fixture_input(
+            "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+        );
+        input.requested_host_channel = Some(channel.to_string());
+        let actual = evaluate_hello_pending_policy(&input);
+        assert_eq!(
+            actual,
+            HelloPendingPolicyResult::Deny {
+                reason: HelloPendingPolicyReason::GenericIoNotAllowed,
+            },
+            "channel {channel}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #1748
Umbrella #1617
Related qualification debt: #1755

## Root cause

`crates/sm-verify/src/hello_pending_admission.rs`'s pending policy checked only:

```rust
if matches!(input.requested_host_channel.as_deref(), Some("stdout")) {
    return HelloPendingPolicyResult::Deny { reason: HelloPendingPolicyReason::StdoutNotDefaultSink };
}
```

but the controlled-observation contract explicitly excludes six channels: `stdout`, `print`, `io.write`, `file`, `network`, `stdin`. The adjacent `prom-cap` Hello capability skeleton (`crates/prom-cap/src/hello_observation_capability.rs`) already implements the complete correct set. The pending verifier seam let the other five through as `Admit`.

## Pre-fix matrix

Confirmed via a throwaway probe (removed before the repair), using the canonical positive fixture with `requested_host_channel` overridden one at a time:

| Channel | Pre-fix result |
|---|---|
| `stdout` | `Deny(StdoutNotDefaultSink)` — correct, preserved |
| `print` | `Admit` (bug) |
| `io.write` | `Admit` (bug) |
| `file` | `Admit` (bug) |
| `network` | `Admit` (bug) |
| `stdin` | `Admit` (bug) |

## Controlled-observation host-channel contract

The documented forbidden set is exactly these six spellings, no more, no fewer — this PR does not broaden to arbitrary unknown channels (`"socket"`, `"terminal"`, etc.), which is explicitly out of scope for #1748.

## Repair

```rust
match input.requested_host_channel.as_deref() {
    Some("stdout") => return HelloPendingPolicyResult::Deny { reason: HelloPendingPolicyReason::StdoutNotDefaultSink },
    Some("print") | Some("io.write") | Some("file") | Some("network") | Some("stdin") =>
        return HelloPendingPolicyResult::Deny { reason: HelloPendingPolicyReason::GenericIoNotAllowed },
    _ => {}
}
```
New reason `HelloPendingPolicyReason::GenericIoNotAllowed`, occupying the same position in the check ordering as the original stdout-only check (before audit-policy/determinism checks). `tests/hello_isolated_policy_harness.rs::denial_reason_from_pending` updated with a matching arm (`"generic_io_not_allowed"`, consistent with the harness's existing label for the same concept on the capability side).

## Diagnostic mapping

`stdout` keeps its own distinct, pre-existing diagnostic (`StdoutNotDefaultSink`) — it is **not** folded into the generic reason. `print` / `io.write` / `file` / `network` / `stdin` all map to `GenericIoNotAllowed`.

## prom-cap consistency

`crates/prom-cap/src/hello_observation_capability.rs`'s `evaluate_hello_observation_capability` and `require_hello_observation_sink_capability` both match exactly the same six spellings with the same stdout-vs-generic split — confirmed by direct re-read, byte-for-byte identical channel set and grouping. `crates/prom-cap/` has zero diff in this PR; the two layers remain intentionally independent (no new `sm-verify → prom-cap` dependency edge, confirmed via `cargo tree --edges normal -p sm-verify`), consistent with the existing provisional-seam architecture — this is in fact the third independent implementation of the same six-channel contract in the codebase (`sm-verify::hello_real_semcode_admission` already has its own).

## Regression matrix

- `requested_host_channel = None` → `Admit` — covered by the existing positive fixture, unchanged.
- `Some("stdout")` → `Deny(StdoutNotDefaultSink)` — preservation check, explicitly commented as such in the test, not counted as a new regression.
- `Some("print"|"io.write"|"file"|"network"|"stdin")` → `Deny(GenericIoNotAllowed)` — new table-driven test `hello_pending_verifier_admission_rejects_forbidden_host_channels`, all 5 pass; confirmed each genuinely returns `Admit` on unmodified main via direct trace of the old logic.
- `negative_stdout_fallback.toml` fixture confirmed byte-unchanged.

## Validation

- `cargo test --test hello_pending_verifier_admission`: 3/3 pass
- `cargo test --test hello_isolated_policy_harness`: 2/2 pass
- `cargo test -p prom-cap`: pass (untouched reference implementation)
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 94/94 pass
- `cargo test --test public_api_contracts`: pass, **zero snapshot changes**
- `cargo clippy -p sm-verify --all-targets --features sm-ir/profile-rust -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

Three independent adversarial review lenses (semantic, boundary, qualification) were run against the committed diff before push — all three PASSed cleanly.

## Scope

`crates/prom-cap/` untouched. No new dependency. No public API snapshot changes. `#1747` (independent, separate PR), `#1749`, `#1750`, `#1755`, `#1808` untouched.

## Batch conflict note

This PR and `#1747`'s PR both extend `HelloPendingPolicyReason` and touch `crates/sm-verify/src/hello_pending_admission.rs` / `tests/hello_isolated_policy_harness.rs`. Both are individually clean now (each built from the same clean main), but merging one first will likely require a rebase + CI rerun on the other before it can merge. Neither is merged in this batch.
