### PR TITLE
fix(sm-verify): ignore inactive call destination register

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -1310,9 +1310,15 @@ fn decode_operands(
                     "non-canonical call destination flag: must be 0 or 1",
                 ));
             }
-            let dst =
-                read_u16_le(code, cursor).map_err(|_| invalid("truncated call dst register"))?;
-            mark_reg(dst);
+            let has_dst = has_dst_flag != 0;
+            if has_dst {
+                let dst = read_u16_le(code, cursor)
+                    .map_err(|_| invalid("truncated call dst register"))?;
+                mark_reg(dst);
+            } else {
+                let _ = read_u16_le(code, cursor)
+                    .map_err(|_| invalid("truncated call dst register"))?;
+            }
             let sid =
                 read_u16_le(code, cursor).map_err(|_| invalid("truncated callee string id"))?;
             refs.string_refs.push((offset, sid as usize, "call target"));
@@ -2228,6 +2234,91 @@ mod tests {
             report.diagnostics[0].code,
             VerificationCode::OperandOutOfBounds
         );
+    }
+
+    // FA-07-013 (#1753): a no-destination CALL (has_dst=0) must not count its
+    // ignored dst placeholder as a live register reference. The emitter
+    // writes a dummy dst field even when has_dst=0; that dummy value must
+    // never reach mark_reg, so an oversized placeholder must not spuriously
+    // blow the register budget.
+    #[test]
+    fn verifier_accepts_call_no_dst_with_out_of_budget_placeholder() {
+        let mut bytes =
+            compile_program_to_semcode("fn helper() { return; } fn main() { helper(); return; }")
+                .expect("compile");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::Call, 0);
+        assert_eq!(
+            bytes[opcode_pos + 1],
+            0u8,
+            "expected has_dst=0 for a no-assignment call"
+        );
+        let dst_pos = opcode_pos + 2;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
+        verify_semcode(&bytes).expect("no-dst call must ignore its dummy dst placeholder");
+    }
+
+    // FA-07-013 (#1753) control: a CALL that genuinely has a destination
+    // (has_dst=1) must still have that real dst register validated against
+    // the register budget - the fix must not blanket-skip mark_reg.
+    #[test]
+    fn verifier_rejects_call_real_dst_past_register_budget() {
+        let mut bytes = compile_program_to_semcode(
+            "fn helper() -> bool { return true; } fn main() { let a: bool = helper(); return; }",
+        )
+        .expect("compile");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::Call, 0);
+        assert_eq!(
+            bytes[opcode_pos + 1],
+            1u8,
+            "expected has_dst=1 for an assigned call"
+        );
+        let dst_pos = opcode_pos + 2;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
+        let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::InvalidRegisterReference
+        );
+    }
+
+    // FA-07-013 (#1753) control: CLOSURE_CALL already ignores its dummy dst
+    // placeholder when has_dst=0 - this locks in that reference behavior
+    // that Opcode::Call's decode_operands branch was made to mirror.
+    #[test]
+    fn verifier_accepts_closure_call_no_dst_with_out_of_budget_placeholder() {
+        let mut bytes = emit_ir_to_semcode(
+            &[
+                IrFunction {
+                    name: "helper".to_string(),
+                    instrs: vec![IrInstr::Ret { src: None }],
+                    ownership_events: Vec::new(),
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    instrs: vec![
+                        IrInstr::MakeClosure {
+                            dst: 0,
+                            name: "helper".to_string(),
+                            captures: Vec::new(),
+                        },
+                        IrInstr::ClosureCall {
+                            dst: None,
+                            closure: 0,
+                            arg: 0,
+                        },
+                        IrInstr::Ret { src: None },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+            ],
+            false,
+        )
+        .expect("emit");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::ClosureCall, 0);
+        assert_eq!(bytes[opcode_pos + 1], 0u8, "expected has_dst=0");
+        let dst_pos = opcode_pos + 2;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
+        verify_semcode(&bytes).expect("no-dst closure-call must ignore its dummy dst placeholder");
     }
 
     // FA-07-003 (#1743): CLOSURE_CALL's destination-present flag must be


### PR DESCRIPTION
Closes #1753
Umbrella #1617

## Root cause

`Opcode::Call`'s encoding physically contains a `dst` field even when `has_dst = 0` (the emitter always writes a dummy placeholder byte for a no-assignment call). `decode_operands()`'s `Opcode::Call` branch read this placeholder and called `mark_reg(dst)` **unconditionally**, regardless of `has_dst_flag`:

```rust
let dst = read_u16_le(code, cursor).map_err(|_| invalid("truncated call dst register"))?;
mark_reg(dst);
```

`mark_reg` folds the register index into `refs.max_register`, later checked against the register budget and rejected as `InvalidRegisterReference` if exceeded. So a `has_dst=0` CALL whose placeholder byte happens to encode a large register number spuriously inflated `max_register` and could trigger a bogus rejection, even though the VM never reads/uses that placeholder when `has_dst` is false.

`Opcode::ClosureCall` already had the correct reference pattern: reads the placeholder unconditionally (cursor still advances), but only calls `mark_reg` when `has_dst != 0`.

## Pre-fix reproduction

Compiled `fn helper() { return; } fn main() { helper(); return; }` (a no-assignment call naturally emits `has_dst=0`), located the CALL instruction via the existing `find_instruction` helper, confirmed `bytes[opcode_pos+1] == 0`, then byte-patched the dummy `dst` field (at `opcode_pos+2`) to `5000u16` (over the 4096 register budget) while leaving `has_dst=0`. Pre-fix result:

```
Err(RejectReport { diagnostics: [VerificationDiagnostic {
    code: InvalidRegisterReference, function: Some("main"), offset: Some(5000),
    message: "function references register r5000, exceeding the verified-local register budget of 4096"
}] })
```

Confirmed this is genuinely a bug: a register that is never live was spuriously rejected.

## VM / ClosureCall reference semantics

`crates/sm-vm/src/semcode_vm.rs`'s `Opcode::Call` execution branch already correctly never observes `dst` when `has_dst` is false (`if has_dst { set_reg(...) }` / `push_frame(vm, &callee, args, if has_dst { Some(dst) } else { None })`) — this is provably a verifier-only fix, no VM change needed. Confirmed by an analogous byte-patched `ClosureCall` (`has_dst=0`, out-of-budget placeholder): it already **accepted** pre-fix, confirming `ClosureCall` was already handling this correctly and is the correct reference pattern to mirror.

## Repair

```rust
let has_dst = has_dst_flag != 0;
if has_dst {
    let dst = read_u16_le(code, cursor).map_err(|_| invalid("truncated call dst register"))?;
    mark_reg(dst);
} else {
    let _ = read_u16_le(code, cursor).map_err(|_| invalid("truncated call dst register"))?;
}
```

The canonical-domain check (`has_dst_flag > 1` rejection) directly above is completely untouched. The `dst` u16 field is still unconditionally read from the byte stream in both branches — only whether it's passed to `mark_reg` is now conditional, exactly mirroring `ClosureCall`.

## Structural decoding preservation

`decode_operands` has exactly two other production call sites: the real semantic walk (`verify_function_code`, which *does* use `refs.max_register`) and `instruction_stream_parses_fully` (the #1731 ambiguous-framing check, `enforce_canonical_domains=false`), which discards the entire `OperandRefs` return value and only checks `.is_err()` — it never touches `.max_register`. Since this fix only changes *whether* `mark_reg` is invoked, not any byte read or cursor advancement, the ambiguity-framing check is provably unaffected.

## Regression matrix

1. `verifier_accepts_call_no_dst_with_out_of_budget_placeholder` — CALL, has_dst=0, dummy dst out of budget -> **ACCEPT** (new, genuinely fails pre-fix).
2. `verifier_rejects_call_real_dst_past_register_budget` — CALL, has_dst=1, real dst out of budget -> still **Reject(InvalidRegisterReference)** (new control, proves a real destination is still validated, the fix is not a blanket skip).
3. CALL, has_dst=1, valid dst -> already covered by the large existing accepted-semcode corpus, confirmed still passing.
4. `verifier_rejects_non_canonical_call_dst_flag` (pre-existing, FA-07-003 #1743) -> still rejects, canonical 0/1 flag check untouched.
5. `verifier_accepts_closure_call_no_dst_with_out_of_budget_placeholder` — new, formalizes the ClosureCall reference/control behavior this fix now mirrors.

Full `sm-verify` suite: 97/97 pass.

## Validation

- `cargo test -p sm-verify --features sm-ir/profile-rust`: 97/97 pass
- `cargo test -p sm-vm --all-features`: pass (confirms runtime CALL semantics untouched)
- `cargo test --test public_api_contracts`: 5/5 pass, zero snapshot changes
- `cargo clippy -p sm-verify --all-targets --features sm-ir/profile-rust -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

Three independent adversarial review lenses (semantic, decoder/boundary, qualification) were run against the committed diff before push — all three PASSed cleanly, including empirical confirmation (via a throwaway worktree grafting the exact new test onto unmodified `main`) that the no-dst test genuinely fails on old code, and that the has_dst=1 test is correctly a preservation/control check.

## Scope

`crates/sm-vm/` untouched — verifier-only fix. `Opcode::ClosureCall`, CALL wire format, register quota values, and the public API are unchanged. Independent of and not stacked on Repair Unit A (#1653+#1750, PR #1817) — confirmed via `git merge-base main HEAD` equaling clean main's tip. `#1751`, `#1752`, `#1754+`, `#1755`, `#1756`, `#1770`, `#1808` untouched.
