### PR TITLE
fix(sm-verify): validate hello pending operation shape

### DIFF
--- a/crates/sm-verify/src/hello_pending_admission.rs
+++ b/crates/sm-verify/src/hello_pending_admission.rs
@@ -21,6 +21,8 @@ pub enum HelloPendingPolicyReason {
     StdoutNotDefaultSink,
     AuditRequiredButUnavailable,
     NondeterministicSinkConfiguration,
+    UnsupportedOperationKind,
+    UnsupportedPayloadType,
 }
 
 #[cfg(feature = "std")]
@@ -31,10 +33,32 @@ pub enum HelloPendingPolicyResult {
 }
 
 #[cfg(feature = "std")]
+const CONTROLLED_OPERATION_KIND: &str = "controlled_observation_text";
+#[cfg(feature = "std")]
+const TEXT_LITERAL_PAYLOAD_TYPE: &str = "text_literal";
+
+#[cfg(feature = "std")]
 pub fn evaluate_hello_pending_policy(input: &HelloPendingPolicyInput) -> HelloPendingPolicyResult {
     if input.capability_observation_sink != "present" || !input.sink_available {
         return HelloPendingPolicyResult::Deny {
             reason: HelloPendingPolicyReason::MissingObservationCapability,
+        };
+    }
+
+    // Identity-shape checks run right after the capability gate and before
+    // channel/audit/ordering policy: whether we CAN observe at all takes
+    // priority over what is being observed, which in turn takes priority
+    // over how it is observed. operation_kind is checked before
+    // payload_type, so when both are unsupported, UnsupportedOperationKind
+    // wins deterministically.
+    if input.operation_kind != CONTROLLED_OPERATION_KIND {
+        return HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedOperationKind,
+        };
+    }
+    if input.payload_type != TEXT_LITERAL_PAYLOAD_TYPE {
+        return HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedPayloadType,
         };
     }
 

--- a/tests/hello_isolated_policy_harness.rs
+++ b/tests/hello_isolated_policy_harness.rs
@@ -151,6 +151,8 @@ fn denial_reason_from_pending(reason: HelloPendingPolicyReason) -> &'static str 
         HelloPendingPolicyReason::NondeterministicSinkConfiguration => {
             "nondeterministic_sink_configuration"
         }
+        HelloPendingPolicyReason::UnsupportedOperationKind => "unsupported_operation_kind",
+        HelloPendingPolicyReason::UnsupportedPayloadType => "unsupported_payload_type",
     }
 }
 

--- a/tests/hello_pending_verifier_admission.rs
+++ b/tests/hello_pending_verifier_admission.rs
@@ -132,6 +132,55 @@ fn hello_pending_verifier_admission_evaluates_all_policy_fixtures() {
 }
 
 #[test]
