### PR TITLE
fix(sm-verify): reject unknown hello audit policy

### DIFF
--- a/crates/sm-verify/src/hello_pending_admission.rs
+++ b/crates/sm-verify/src/hello_pending_admission.rs
@@ -24,6 +24,7 @@ pub enum HelloPendingPolicyReason {
     NondeterministicSinkConfiguration,
     UnsupportedOperationKind,
     UnsupportedPayloadType,
+    UnsupportedAuditPolicy,
 }
 
 #[cfg(feature = "std")]
@@ -77,10 +78,19 @@ pub fn evaluate_hello_pending_policy(input: &HelloPendingPolicyInput) -> HelloPe
         _ => {}
     }
 
-    if input.audit_policy == "required" && !input.audit_available {
-        return HelloPendingPolicyResult::Deny {
-            reason: HelloPendingPolicyReason::AuditRequiredButUnavailable,
-        };
+    match input.audit_policy.as_str() {
+        "required" => {
+            if !input.audit_available {
+                return HelloPendingPolicyResult::Deny {
+                    reason: HelloPendingPolicyReason::AuditRequiredButUnavailable,
+                };
+            }
+        }
+        _ => {
+            return HelloPendingPolicyResult::Deny {
+                reason: HelloPendingPolicyReason::UnsupportedAuditPolicy,
+            };
+        }
     }
 
     if !input.deterministic_order {

--- a/tests/hello_isolated_policy_harness.rs
+++ b/tests/hello_isolated_policy_harness.rs
@@ -136,10 +136,14 @@ fn to_capability_context(map: &BTreeMap<String, String>) -> HelloObservationCapa
 fn audit_policy_class_from_input(
     input: &HelloPendingPolicyInput,
 ) -> HelloObservationAuditPolicyClass {
-    if input.audit_policy == "required" {
-        HelloObservationAuditPolicyClass::Required
-    } else {
-        HelloObservationAuditPolicyClass::Deferred
+    // evaluate_hello_pending_policy (called earlier in run_isolated_harness,
+    // which returns on Deny before this helper is ever reached) already
+    // denies any audit_policy other than exactly "required". So this arm is
+    // an assertion that the upstream fail-closed check is doing its job, not
+    // a new fail-open classification path.
+    match input.audit_policy.as_str() {
+        "required" => HelloObservationAuditPolicyClass::Required,
+        other => panic!("pending admission allowed unsupported audit_policy: {other}"),
     }
 }
 
@@ -154,6 +158,7 @@ fn denial_reason_from_pending(reason: HelloPendingPolicyReason) -> &'static str 
         }
         HelloPendingPolicyReason::UnsupportedOperationKind => "unsupported_operation_kind",
         HelloPendingPolicyReason::UnsupportedPayloadType => "unsupported_payload_type",
+        HelloPendingPolicyReason::UnsupportedAuditPolicy => "unsupported_audit_policy",
     }
 }
 

--- a/tests/hello_pending_verifier_admission.rs
+++ b/tests/hello_pending_verifier_admission.rs
@@ -204,6 +204,96 @@ fn hello_pending_verifier_admission_rejects_forbidden_host_channels() {
 }
 
 #[test]
