### PR TITLE
fix(sm-verify): enforce program-wide symbol quota

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -344,6 +344,32 @@ pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectR
         }
     }
 
+    // #1754 (FA-07-014): the VM builds ONE program-wide `RuntimeSymbolTable`
+    // shared across every function (see `build_vm_program_view_from_decoded`
+    // in crates/sm-vm/src/semcode_vm.rs), interning each function's
+    // `env.strings` into it and deduplicating by exact string value. A
+    // per-function check against `max_symbol_table` cannot catch a program
+    // that stays under the budget in every individual function but exceeds
+    // it once all functions' distinct strings are unioned program-wide, so
+    // the check has to be made at this granularity to match the real
+    // runtime resource.
+    let unique_runtime_symbols: HashSet<&str> = decoded_functions
+        .iter()
+        .flat_map(|env| env.strings.iter().map(|s| s.as_str()))
+        .collect();
+    let unique_runtime_symbol_count = unique_runtime_symbols.len();
+    if unique_runtime_symbol_count > quotas.max_symbol_table {
+        diagnostics.push(diag(
+            VerificationCode::ResourceLimitExceeded,
+            None,
+            None,
+            format!(
+                "program-wide runtime symbol table uses {} distinct entries, exceeding the verified-local symbol budget of {}",
+                unique_runtime_symbol_count, quotas.max_symbol_table
+            ),
+        ));
+    }
+
     if header.capabilities & CAP_OWNERSHIP_PATHS != 0
         && !pending_functions
             .iter()
@@ -488,18 +514,18 @@ fn verify_function_code(
         ));
     }
 
+    // #1754 (FA-07-014): a per-function string-table check against
+    // `max_symbol_table` used to live here, but sm-format already caps each
+    // function's local string table at `MAX_STRINGS_PER_FUNCTION` (256, see
+    // semcode_decode.rs), which is far below `max_symbol_table` (16_384) -
+    // making that check dead code. The real program-wide resource is the VM's
+    // `RuntimeSymbolTable` (crates/sm-runtime-core/src/lib.rs), which is
+    // built ONCE per program and shared across every function (see
+    // `build_vm_program_view_from_decoded` in crates/sm-vm/src/semcode_vm.rs,
+    // which interns each function's `env.strings` into a single
+    // program-wide, dedup-by-value table). That budget is enforced
+    // program-wide in `verify_semcode_token` instead, see the check there.
     let string_count = env.strings.len();
