### PR TITLE
fix(call): align builtin resolution with user functions

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -154,16 +154,6 @@ const APPLICATION_BUILTIN_NAMES: &[&str] = &[
     "time_duration_ms",
 ];
 
-/// `std.math` Selected-surface builtin names (SSF-07). A user-defined
-/// function sharing one of these names would typecheck (call analysis
-/// prefers the user signature), but `try_eval_builtin_call` in
-/// `crates/sm-vm/src/semcode_vm.rs` intercepts these names by bare string
-/// match before function-frame dispatch, so the builtin would silently run
-/// instead of the user's function body. Reserved here so that collision is
-/// a deterministic compile-time rejection instead of silent runtime
-/// shadowing, matching APPLICATION_BUILTIN_NAMES's pattern above.
-const STDLIB_MATH_BUILTIN_NAMES: &[&str] = &["sqrt", "abs"];
-
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub type SchemaTable = BTreeMap<SymbolId, SchemaDecl>;
 
@@ -498,14 +488,6 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
             return Err(FrontendError {
                 pos: 0,
                 message: format!("function name '{name}' is reserved for the application boundary"),
-            });
-        }
-        if STDLIB_MATH_BUILTIN_NAMES.contains(&name) {
-            return Err(FrontendError {
-                pos: 0,
-                message: format!(
-                    "function name '{name}' is reserved for the std.math standard library surface"
-                ),
             });
         }
         if out.contains_key(&f.name) {
@@ -1256,25 +1238,30 @@ mod tests {
     }
 
     #[test]
-    fn build_fn_table_rejects_math_builtin_name_collision() {
-        let src = r#"
-fn sqrt(x: f64) -> f64 {
+    fn build_fn_table_admits_math_builtin_name_as_user_function() {
+        // #1653/#1750 (umbrella #1617): user-defined math functions now
+        // follow the same user-first resolution rule as every other name
+        // (see crates/sm-vm/src/semcode_vm.rs's Opcode::Call dispatch) —
+        // they are no longer rejected at the frontend boundary.
+        for name in ["sin", "cos", "tan", "sqrt", "abs", "pow"] {
+            let src = format!(
+                r#"
+fn {name}(x: f64) -> f64 {{
     return 42.0;
-}
-fn main() {
+}}
+fn main() {{
     return;
-}
-"#;
-        let program = match parse_rustlike(src).expect("parse") {
-            AstBundle::RustLike(p) => p,
-            AstBundle::Logos(_) => panic!("expected rustlike bundle"),
-        };
-        let err = build_fn_table(&program).expect_err("user function named sqrt must be rejected");
-        assert!(
-            err.message.contains("sqrt") && err.message.contains("reserved"),
-            "unexpected error: {}",
-            err.message
-        );
+}}
+"#
+            );
+            let program = match parse_rustlike(&src).expect("parse") {
+                AstBundle::RustLike(p) => p,
+                AstBundle::Logos(_) => panic!("expected rustlike bundle"),
+            };
+            build_fn_table(&program).unwrap_or_else(|err| {
+                panic!("user function named '{name}' must be admitted: {err:?}")
+            });
+        }
     }
 
     #[test]

--- a/crates/sm-vm/Cargo.toml
+++ b/crates/sm-vm/Cargo.toml
@@ -23,4 +23,5 @@ sm-format = { path = "../sm-format", default-features = false, features = ["std"
 
 [dev-dependencies]
 sm-emit = { path = "../sm-emit", default-features = false, features = ["std"] }
+sm-ir = { path = "../sm-ir", default-features = false, features = ["std"] }
 

--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -29,8 +29,9 @@ pub use semcode_vm::*;
 mod tests {
     use super::*;
     use sm_emit::compile_program_to_semcode;
+    use sm_ir::{emit_ir_to_semcode, IrFunction, IrInstr};
     use sm_runtime_core::RecordCarrier;
-    use sm_verify::verify_semcode_token;
+    use sm_verify::{verify_semcode, verify_semcode_token, VerificationCode};
 
     #[test]
     fn test_1_invoke_function_returning_i32() {
@@ -151,5 +152,221 @@ mod tests {
                     .expect("run");
             assert_eq!(res, Value::I32(i * 2));
         }
+    }
+
+    // --- #1653 / #1750 (umbrella #1617) regression matrix -----------------
+    //
+    // Rule enforced by crates/sm-vm/src/semcode_vm.rs's Opcode::Call
+    // dispatch: an internal (program-defined) function named `callee`
+    // always wins over a same-named builtin. Builtin resolution is only
+    // attempted when no internal function by that name exists. This
+    // matches the source-level rule (crates/sm-front: user table checked
+    // before `builtin_sig`) and the verifier's rule (crates/sm-verify:
+    // `known_functions.contains(callee)` short-circuits before any
+    // builtin capability check).
+
+    /// Case 1 (also the #1653 reproduction): a user-defined `sin` is
+    /// admitted by the frontend and, when called, the VM executes the
+    /// USER body — not the real sine function.
+    #[test]
+    fn user_defined_sin_wins_over_builtin_dispatch() {
+        let src = "fn sin(x: f64) -> f64 { return x + 1000.0; } fn caller(x: f64) -> f64 { return sin(x); } fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("caller").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::F64(5.0)])
+            .expect("run");
+        assert_eq!(
+            res,
+            Value::F64(1005.0),
+            "expected user body result, got {res:?}"
+        );
+    }
+
+    /// Case 2: `sqrt` used to be frontend-rejected via
+    /// STDLIB_MATH_BUILTIN_NAMES; now it follows the same user-first rule.
+    #[test]
+    fn user_defined_sqrt_wins_over_builtin_dispatch() {
+        let src = "fn sqrt(x: f64) -> f64 { return x + 2000.0; } fn caller(x: f64) -> f64 { return sqrt(x); } fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("caller").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::F64(16.0)])
+            .expect("run");
+        assert_eq!(
+            res,
+            Value::F64(2016.0),
+            "expected user body result, got {res:?}"
+        );
+    }
+
+    /// Case 3: same as above for `abs`.
+    #[test]
+    fn user_defined_abs_wins_over_builtin_dispatch() {
+        let src = "fn abs(x: f64) -> f64 { return x + 3000.0; } fn caller(x: f64) -> f64 { return abs(x); } fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("caller").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::F64(-4.0)])
+            .expect("run");
+        assert_eq!(
+            res,
+            Value::F64(2996.0),
+            "expected user body result, got {res:?}"
+        );
+    }
+
+    /// Case 4: with NO same-named internal function, `sin` still dispatches
+    /// to the real builtin (proves the common/normal case is unbroken).
+    #[test]
+    fn ordinary_builtin_sin_still_executes_without_internal_function() {
+        // A literal f64 argument (rather than a passed-in parameter) is used
+        // so the emitted header naturally carries CAP_F64_MATH (see
+        // `has_v1_math_instr` in sm-ir's legacy_lowering.rs), matching the
+        // established pattern in sm-verify's own
+        // `verifier_accepts_builtin_f64_call_targets` test.
+        let src = "fn caller() -> f64 { return sin(5.0); } fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("caller").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![]).expect("run");
+        match res {
+            Value::F64(v) => assert!((v - 5.0_f64.sin()).abs() < 1e-9, "got {v}"),
+            other => panic!("expected F64, got {other:?}"),
+        }
+    }
+
+    /// Case 5: same as above for `sqrt`.
+    #[test]
+    fn ordinary_builtin_sqrt_still_executes_without_internal_function() {
+        let src = "fn caller() -> f64 { return sqrt(16.0); } fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("caller").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![]).expect("run");
+        match res {
+            Value::F64(v) => assert!((v - 16.0_f64.sqrt()).abs() < 1e-9, "got {v}"),
+            other => panic!("expected F64, got {other:?}"),
+        }
+    }
+
+    fn hand_built_to_text_program() -> Vec<u8> {
+        emit_ir_to_semcode(
+            &[
+                IrFunction {
+                    // Deliberately capability-free body (no LoadText/other
+                    // CAP_TEXT_VALUES-gated instruction): this lets the
+                    // header be downgraded to a spec lacking CAP_TEXT_VALUES
+                    // without the function's OWN per-function verification
+                    // failing on that unrelated ground, so the test below
+                    // can isolate exactly one property: does the call-target
+                    // check for `caller`'s call to "to_text" require
+                    // CAP_TEXT_VALUES, or does known_functions.contains(...)
+                    // short-circuit it? A sentinel i32 return is also an
+                    // unmistakably different type+value from what the real
+                    // to_text builtin would produce (Value::Text("42")).
+                    name: "to_text".to_string(),
+                    instrs: vec![
+                        IrInstr::LoadI32 { dst: 1, val: 777 },
+                        IrInstr::Ret { src: Some(1) },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+                IrFunction {
+                    name: "caller".to_string(),
+                    instrs: vec![
+                        IrInstr::Call {
+                            dst: Some(1),
+                            name: "to_text".to_string(),
+                            args: vec![0],
+                        },
+                        IrInstr::Ret { src: Some(1) },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+            ],
+            false,
+        )
+        .expect("emit hand-built to_text program")
+    }
+
+    /// Case 6 (also the #1750 reproduction): an internal function literally
+    /// named `to_text` is verifier-ACCEPTED under a header that explicitly
+    /// LACKS CAP_TEXT_VALUES (known_functions short-circuits the builtin
+    /// capability check for the *call* to this callee before
+    /// `builtin_call_required_capabilities` is ever consulted), and the VM
+    /// executes the INTERNAL function's body, not the real `to_text`
+    /// builtin.
+    ///
+    /// The header is deliberately downgraded here (same `bytes[7]`
+    /// technique as Case 7 below) specifically to prove the short-circuit is
+    /// doing real work: without the downgrade, this hand-built program's
+    /// header would naturally carry CAP_TEXT_VALUES anyway (the emitter's
+    /// header-revision selection treats any `Call { name: "to_text", .. }`
+    /// call SITE as requiring it, purely by name, independent of whether
+    /// that name resolves to the builtin or an internal function) — which
+    /// would make a plain "verifier accepts" assertion pass for the wrong
+    /// reason (capability present) instead of the reason under test
+    /// (capability not required because the callee is a known function).
+    /// `hand_built_to_text_program`'s internal `to_text` body is
+    /// deliberately capability-free so downgrading the header doesn't also
+    /// trip a *different* rejection on the function's own per-function
+    /// verification. Case 7 below is the negative pair proving the
+    /// capability requirement still applies when there is no known function
+    /// to short-circuit on.
+    #[test]
+    fn internal_to_text_wins_and_verifier_accepts_without_text_capability() {
+        let mut bytes = hand_built_to_text_program();
+        bytes[7] = b'7'; // downgrade header to a spec lacking CAP_TEXT_VALUES
+        let report = verify_semcode(&bytes);
+        assert!(
+            report.is_ok(),
+            "verifier must accept: internal to_text is a known function, so no builtin \
+             capability is required for this callee, even though the header lacks \
+             CAP_TEXT_VALUES; got {report:?}"
+        );
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("caller").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::I32(42)])
+            .expect("run");
+        assert_eq!(
+            res,
+            Value::I32(777),
+            "VM must execute the internal to_text function, not the builtin \
+             (which would have returned Value::Text(\"42\")); got {res:?}"
+        );
+    }
+
+    /// Case 7: the critical negative pair for Case 6. With NO internal
+    /// `to_text` defined, the SAME bare call to "to_text" under a header
+    /// lacking CAP_TEXT_VALUES must still be REJECTED by the verifier with
+    /// CapabilityViolation. This proves the builtin capability requirement
+    /// was not weakened: it is only bypassed for calls that truly resolve
+    /// to a known internal function.
+    #[test]
+    fn bare_builtin_to_text_call_still_requires_capability() {
+        let mut bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "caller".to_string(),
+                instrs: vec![
+                    IrInstr::LoadI32 { dst: 0, val: 42 },
+                    IrInstr::Call {
+                        dst: Some(1),
+                        name: "to_text".to_string(),
+                        args: vec![0],
+                    },
+                    IrInstr::Ret { src: Some(1) },
+                ],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+        bytes[7] = b'7'; // downgrade header to a spec lacking CAP_TEXT_VALUES
+        let report = verify_semcode(&bytes).expect_err("must reject: no known-function to_text");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::CapabilityViolation
+        );
     }
 }

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -2483,6 +2483,19 @@ where
                     next_pc = cur - f.instr_start;
                 }
             }
+            // Call target resolution precedence (#1653 / #1750, umbrella #1617):
+            // an internal/program function named `callee` always wins over a
+            // same-named builtin. This mirrors the verifier's already-correct
+            // rule (crates/sm-verify/src/lib.rs: `known_functions.contains`
+            // short-circuits before any builtin capability check) and the
+            // source-level rule (crates/sm-front: user table checked before
+            // `builtin_sig`). Before this fix, `try_eval_builtin_call` ran
+            // unconditionally first, so a user-defined `sin`/`to_text`/etc.
+            // was silently shadowed by the builtin at the one layer (the VM)
+            // that actually executes code, even though both the frontend and
+            // the verifier had already admitted/proven the user function.
+            // Builtin resolution now only happens when no internal function
+            // by that name exists.
             Opcode::Call => {
                 let has_dst = read_u8(&f.code, &mut cur).map_err(map_format_err)? != 0;
                 let dst = read_u16_le(&f.code, &mut cur).map_err(map_format_err)?;
@@ -2494,12 +2507,22 @@ where
                     let r = read_u16_le(&f.code, &mut cur).map_err(map_format_err)?;
                     args.push(get_reg(vm, frame_idx, r)?);
                 }
-                if let Some(result) = try_eval_builtin_call(host, observation, &callee, &args)? {
+                if vm.functions.contains_key(&callee) {
+                    vm.callstack[frame_idx].pc = cur - f.instr_start;
+                    push_frame(vm, &callee, args, if has_dst { Some(dst) } else { None })?;
+                    continue;
+                } else if let Some(result) =
+                    try_eval_builtin_call(host, observation, &callee, &args)?
+                {
                     if has_dst {
                         set_reg(vm, frame_idx, dst, result)?;
                     }
                     next_pc = cur - f.instr_start;
                 } else {
+                    // Truly unknown callee: neither an internal function nor
+                    // a builtin. Route through push_frame so the error
+                    // (RuntimeError::UnknownFunction) is unchanged from
+                    // pre-fix behavior.
                     vm.callstack[frame_idx].pc = cur - f.instr_start;
                     push_frame(vm, &callee, args, if has_dst { Some(dst) } else { None })?;
                     continue;


### PR DESCRIPTION
Closes #1653
Closes #1750
Umbrella #1617

## Why one PR closes both findings

#1653 and #1750 are two observed consequences of the same target-resolution disagreement between layers: the source/frontend/verifier already resolve calls user-function-first, but the VM resolved builtin-first. The production repair is indivisible without manufacturing an artificial intermediate semantics — fixing the VM's resolution order simultaneously stops an admitted user function body from being skipped (#1653) and makes the VM execute the same target the verifier proved (#1750).

## Shared root cause

**Frontend** (`crates/sm-front/src/typecheck.rs:2817-2820`) resolves user-table-first, falling back to `builtin_sig` only when no user function exists — already correct. **IR lowering** mirrors this. The emitted `IrInstr::Call` always carries the bare source name regardless of which branch resolved it, so `fn sin(x: f64) -> f64 { ... }` calling `sin(5.0)` really does emit `CALL "sin"` — the exact string the VM's builtin table also matches on.

**Verifier** (`crates/sm-verify/src/lib.rs:373-398`) already implements the canonical rule correctly and is **untouched** by this PR: `if known_functions.contains(callee.as_str()) { continue; }` short-circuits before any builtin capability check.

**VM** (`crates/sm-vm/src/semcode_vm.rs`, `Opcode::Call`) was the inconsistent layer: `try_eval_builtin_call` ran unconditionally, first, purely by string match — zero knowledge of `vm.functions` — and only fell through to `push_frame` (user dispatch) when the builtin table returned `None`.

## Canonical source resolution rule

User-defined function present -> user function wins. No user definition -> builtin fallback. This applies uniformly to source, IR, verifier, and now the VM.

## #1653 pre-fix wrong-code reproduction

`fn sin(x: f64) -> f64 { return x + 1000.0; } fn caller(x: f64) -> f64 { return sin(x); }` -- frontend admitted it (compile succeeded, since `sin`/`cos`/`tan`/`pow` were never blocked by `STDLIB_MATH_BUILTIN_NAMES`, which only ever covered `sqrt`/`abs`), verifier accepted, and pre-fix execution of `caller(5.0)` returned `Value::F64(-0.9589242746631385)` -- the real IEEE sine -- not `1005.0` (the admitted user body's sentinel result). Independently confirmed by grafting the identical test into a throwaway worktree at unmodified `main`: it fails there for the same reason.

## #1750 pre-fix verifier/VM proof mismatch

Hand-built via `emit_ir_to_semcode`: an internal function literally named `to_text`, called from `caller`. Pre-fix: `verify_semcode` -> **Accept** (the verifier's `known_functions.contains("to_text")` short-circuit already worked correctly -- this half of the behavior is unchanged by this PR). Executing `caller` pre-fix returned `Value::Text("42")` -- the real `to_text` builtin's conversion of the argument -- not the internal function's own sentinel body. This is the strongest reproduction: verifier proof target != execution target.

## VM repair

`Opcode::Call` dispatch now checks `vm.functions.contains_key(&callee)` **before** `try_eval_builtin_call`. Internal function exists -> `push_frame` (user dispatch), builtin evaluator never invoked. Builtin fallback happens only when no internal function exists. The "truly unknown callee" fallback is byte-identical to pre-fix (still routes through `push_frame`, still raises `RuntimeError::UnknownFunction`) -- no error-path regression. No new string allowlist; the check is structural (HashMap membership), not a name list.

## sqrt/abs frontend workaround removal

`STDLIB_MATH_BUILTIN_NAMES` (`["sqrt", "abs"]`) and its rejection check in `build_fn_table` are removed -- the constant's own doc comment explicitly said it existed only to work around VM builtin-first dispatch, which no longer exists. `APPLICATION_BUILTIN_NAMES` and its check are **completely untouched** -- this repair changes runtime resolution precedence, not application-boundary source admission policy.

## Behavior for all six math builtin names

| Name | User definition present | No user definition |
|---|---|---|
| sin, cos, tan, sqrt, abs, pow | frontend admits, VM executes **user body** | frontend admits call, VM executes **builtin** |

All six now obey the identical rule (previously `sqrt`/`abs` were frontend-rejected while `sin`/`cos`/`tan`/`pow` were silently shadowed -- two different bugs, now one consistent rule).

## Internal `to_text` / missing-capability results, before -> after

- Internal `to_text` present, header genuinely lacking `CAP_TEXT_VALUES` (deliberately downgraded, capability-free internal body so this isolates exactly one property): verifier **Accept** (unchanged -- already correct), VM now executes the **internal** function (`Value::I32(777)`), not the builtin (`Value::Text("42")`).
- No internal `to_text`, same missing-capability header: verifier still **Rejects** with `CapabilityViolation` -- proving the capability requirement was not weakened; it is bypassed only for calls that truly resolve to a known internal function.

## Files changed

`crates/sm-front/src/lib.rs`, `crates/sm-vm/src/semcode_vm.rs`, `crates/sm-vm/src/lib.rs` (regression tests), `crates/sm-vm/Cargo.toml` (test-only `sm-ir` dev-dependency for hand-built-IR tests -- confirmed via `cargo tree --edges normal -p sm-vm` it does **not** appear in the normal dependency graph, so the sm-vm-must-not-depend-on-sm-ir trust boundary is not violated).

## Focused tests (7-item regression matrix + frontend unification)

1. `user_defined_sin_wins_over_builtin_dispatch` -- user body (1005.0) wins.
2. `user_defined_sqrt_wins_over_builtin_dispatch` -- user body (2016.0) wins.
3. `user_defined_abs_wins_over_builtin_dispatch` -- user body (2996.0) wins.
4. `ordinary_builtin_sin_still_executes_without_internal_function` -- real builtin still works, no user target.
5. `ordinary_builtin_sqrt_still_executes_without_internal_function` -- same.
6. `internal_to_text_wins_and_verifier_accepts_without_text_capability` -- internal fn wins, verifier accepts under a genuinely capability-lacking header (see note below).
7. `bare_builtin_to_text_call_still_requires_capability` -- the critical negative pair: no internal fn, same missing capability -> `CapabilityViolation`.
8. `build_fn_table_admits_math_builtin_name_as_user_function` -- all six names now admitted as user function names.

**Self-review correction:** an independent adversarial qualification pass caught that test #6's original form let the header naturally carry `CAP_TEXT_VALUES` (the emitter's header-revision selection treats any `Call{name:"to_text"}` **call site** as requiring it, purely by name, regardless of whether it resolves to a builtin or an internal function) -- so the original assertion didn't actually isolate whether verifier acceptance came from the `known_functions` short-circuit or from the capability bit being present anyway. Fixed by giving the internal function a capability-free body and explicitly downgrading the header (the same `bytes[7]` technique test #7 already uses) before asserting acceptance -- now genuinely proving the short-circuit in isolation. Empirically re-confirmed the corrected test still fails on unmodified `main` (via a throwaway worktree) for the intended reason.

Full `sm-vm` suite: 106 passed, 0 failed. `sm-front`: 483 passed. `sm-verify` (untouched): 94 passed, 0 failed.

## Capability-proof preservation

`crates/sm-verify/src/lib.rs` has **zero diff** in this PR. The already-correct `known_functions`/`builtin_call_required_capabilities` logic is untouched; test #7 is the direct proof a missing builtin capability cannot be bypassed when the builtin actually executes.

## Application-boundary non-goal

`APPLICATION_BUILTIN_NAMES` (`args_read`, `stdin_read_text`, `stdout_write`, `stderr_write`, `path_inspect`, `fs_read_text`, `fs_write_text`, `time_duration_ms`) and its rejection check are unchanged. These remain reserved; they did not become user-overridable.

## Validation

- `cargo test -p sm-front --all-features`: 483/483 pass
- `cargo test -p sm-vm --all-features`: 106 + 1 + 23 pass (1 pre-existing unrelated ignored test)
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 94/94 pass (untouched)
- `cargo test --test public_api_contracts`: 5/5 pass, zero snapshot changes
- `cargo clippy -p sm-front/-p sm-vm/-p sm-verify/--workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace --quiet` (via admission_guard + 7hell): 0 failures workspace-wide
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**, including Hell 2's trust-boundary dependency-graph guard confirming the new sm-ir dev-dependency doesn't leak into the normal dependency graph

Three independent adversarial review lenses (semantic, trust/boundary, qualification) were run against the committed diff before push. Semantic and trust/boundary PASSed cleanly; qualification's finding on test #6 is addressed above.

## Scope

No shared call-resolution crate introduced. `Opcode::Call` encoding, `ClosureCall`, builtin capability bit assignments, SemCode headers, `builtin_call_required_capabilities`, and builtin implementations are all unchanged. `#1751`/`#1752`/`#1753` not started as part of this PR.
