### PR TITLE
fix(sm-verify): separate function count from frame quota

### DIFF
--- a/crates/sm-format/src/semcode_decode.rs
+++ b/crates/sm-format/src/semcode_decode.rs
@@ -468,6 +468,41 @@ mod tests {
     // index panic, not a decode error. This is the exact artifact shape
     // that reproduced `slice index starts at 18 but ends at 2` under
     // `cargo test --target i686-pc-windows-msvc --release`.
+    // #1751 (FA-07-011): sm-format is sole owner of the static function-count
+    // bound (`MAX_FUNCTIONS`). This confirms the decoder still enforces it
+    // directly (independent of, and unaffected by, sm-verify no longer
+    // conflating function-definition count with the runtime frame quota).
+    fn minimal_function_bytes(name: &str) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(name.as_bytes());
+        bytes.extend_from_slice(&2u32.to_le_bytes()); // code_len: 2 bytes
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // empty string table
+        bytes
+    }
+
+    #[test]
+    fn decode_accepts_exactly_max_functions() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC0);
+        for i in 0..MAX_FUNCTIONS {
+            bytes.extend_from_slice(&minimal_function_bytes(&format!("f{i}")));
+        }
+        let (_, functions) = decode_semcode_envelope(&bytes).expect("must accept MAX_FUNCTIONS");
+        assert_eq!(functions.len(), MAX_FUNCTIONS);
+    }
+
+    #[test]
+    fn decode_rejects_one_more_than_max_functions() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MAGIC0);
+        for i in 0..(MAX_FUNCTIONS + 1) {
+            bytes.extend_from_slice(&minimal_function_bytes(&format!("f{i}")));
+        }
+        let err = decode_semcode_envelope(&bytes).expect_err("must reject over MAX_FUNCTIONS");
+        assert!(matches!(err, DecodeError::ResourceLimit { .. }));
+    }
+
     #[test]
     fn decode_rejects_code_len_that_would_overflow_cursor_arithmetic() {
         let mut bytes = Vec::new();

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -344,19 +344,6 @@ pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectR
         }
     }
 
-    if pending_functions.len() > quotas.max_frames {
-        diagnostics.push(diag(
-            VerificationCode::ResourceLimitExceeded,
-            None,
-            None,
-            format!(
-                "program defines {} functions, which exceeds the verified-local frame budget of {}",
-                pending_functions.len(),
-                quotas.max_frames
-            ),
-        ));
-    }
-
     if header.capabilities & CAP_OWNERSHIP_PATHS != 0
         && !pending_functions
             .iter()
@@ -3724,5 +3711,39 @@ mod tests {
         assert_eq!(&bytes[0..8], b"SEMCOD18");
         let verified = verify_semcode(&bytes).expect("emitted QTruth program must verify");
         assert_eq!(verified.header.rev, 19);
+    }
+
+    // #1751 (FA-07-011): `pending_functions.len()` is a static count of
+    // function definitions in the whole program; `quotas.max_frames` is a
+    // dynamic runtime call-stack-depth budget enforced independently (and
+    // correctly) at execution time in sm-vm's `push_frame`. Comparing the
+    // two conflated "how many functions exist" with "how deep can the call
+    // stack get". sm-format already owns the real static function-count
+    // bound (`MAX_FUNCTIONS = 1024`, enforced at decode time), so the
+    // verifier must not duplicate or misuse `max_frames` for this purpose.
+    #[test]
+    fn verify_semcode_token_accepts_many_function_definitions_regardless_of_frame_quota() {
+        // Control: previously accepted (256 total functions, at the old
+        // static bound) and must remain accepted.
+        let bytes_256 = compile_many_functions(255);
+        verify_semcode_token(&bytes_256).expect("256 functions must be accepted");
+
+        // #1751 repro: previously rejected with ResourceLimitExceeded citing
+        // "verified-local frame budget of 256" purely because the program
+        // defines more functions than the runtime frame quota - a static
+        // function count has nothing to do with live call-stack depth, so
+        // this must now be accepted.
+        let bytes_258 = compile_many_functions(257);
+        verify_semcode_token(&bytes_258)
+            .expect("function count must not be checked against the runtime frame quota");
+    }
+
+    fn compile_many_functions(extra_fn_count: usize) -> Vec<u8> {
+        let mut src = String::new();
+        for i in 0..extra_fn_count {
+            src.push_str(&format!("fn fn_{i}() {{ return; }}\n"));
+        }
+        src.push_str("fn main() { return; }");
+        compile_program_to_semcode(&src).expect("compile")
     }
 }

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -5498,6 +5498,31 @@ mod tests {
         assert_eq!(err, RuntimeError::StackOverflow);
     }
 