-    if string_count > quotas.max_symbol_table {
-        return Err(reject_one(
-            name,
-            VerificationCode::ResourceLimitExceeded,
-            0,
-            format!(
-                "function string table uses {} entries, exceeding the verified-local symbol budget of {}",
-                string_count, quotas.max_symbol_table
-            ),
-        ));
-    }
 
     let debug_symbol_count = env.debug_symbols.len();
     if debug_symbol_count > quotas.max_trace_entries {
@@ -3745,5 +3771,139 @@ mod tests {
         }
         src.push_str("fn main() { return; }");
         compile_program_to_semcode(&src).expect("compile")
+    }
+
+    // #1754 (FA-07-014) test matrix: the verifier must sum DISTINCT
+    // runtime symbols (function-local string-table entries, deduplicated
+    // by exact value) across the WHOLE program against max_symbol_table
+    // (16_384), matching the VM's single shared `RuntimeSymbolTable`
+    // (crates/sm-runtime-core/src/lib.rs), not a per-function check.
+
+    fn function_with_strings(name: &str, strings: &[String]) -> IrFunction {
+        let mut instrs: Vec<IrInstr> = strings
+            .iter()
+            .map(|s| IrInstr::LoadText {
+                dst: 0,
+                val: s.clone(),
+            })
+            .collect();
+        instrs.push(IrInstr::Ret { src: None });
+        IrFunction {
+            name: name.to_string(),
+            instrs,
+            ownership_events: Vec::new(),
+        }
+    }
+
+    /// Union of every function's local strings, deduplicated by value -
+    /// the same quantity `RuntimeSymbolTable` (via
+    /// `build_vm_program_view_from_decoded`) ends up holding.
+    fn distinct_runtime_symbol_count(bytes: &[u8]) -> usize {
+        let (_, decoded) =
+            sm_format::semcode_decode::decode_semcode_envelope(bytes).expect("decode");
+        decoded
+            .iter()
+            .flat_map(|env| env.strings.iter().map(|s| s.as_str()))
+            .collect::<HashSet<_>>()
+            .len()
+    }
+
+    #[test]
+    fn verifier_accepts_heavy_duplication_under_program_wide_symbol_quota() {
+        // 165 functions x 100 strings, but every function reuses the exact
+        // same 100 string values: raw per-function-summed entries
+        // (16_500) exceed max_symbol_table, while the DISTINCT program-wide
+        // count (100) stays far under it. A naive "sum all local string
+        // table lengths" implementation would wrongly reject this; the
+        // correct dedup-by-value implementation must accept it.
+        let shared_strings: Vec<String> = (0..100).map(|j| format!("dup_s{j}")).collect();
+        let funcs: Vec<IrFunction> = (0..165)
+            .map(|i| function_with_strings(&format!("f{i}"), &shared_strings))
+            .collect();
+        let bytes = emit_ir_to_semcode(&funcs, false).expect("emit");
+
+        let raw_sum: usize = funcs.len() * shared_strings.len();
+        assert!(
+            raw_sum > 16_384,
+            "raw sum must exceed the quota to be a meaningful control"
+        );
+        let distinct = distinct_runtime_symbol_count(&bytes);
+        assert_eq!(distinct, 100);
+        assert!(distinct <= 16_384);
+
+        verify_semcode_token(&bytes)
+            .expect("duplicate-heavy program under the distinct-symbol quota must be accepted");
+    }
+
+    #[test]
+    fn verifier_accepts_program_wide_symbols_at_exact_quota_boundary() {
+        // 64 functions x 256 strings, all globally distinct, each function
+        // exactly at sm-format's MAX_STRINGS_PER_FUNCTION cap: 64 * 256 =
+        // 16_384, exactly max_symbol_table. This hits the boundary exactly.
+        let functions_count = 64usize;
+        let strings_per_function = 256usize;
+        assert_eq!(functions_count * strings_per_function, 16_384);
+        assert_eq!(
+            strings_per_function,
+            sm_format::semcode_decode::MAX_STRINGS_PER_FUNCTION
+        );
+
+        let funcs: Vec<IrFunction> = (0..functions_count)
+            .map(|i| {
+                let strings: Vec<String> = (0..strings_per_function)
+                    .map(|j| format!("b{i}_{j}"))
+                    .collect();
+                function_with_strings(&format!("f{i}"), &strings)
+            })
+            .collect();
+        let bytes = emit_ir_to_semcode(&funcs, false).expect("emit");
+
+        let distinct = distinct_runtime_symbol_count(&bytes);
+        assert_eq!(distinct, 16_384);
+
+        verify_semcode_token(&bytes)
+            .expect("program exactly at the symbol quota boundary must be accepted");
+    }
+
+    #[test]
+    fn verifier_rejects_program_wide_symbols_over_quota() {
+        // Permanent regression test for the #1754 reproduction: 66
+        // functions x 250 globally-distinct strings each (66 * 250 =
+        // 16_500 > 16_384), with every individual function's local string
+        // table staying at 250 <= MAX_STRINGS_PER_FUNCTION (256) - proving
+        // this is caught only by GLOBAL, program-wide accounting, not by
+        // any per-function limit.
+        let functions_count = 66usize;
+        let strings_per_function = 250usize;
+        assert!(strings_per_function <= sm_format::semcode_decode::MAX_STRINGS_PER_FUNCTION);
+        assert!(functions_count <= 256); // stay under the unrelated #1751 max_frames check
+
+        let funcs: Vec<IrFunction> = (0..functions_count)
+            .map(|i| {
+                let strings: Vec<String> = (0..strings_per_function)
+                    .map(|j| format!("f{i}_s{j}"))
+                    .collect();
+                function_with_strings(&format!("f{i}"), &strings)
+            })
+            .collect();
+        let bytes = emit_ir_to_semcode(&funcs, false).expect("emit");
+
+        let distinct = distinct_runtime_symbol_count(&bytes);
+        assert_eq!(distinct, functions_count * strings_per_function);
+        assert!(distinct > 16_384);
+
+        let report = verify_semcode_token(&bytes)
+            .expect_err("program-wide distinct runtime symbol count over quota must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::ResourceLimitExceeded
+        );
+        assert!(
+            report.diagnostics[0]
+                .message
+                .contains("program-wide runtime symbol table"),
+            "diagnostic message must name the program-wide runtime symbol table: {}",
+            report.diagnostics[0].message
+        );
     }
 }

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -6150,4 +6150,59 @@ mod tests {
             "unexpected error: {err:?}"
         );
     }