+fn hello_pending_verifier_admission_rejects_unknown_audit_policy_when_audit_unavailable() {
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.audit_policy = "unknown".to_string();
+    input.audit_available = false;
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedAuditPolicy,
+        }
+    );
+}
+
+#[test]
+fn hello_pending_verifier_admission_rejects_unknown_audit_policy_even_when_audit_available() {
+    // The defect this guards against is unknown POLICY IDENTITY, not merely
+    // missing audit availability: an unrecognized audit_policy string must
+    // deny regardless of audit_available.
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.audit_policy = "unknown".to_string();
+    input.audit_available = true;
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedAuditPolicy,
+        }
+    );
+}
+
+#[test]
+fn hello_pending_verifier_admission_rejects_misspelled_audit_policy() {
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.audit_policy = "requred".to_string();
+    input.audit_available = true;
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedAuditPolicy,
+        }
+    );
+}
+
+#[test]
+fn hello_pending_verifier_admission_rejects_empty_audit_policy() {
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.audit_policy = String::new();
+    input.audit_available = true;
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedAuditPolicy,
+        }
+    );
+}
+
+#[test]
+fn hello_pending_verifier_admission_rejects_deferred_audit_policy_string() {
+    // This freezes the CURRENT boundary of this pending-verifier String API:
+    // no serialized spelling for the Deferred audit policy class has been
+    // defined/evidenced at this layer yet, so "deferred" denies like any
+    // other unrecognized string. This does NOT mean Deferred is conceptually
+    // invalid — HelloObservationAuditPolicyClass::Deferred remains a valid
+    // typed state in prom-audit; a future issue may define a canonical
+    // deferred string representation here with its own evidence/fixtures.
+    let mut input = fixture_input(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+    );
+    input.audit_policy = "deferred".to_string();
+    input.audit_available = true;
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(
+        actual,
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::UnsupportedAuditPolicy,
+        }
+    );
+}
+
+#[test]
 fn hello_pending_verifier_admission_policy_registry_stays_pending_only() {
     let registry = fixture_text("docs/language/semantic_hello_policy_fixtures.md");
     let readme = fixture_text("tests/fixtures/pending/hello_policy/README.md");


### PR DESCRIPTION
Closes #1749
Umbrella #1617
Related qualification debt: #1755

## Prior investigation and owner decision

A prior investigation searched the entire repository for a canonical String spelling of a "deferred" `audit_policy` value and found none — see the [STOP comment](https://github.com/skulmakov-oss/Semantic/issues/1749#issuecomment-5350121724) on this issue. `HelloObservationAuditPolicyClass::Required`/`::Deferred` exists only as a typed Rust enum in `prom-audit`, never serialized to/from a string anywhere.

**Owner decision (binding for this PR):** do not introduce `"deferred"` as a `HelloPendingPolicyInput.audit_policy` string spelling. The fail-closed repair recognizes only the one currently evidenced pending string value, `"required"`. Every other value — including `"deferred"` — denies. This freezes the current boundary; it does not define the future serialized Deferred representation. `HelloObservationAuditPolicyClass::Deferred` remains valid and untouched in `prom-audit`. A future issue may define a canonical deferred string with its own evidence/fixtures/mapping — that is explicitly not this PR.

## Root cause

```rust
if input.audit_policy == "required" && !input.audit_available {
    Deny(AuditRequiredButUnavailable)
}
```
Every `audit_policy` String other than exactly `"required"` silently acquired permissive semantics — the check is skipped entirely and evaluation falls through toward `Admit`. This includes unknown, misspelled, empty, and any future spelling.

`tests/hello_isolated_policy_harness.rs`'s `audit_policy_class_from_input` had the same class of bug at the qualification-harness layer: `if audit_policy == "required" { Required } else { Deferred }` silently classified any unrecognized string as `Deferred`.

## Pre-fix reproduction

Confirmed via a throwaway probe (removed before the repair), using the canonical positive fixture:

| `audit_policy` | `audit_available` | Pre-fix result |
|---|---|---|
| `"unknown"` | `false` | `Admit` (bug) |
| `"unknown"` | `true` | `Admit` (bug — the key case: the defect is unknown **policy identity**, not missing availability) |
| `"requred"` (typo) | `true` | `Admit` (bug) |
| `"required"` | `false` | `Deny(AuditRequiredButUnavailable)` — correct, preserved |

## Recognized pending audit policies

Exactly one: `"required"`. No other spelling is recognized by this pending-verifier String API today.

## Fail-closed repair

```rust
match input.audit_policy.as_str() {
    "required" => {
        if !input.audit_available {
            return HelloPendingPolicyResult::Deny { reason: HelloPendingPolicyReason::AuditRequiredButUnavailable };
        }
    }
    _ => {
        return HelloPendingPolicyResult::Deny { reason: HelloPendingPolicyReason::UnsupportedAuditPolicy };
    }
}
```
New reason `HelloPendingPolicyReason::UnsupportedAuditPolicy`, occupying the same position as the original audit check. `#1747`'s operation/payload checks and `#1748`'s host-channel checks (both already merged into `main`) were read and left untouched.

## Required vs Deferred semantics

`"required"` + `audit_available=false` retains its own distinct diagnostic (`AuditRequiredButUnavailable`) — this is a different failure from an unrecognized policy string and must not be conflated with `UnsupportedAuditPolicy`. No `"deferred"` path exists yet at all — see owner decision above.

## Unknown-policy diagnostic

`HelloPendingPolicyReason::UnsupportedAuditPolicy`, added to the enum. `tests/hello_isolated_policy_harness.rs::denial_reason_from_pending` (exhaustive match) updated with a matching arm.

## Harness qualification repair

```rust
fn audit_policy_class_from_input(input: &HelloPendingPolicyInput) -> HelloObservationAuditPolicyClass {
    match input.audit_policy.as_str() {
        "required" => HelloObservationAuditPolicyClass::Required,
        other => panic!("pending admission allowed unsupported audit_policy: {other}"),
    }
}
```
Safe, not a new fail-open path: `run_isolated_harness` calls `evaluate_hello_pending_policy` first and returns immediately on `Deny`, only reaching this helper when the pending check already returned `Admit`. After this repair, that can only happen when `audit_policy == "required"` — the panic arm is unreachable in practice, a defense-in-depth assertion that the upstream check is doing its job. `HelloObservationAuditPolicyClass::Deferred` itself is not removed or touched in `prom-audit`.

## Regression matrix

- `"required"` + `audit_available=true` → `Admit` (existing fixture coverage, reconfirmed)
- `"required"` + `audit_available=false` → `Deny(AuditRequiredButUnavailable)` (existing fixture coverage, reconfirmed)
- `"unknown"` + `audit_available=false` → `Deny(UnsupportedAuditPolicy)` — new
- `"unknown"` + `audit_available=true` → `Deny(UnsupportedAuditPolicy)` — new, the important case
- `"requred"` (typo) + `true` → `Deny(UnsupportedAuditPolicy)` — new
- `""` (empty) + `true` → `Deny(UnsupportedAuditPolicy)` — new
- `"deferred"` + `true` → `Deny(UnsupportedAuditPolicy)` — new, intentionally freezes the current boundary (see code comment; does not claim Deferred is conceptually invalid)

All 5 new tests genuinely fail on unmodified `main` (confirmed by tracing the old logic, not assumption).

## Validation

- `cargo test --test hello_pending_verifier_admission`: 11/11 pass
- `cargo test --test hello_isolated_policy_harness`: 2/2 pass
- `cargo test --test hello_observation_audit_decision`: 3/3 pass
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 94/94 pass
- `cargo test --test public_api_contracts`: 5/5 pass, **zero snapshot changes**
- `cargo clippy -p sm-verify --all-targets --features sm-ir/profile-rust -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

Three independent adversarial review lenses (semantic, boundary, qualification) were run against the committed diff before push — all three PASSed cleanly, including explicit confirmation the "deferred" freeze-test's comment doesn't mischaracterize `HelloObservationAuditPolicyClass::Deferred` as invalid.

## Scope

`crates/prom-audit/` untouched — `HelloObservationAuditPolicyClass::Deferred` remains valid and unmodified there. `HelloPendingPolicyInput.audit_policy` remains a plain `String` (not converted to an enum). No new cross-crate dependency. No `record`/`deny`/`redact`/`no_store` storage-policy vocabulary imported. `#1747`/`#1748` (already merged), `#1750`, `#1755`, `#1808` untouched.