+    // #1751 (FA-07-011): proves `max_frames` is still enforced against live
+    // call-stack depth at execution time (in `push_frame`) after sm-verify
+    // stopped misusing the same field name as a static function-definition
+    // count. A real 2-level call chain (main -> helper) must still trap once
+    // it genuinely exceeds a shrunk frame budget.
+    #[test]
+    fn vm_enforces_configured_frame_budget() {
+        let src = r#"
+            fn helper() { return; }
+            fn main() { helper(); return; }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let mut config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
+        config.quotas.max_frames = 1;
+        let err = run_semcode_with_config(&bytes, config).expect_err("must fail");
+        assert_eq!(
+            err,
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::Frames,
+                limit: 1,
+                used: 2,
+            })
+        );
+    }
+
     #[test]
     fn vm_enforces_configured_register_budget() {
         let src = r#"

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -37,7 +37,10 @@ Current SemCode verification checks include:
 
 - header validity
 - supported version validity
-- function and section integrity
+- function and section integrity (the number of function definitions in an
+  artifact is a static structural bound owned by `sm-format`
+  (`MAX_FUNCTIONS`), independent of any runtime resource quota; the verifier
+  does not re-derive or narrow it from a quota profile)
 - canonical (unambiguous) instruction framing
 - opcode validity
 - opcode/header-revision consistency


### PR DESCRIPTION
Closes #1751
Umbrella #1617

## Root cause

`verify_semcode_token()` (`crates/sm-verify/src/lib.rs`) contained:

```rust
if pending_functions.len() > quotas.max_frames {
    diagnostics.push(diag(VerificationCode::ResourceLimitExceeded, None, None,
        format!("program defines {} functions, which exceeds the verified-local frame budget of {}", pending_functions.len(), quotas.max_frames)));
}
```

`pending_functions.len()` is a **static count of function definitions**. `quotas.max_frames` (`RuntimeQuotas::verified_local()` = 256) is a **dynamic runtime call-stack-depth budget**, already correctly and independently enforced at actual execution time in `crates/sm-vm/src/semcode_vm.rs`'s `push_frame()`:

```rust
let next_depth = vm.callstack.len() + 1;
enforce_quota(&vm.config.quotas, QuotaKind::Frames, next_depth)?;
```

That runtime check measures live call-stack depth and is correct — untouched by this PR. The verifier's static check conflated "how many functions exist in the artifact" with "how deep can the call stack get." The real static function-count bound already belongs to `sm-format`: `pub const MAX_FUNCTIONS: usize = 1024;` (`crates/sm-format/src/semcode_decode.rs`), enforced at decode time.

## Pre-fix reproduction

258 trivial function definitions (`fn_0`..`fn_256` + `main`) — well under sm-format's 1024 `MAX_FUNCTIONS`:
- `decode_semcode_envelope` → success.
- `verify_semcode_token` → `Reject(ResourceLimitExceeded)`: *"program defines 258 functions, which exceeds the verified-local frame budget of 256"*.

Control: 256 total functions (the old static bound) confirmed `Accept` pre-fix, as expected.

## Static-vs-runtime resource identity

| Resource | Owner | Bound |
|---|---|---|
| Static function-definition count | `sm-format` (decode time) | `MAX_FUNCTIONS = 1024` |
| Dynamic call-stack depth | `sm-vm` (execution time) | `RuntimeQuotas.max_frames` (256 for VerifiedLocal) |

`sm-verify` must not equate the two. This PR removes the equation; it does not touch either owner.

## Repair

Removed the `pending_functions.len() > quotas.max_frames` check entirely. No replacement static constant was added — `sm-format`'s `MAX_FUNCTIONS` already owns this bound and is untouched.

## Decoder bound preservation

Added two new sm-format tests confirming `MAX_FUNCTIONS = 1024` enforcement is completely untouched: `decode_accepts_exactly_max_functions` (1024 functions decode OK) and `decode_rejects_one_more_than_max_functions` (1025 → `DecodeError::ResourceLimit`).

## Runtime frame enforcement preservation

Added `vm_enforces_configured_frame_budget` (`crates/sm-vm/src/semcode_vm.rs`): a real 2-level call chain (`main` → `helper`) with `config.quotas.max_frames` shrunk to `1` — confirms `push_frame`'s live-callstack-depth enforcement still traps with `RuntimeError::QuotaExceeded(QuotaKind::Frames, limit: 1, used: 2)`, completely unaffected by the verifier fix.

## Regression matrix

1. 256 total functions → Accept (control, unchanged).
2. 258 total functions → pre-fix Reject, post-fix Accept (the fix, reused as the permanent test).
3. sm-format `MAX_FUNCTIONS` boundary (1024/1025) → decoder still enforces (new tests, since none existed before).
4. Real runtime frame exhaustion → still fails dynamically (new test).

## Validation

- `cargo test -p sm-verify --features sm-ir/profile-rust`: 98/98 pass
- `cargo test -p sm-format --all-features`: 21/21 pass
- `cargo test -p sm-runtime-core --all-features`: 9/9 pass (untouched)
- `cargo test -p sm-vm --all-features`: 107+1+23 pass
- `cargo test --test public_api_contracts`: 5/5 pass, zero snapshot changes
- `cargo clippy -p sm-verify/--workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

Three independent adversarial review lenses (semantic, boundary, qualification) run against the committed diff before push — all three PASSed cleanly, including empirical confirmation (via a disposable worktree at the pre-fix commit) that the 258-function reproduction genuinely fails on unmodified `main`.

## Scope

`crates/sm-format/` and `crates/sm-vm/src/semcode_vm.rs`'s production logic are untouched (test-only additions). No new dependency. `#1754`, `#1757` (independent, separate PRs), `#1752`, `#1755`, `#1756`, `#1758`, `#1808` untouched.

## Batch conflict note

This PR and `#1754`/`#1757`'s PRs all touch `crates/sm-verify/src/lib.rs`. All are individually clean now (each built from the same clean main), but merging one first will require a rebase + CI rerun on the others before they can merge, per the batch's own expected merge sequence.