+
+    // #1754 (FA-07-014): cross-check that sm-verify's program-wide distinct
+    // runtime symbol count (union of every function's local strings,
+    // deduped by exact value) matches what `build_vm_program_view_from_decoded`
+    // actually builds into `RuntimeSymbolTable`, for a representative
+    // multi-function artifact that reuses some strings across functions.
+    // No new production API: `build_vm_program_view_from_decoded` is an
+    // existing private fn in this same module, called directly from this
+    // in-crate test.
+    #[test]
+    fn program_wide_symbol_table_matches_verifier_distinct_count() {
+        use sm_ir::{IrFunction, IrInstr};
+
+        // f0: a,b,c ; f1: b,c,d (b,c shared with f0) ; f2: d,e (d shared with f1)
+        let make = |name: &str, strings: &[&str]| IrFunction {
+            name: name.to_string(),
+            instrs: {
+                let mut instrs: Vec<IrInstr> = strings
+                    .iter()
+                    .map(|s| IrInstr::LoadText {
+                        dst: 0,
+                        val: s.to_string(),
+                    })
+                    .collect();
+                instrs.push(IrInstr::Ret { src: None });
+                instrs
+            },
+            ownership_events: Vec::new(),
+        };
+        let funcs = vec![
+            make("f0", &["a", "b", "c"]),
+            make("f1", &["b", "c", "d"]),
+            make("f2", &["d", "e"]),
+        ];
+        let bytes = sm_emit::emit_ir_to_semcode(&funcs, false).expect("emit");
+
+        // sm-verify must accept it (well under quota).
+        sm_verify::verify_semcode_token(&bytes).expect("small duplicate-string program admits");
+
+        // The verifier's counting algorithm, mirrored here: union of every
+        // function's local strings, deduped by value.
+        let (header, decoded) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let verifier_style_distinct = decoded
+            .iter()
+            .flat_map(|env| env.strings.iter().map(|s| s.as_str()))
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        assert_eq!(verifier_style_distinct, 5); // a, b, c, d, e
+
+        // The REAL VM resource, built the same way execution builds it.
+        let program =
+            build_vm_program_view_from_decoded(header, &decoded).expect("build vm program view");
+        assert_eq!(program.runtime_symbols.len(), verifier_style_distinct);
+    }
 }

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -49,6 +49,9 @@ Current SemCode verification checks include:
 - reachable control-flow closure (no end-of-stream fallthrough)
 - string and debug reference validity
 - register-budget validity
+- program-wide runtime symbol-table budget validity (the number of *distinct*
+  strings the VM will intern across every function, deduplicated by exact
+  string value program-wide - not a per-function string-table entry count)
 - call-target validity
 - capability consistency with actual opcode usage
 


### PR DESCRIPTION
Closes #1754
Umbrella #1617

## Root cause

`verify_function_code()` (`crates/sm-verify/src/lib.rs`) checked one function's local string-table entry count against `quotas.max_symbol_table`:

```rust
let string_count = env.strings.len();
if string_count > quotas.max_symbol_table {
    return Err(reject_one(name, VerificationCode::ResourceLimitExceeded, 0, ...));
}
```

But `sm-format` already caps each function's local string table at `MAX_STRINGS_PER_FUNCTION = 256` (`crates/sm-format/src/semcode_decode.rs`) — far below `max_symbol_table` (16,384 in `RuntimeQuotas::verified_local()`). This check could **never fire** for any successfully-decoded program: it was dead code. Nothing anywhere summed string usage *across* all functions against the real program-wide resource.

## Exact VM symbol-table construction inventory

Confirmed by direct code reading (re-verified live, not assumed): `build_vm_program_view_from_decoded()` (`crates/sm-vm/src/semcode_vm.rs`) declares **one** `RuntimeSymbolTable` before looping over all decoded functions, and interns only `env.strings` (function-local string-table entries) into it:

| Category | Interned into `RuntimeSymbolTable`? |
|---|---|
| Function-local string-table entries (`env.strings`) | **Yes** |
| Function names | No (kept as `HashMap` keys) |
| Ownership/access-path names | N/A — numeric indices only, already remapped through interned strings |
| Debug symbol names | N/A — this format has no debug symbol *names*, only positional pc/line/col |