+fn hello_pending_verifier_admission_rejects_unsupported_operation_kind() {
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.operation_kind = "generic_io".to_string();
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedOperationKind,
+        }
+    );
+}
+
+#[test]
+fn hello_pending_verifier_admission_rejects_unsupported_payload_type() {
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.payload_type = "bytes".to_string();
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedPayloadType,
+        }
+    );
+}
+
+#[test]
+fn hello_pending_verifier_admission_rejects_both_unsupported_with_operation_kind_priority() {
+    // evaluate_hello_pending_policy checks operation_kind before payload_type
+    // (both checks run right after the capability gate), so when both fields
+    // are unsupported the operation_kind check wins deterministically.
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.operation_kind = "generic_io".to_string();
+    input.payload_type = "bytes".to_string();
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedOperationKind,
+        }
+    );
+}
+
+#[test]
 fn hello_pending_verifier_admission_policy_registry_stays_pending_only() {
     let registry = fixture_text("docs/language/semantic_hello_policy_fixtures.md");
     let readme = fixture_text("tests/fixtures/pending/hello_policy/README.md");


### PR DESCRIPTION
Closes #1747
Umbrella #1617
Related qualification debt: #1755

## Root cause

`crates/sm-verify/src/hello_pending_admission.rs`'s `HelloPendingPolicyInput` exposes `operation_kind: String` and `payload_type: String`, but `evaluate_hello_pending_policy()` never read either field — making them inert metadata. An otherwise-valid input with `operation_kind = "generic_io"` or `payload_type = "bytes"` (or any other spelling) was still admitted.

## Pre-fix reproduction

Confirmed via a throwaway probe (removed before the repair), from the canonical positive fixture with one field mutated at a time, all other fields canonical:

| Mutation | Pre-fix result |
|---|---|
| `operation_kind = "generic_io"` | `Admit` (bug) |
| `operation_kind = "xyz_totally_unknown"` | `Admit` (bug) |
| `payload_type = "bytes"` | `Admit` (bug) |
| `payload_type = "xyz_totally_unknown"` | `Admit` (bug) |

The arbitrary-unknown-spelling cases confirm the evaluator ignores these fields entirely — this isn't a missing alias, it's a missing check.

## Canonical operation identity

`operation_kind == "controlled_observation_text"` — the only value with live evidence (the canonical positive fixture).

## Canonical payload identity

`payload_type == "text_literal"` — same basis.

## Repair

```rust
const CONTROLLED_OPERATION_KIND: &str = "controlled_observation_text";
const TEXT_LITERAL_PAYLOAD_TYPE: &str = "text_literal";

if input.operation_kind != CONTROLLED_OPERATION_KIND {
    return HelloPendingPolicyResult::Deny { reason: HelloPendingPolicyReason::UnsupportedOperationKind };
}
if input.payload_type != TEXT_LITERAL_PAYLOAD_TYPE {
    return HelloPendingPolicyResult::Deny { reason: HelloPendingPolicyReason::UnsupportedPayloadType };
}
```
Exact string equality only — no normalization, no aliases, no prefix matching. Placed immediately after the existing capability-presence check and before the channel/audit/determinism checks (rationale: whether we can observe at all outranks what is being observed, which outranks how it is observed). This ordering does not change the outcome for any of the 5 existing fixtures — all already carry (or default to, via the test fixture loaders) the canonical values.

## Diagnostic behavior

Two new precise `HelloPendingPolicyReason` variants — `UnsupportedOperationKind`, `UnsupportedPayloadType` — added rather than misusing `MissingObservationCapability`. `tests/hello_isolated_policy_harness.rs::denial_reason_from_pending` (the exhaustive match over this enum) updated with matching arms.

## Regression matrix

- canonical + canonical → `Admit` (pre-existing fixture test, reconfirmed)
- bad operation + canonical payload → `Deny(UnsupportedOperationKind)` — new test, genuinely fails pre-fix (verified by tracing the old logic)
- canonical operation + bad payload → `Deny(UnsupportedPayloadType)` — new test, genuinely fails pre-fix
- both bad → `Deny(UnsupportedOperationKind)` deterministically (operation_kind checked first) — new test with the ordering documented inline

## Public API / #1755 boundary

`hello_pending_admission.rs` is not currently in `tests/public_api_contracts.rs`'s `TARGETS` (only `crates/sm-verify/src/lib.rs` is) — that gap is `#1755`, explicitly out of scope here. `cargo test --test public_api_contracts` passes with **zero snapshot changes**, as expected.

## Validation

- `cargo test --test hello_pending_verifier_admission`: 5/5 pass
- `cargo test --test hello_isolated_policy_harness`: 2/2 pass
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 94/94 pass
- `cargo test --test public_api_contracts`: 5/5 pass, zero snapshot changes
- `cargo clippy -p sm-verify --all-targets --features sm-ir/profile-rust -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

Three independent adversarial review lenses (semantic, boundary, qualification) were run against the committed diff before push — all three PASSed cleanly.

## Scope

No production code outside `crates/sm-verify/src/hello_pending_admission.rs` (plus the two test files) touched. No new dependencies. `#1748` (independent, separate PR), `#1749`, `#1750`, `#1755`, `#1808` untouched.

## Batch conflict note

This PR and `#1748`'s PR both extend `HelloPendingPolicyReason` and touch the same two files. Both are individually clean now (each built from the same clean main), but merging one first will likely require a rebase + CI rerun on the other before it can merge. Neither is merged in this batch.

## Repaired invariant

`operation_kind` and `payload_type` are now admission inputs rather than inert metadata. Only the canonical controlled text observation identity is admitted by this pending policy seam.