`RuntimeSymbolTable::intern` (`crates/sm-runtime-core/src/lib.rs`) dedups by exact string value via a `BTreeMap<String, SymbolId>` index, **program-wide** (one shared instance across the whole function loop) — two functions using the identical string count as one runtime symbol, not two.

## Pre-fix reproduction

66 hand-built IR functions × 250 globally-distinct string literals each (16,500 distinct strings total; each function stays at 250 ≤ sm-format's 256-per-function cap; 66 functions stays well under the pre-existing static function-count check so the independent #1751 issue isn't tripped). Directly measured the real runtime resource by unioning every function's `env.strings` into a `HashSet` (mirroring the VM's own intern loop exactly) → 16,500 distinct entries, > `max_symbol_table` (16,384). Pre-fix: `verify_semcode_token` → **Accept** anyway.

## Distinct-vs-entry semantics

The verifier must count **distinct runtime symbols**, not raw string-table entries. A program with heavy cross-function string reuse can have a raw entry sum far above 16,384 while its actual distinct/deduplicated set stays well under budget — and must be accepted.

## Program-wide repair

Removed the dead per-function check from `verify_function_code` (with a comment pointing to where the real check now lives). Added one program-wide check in `verify_semcode_token`, at the point where all decoded functions are already available:

```rust
let unique_runtime_symbols: HashSet<&str> = decoded_functions
    .iter()
    .flat_map(|env| env.strings.iter().map(|s| s.as_str()))
    .collect();
if unique_runtime_symbols.len() > quotas.max_symbol_table {
    // Deny: "program-wide runtime symbol table uses {N} distinct entries, exceeding the verified-local symbol budget of {limit}"
}
```

No dependency on `sm-vm` — the counting logic is a plain string-table union mirroring (not calling into) the VM's interning behavior.

## Per-function format bound preservation

`sm-format`'s `MAX_STRINGS_PER_FUNCTION = 256` enforcement is completely untouched — confirmed every function in every regression test individually stays at or under that cap, proving the reproduction exercises **program-wide** granularity, not a locally-malformed input.

## Regression matrix

1. Heavy duplication (165 functions × 100 shared strings; raw sum 16,500 > 16,384, but distinct = 100 ≤ 16,384) → **Accept** — proves a naive "sum all entries" implementation would have wrongly rejected this, while the correct dedup implementation accepts it.
2. Distinct symbols exactly at the boundary (64 functions × 256 strings each = 16,384 exactly) → **Accept**.
3. Distinct symbols over the limit (66 functions × 250 globally-distinct strings = 16,500) → **Reject(ResourceLimitExceeded)** — the pre-fix reproduction, now a permanent test.
4. Every function individually ≤ 256 strings in all reproductions.
5. Full existing sm-verify suite (97 pre-existing tests) unchanged.
6. VM-consistency: a new sm-vm test calls the real `build_vm_program_view_from_decoded` directly on a multi-function, string-sharing artifact and asserts the resulting `RuntimeSymbolTable`'s actual size matches the verifier's independently-computed distinct count — no new production API was added to enable this (same-crate test access to the existing private function).

## Validation

- `cargo test -p sm-verify --features sm-ir/profile-rust`: 100/100 pass (97 pre-existing + 3 new)
- `cargo test -p sm-runtime-core --all-features`: 9/9 pass
- `cargo test -p sm-vm --all-features`: 107+1+23 pass (includes the new VM-consistency test)
- `cargo test -p sm-format --all-features`: 19/19 pass
- `cargo test --test public_api_contracts`: 5/5 pass, zero snapshot changes
- `cargo clippy -p sm-verify/--workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS** (Hell 2's trust-boundary guards confirm no `sm-verify → sm-vm` dependency was introduced)

Three independent adversarial review lenses (semantic, boundary, qualification) run against the committed diff before push — all three PASSed cleanly.

## Scope

`crates/sm-vm/`'s production logic and `crates/sm-runtime-core/` are untouched. No new dependency. `#1751`, `#1757` (independent, separate PRs), `#1752`, `#1755`, `#1756`, `#1758`, `#1808` untouched.

## Batch conflict note

This PR and `#1751`/`#1757`'s PRs all touch `crates/sm-verify/src/lib.rs`. Individually clean now, but expect a rebase + CI rerun on whichever merges second/third, per the batch's own expected merge sequence.
