### PR TITLE
fix(sm-verify): admit against explicit runtime quotas

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -244,11 +244,28 @@ impl<'a> VerifiedSemCode<'a> {
 ///
 /// This is the primary entry point for the canonical verified execution path.
 /// It validates raw SemCode bytes against admission policies and returns a
-/// `VerifiedSemCode` token if successful.
+/// `VerifiedSemCode` token if successful. Admits against the `VerifiedLocal`
+/// quota profile; use `verify_semcode_token_with_quotas` to admit against a
+/// different (e.g. `KernelBound`) profile.
 #[cfg(feature = "std")]
 pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectReport> {
+    verify_semcode_token_with_quotas(bytes, RuntimeQuotas::verified_local())
+}
+
+/// Admission gate for SemCode bytes against an explicit quota profile.
+///
+/// Identical to `verify_semcode_token` except the caller supplies the
+/// `RuntimeQuotas` admission is checked against, instead of the hardcoded
+/// `VerifiedLocal` profile. This lets a context (e.g. `KernelBound`) admit
+/// tokens whose register/symbol usage exceeds `VerifiedLocal`'s budget but
+/// stays within its own. The returned token's admission proof reflects only
+/// the quotas passed here - it says nothing about any other profile.
+#[cfg(feature = "std")]
+pub fn verify_semcode_token_with_quotas(
+    bytes: &[u8],
+    quotas: RuntimeQuotas,
+) -> Result<VerifiedSemCode<'_>, RejectReport> {
     let mut diagnostics = Vec::new();
-    let quotas = RuntimeQuotas::verified_local();
 
     let (header, decoded_functions) =
         match sm_format::semcode_decode::decode_semcode_envelope(bytes) {
@@ -364,7 +381,7 @@ pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectR
             None,
             None,
             format!(
-                "program-wide runtime symbol table uses {} distinct entries, exceeding the verified-local symbol budget of {}",
+                "program-wide runtime symbol table uses {} distinct entries, exceeding the symbol budget of {}",
                 unique_runtime_symbol_count, quotas.max_symbol_table
             ),
         ));
@@ -534,7 +551,7 @@ fn verify_function_code(
             VerificationCode::ResourceLimitExceeded,
             0,
             format!(
-                "debug section uses {} entries, exceeding the verified-local trace budget of {}",
+                "debug section uses {} entries, exceeding the trace budget of {}",
                 debug_symbol_count, quotas.max_trace_entries
             ),
         ));
@@ -739,7 +756,7 @@ fn verify_function_code(
                 VerificationCode::InvalidRegisterReference,
                 used - 1,
                 format!(
-                    "function references register r{}, exceeding the verified-local register budget of {}",
+                    "function references register r{}, exceeding the register budget of {}",
                     max_register, quotas.max_registers
                 ),
             ));
@@ -2190,6 +2207,83 @@ mod tests {
         assert_eq!(
             report.diagnostics[0].code,
             VerificationCode::InvalidRegisterReference
+        );
+    }
+
+    // #1757 (FA-07-017): a register above VerifiedLocal's 4096 budget but
+    // within KernelBound's 8192 budget must be rejected under the default
+    // (VerifiedLocal) admission gate.
+    #[test]
+    fn verify_semcode_token_default_still_rejects_register_past_verified_local_budget() {
+        let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
+            .expect("compile");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::LoadBool, 0);
+        let dst_pos = opcode_pos + 1;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
+        let report = verify_semcode_token(&bytes).expect_err("must reject under default quotas");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::InvalidRegisterReference
+        );
+    }
+
+    // The same register must be ACCEPTED when the caller explicitly admits
+    // against KernelBound quotas via the new quota-aware API.
+    #[test]
+    fn verify_semcode_token_with_quotas_accepts_register_within_kernel_bound_budget() {
+        let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
+            .expect("compile");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::LoadBool, 0);
+        let dst_pos = opcode_pos + 1;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
+        verify_semcode_token_with_quotas(&bytes, RuntimeQuotas::kernel_bound())
+            .expect("r5000 must be within KernelBound's register budget");
+    }
+
+    // KernelBound is not infinite: a register above its own 8192 budget must
+    // still be rejected even when explicitly admitting against KernelBound.
+    #[test]
+    fn verify_semcode_token_with_quotas_rejects_register_past_kernel_bound_budget() {
+        let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
+            .expect("compile");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::LoadBool, 0);
+        let dst_pos = opcode_pos + 1;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&8200u16.to_le_bytes());
+        let report = verify_semcode_token_with_quotas(&bytes, RuntimeQuotas::kernel_bound())
+            .expect_err("must reject past KernelBound's own register budget");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::InvalidRegisterReference
+        );
+    }
+
+    // No regression to the common path: an ordinary small artifact still
+    // admits cleanly under the unchanged default quota profile.
+    #[test]
+    fn verify_semcode_token_default_still_accepts_ordinary_artifact() {
+        let bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
+            .expect("compile");
+        verify_semcode_token(&bytes).expect("ordinary artifact must still admit");
+    }
+
+    // #1757 review follow-up: since quotas are now caller-supplied, a
+    // rejection diagnostic must not hardcode "verified-local" - that text
+    // would misidentify the active policy for any other profile (e.g. a
+    // KernelBound rejection reporting its 8192-register budget as if it
+    // were verified-local's, whose real budget is 4096).
+    #[test]
+    fn verify_semcode_token_with_quotas_rejection_message_does_not_hardcode_verified_local() {
+        let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
+            .expect("compile");
+        let opcode_pos = find_instruction(&bytes, "main", Opcode::LoadBool, 0);
+        let dst_pos = opcode_pos + 1;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&8200u16.to_le_bytes());
+        let report = verify_semcode_token_with_quotas(&bytes, RuntimeQuotas::kernel_bound())
+            .expect_err("must reject past KernelBound's own register budget");
+        assert!(
+            !report.diagnostics[0].message.contains("verified-local"),
+            "diagnostic must not claim a KernelBound rejection is a verified-local budget: {}",
+            report.diagnostics[0].message
         );
     }
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -16,7 +16,10 @@ use sm_runtime_core::{
     RecordCarrier, RuntimeQuotas, RuntimeSymbolTable, RuntimeTrap, SymbolId,
 };
 use sm_verify::RejectReport;
-use sm_verify::{verify_semcode_token, EntryResolutionError, VerifiedEntrySemCode};
+use sm_verify::{
+    verify_semcode_token, verify_semcode_token_with_quotas, EntryResolutionError,
+    VerifiedEntrySemCode,
+};
 use std::collections::{HashMap, HashSet};
 
 /// Scalar key type for Map values.
@@ -611,7 +614,8 @@ pub fn run_verified_semcode_with_config(
     bytes: &[u8],
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+    let token = verify_semcode_token_with_quotas(bytes, config.quotas)
+        .map_err(RuntimeError::VerifierRejected)?;
     let entry_token = token.require_entry("main").map_err(|err| match err {
         EntryResolutionError::MissingEntry { entry } => RuntimeError::UnknownFunction(entry),
     })?;
@@ -644,7 +648,8 @@ pub fn run_verified_semcode_with_entry_and_config(
     entry: &str,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+    let token = verify_semcode_token_with_quotas(bytes, config.quotas)
+        .map_err(RuntimeError::VerifierRejected)?;
     let entry_token = token.require_entry(entry).map_err(|err| match err {
         EntryResolutionError::MissingEntry { entry } => RuntimeError::UnknownFunction(entry),
     })?;
@@ -664,7 +669,9 @@ pub fn run_verified_semcode_with_host_and_capabilities<
     host: &mut H,
     capabilities: &C,
 ) -> Result<(), RuntimeError> {
-    let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+    let config = ExecutionConfig::for_context(ExecutionContext::KernelBound);
+    let token = verify_semcode_token_with_quotas(bytes, config.quotas)
+        .map_err(RuntimeError::VerifierRejected)?;
     let entry_token = token.require_entry("main").map_err(|err| match err {
         EntryResolutionError::MissingEntry { entry } => RuntimeError::UnknownFunction(entry),
     })?;
@@ -672,7 +679,7 @@ pub fn run_verified_semcode_with_host_and_capabilities<
         &entry_token,
         host,
         capabilities,
-        ExecutionConfig::for_context(ExecutionContext::KernelBound),
+        config,
     )
 }
 
@@ -691,7 +698,8 @@ pub fn run_verified_semcode_with_host_and_capabilities_and_config<
     capabilities: &C,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+    let token = verify_semcode_token_with_quotas(bytes, config.quotas)
+        .map_err(RuntimeError::VerifierRejected)?;
     let entry_token = token.require_entry(entry).map_err(|err| match err {
         EntryResolutionError::MissingEntry { entry } => RuntimeError::UnknownFunction(entry),
     })?;
@@ -713,7 +721,8 @@ pub fn run_verified_semcode_with_application_host_and_capabilities_and_config<
     capabilities: &C,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+    let token = verify_semcode_token_with_quotas(bytes, config.quotas)
+        .map_err(RuntimeError::VerifierRejected)?;
     let entry_token = token.require_entry(entry).map_err(|err| match err {
         EntryResolutionError::MissingEntry { entry } => RuntimeError::UnknownFunction(entry),
     })?;
@@ -4030,6 +4039,73 @@ mod tests {
         let mut config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
         config.quotas.max_stack_depth = 1;
         run_verified_entry_semcode_with_config(&entry_token, config).expect("run");
+    }
+
+    // #1757 (FA-07-017): builds "fn main() { let a: bool = true; return; }"
+    // and patches LOAD_BOOL's dst register operand to r5000 - the same
+    // fixture shape as sm-verify's own r5000 regression tests. LOAD_BOOL is
+    // the function's first instruction, so its absolute byte offset is just
+    // the function's code-slice start (recovered via pointer arithmetic,
+    // since `code_slice` is a genuine subslice of `bytes`) plus
+    // `instr_start_offset`.
+    fn build_r5000_register_artifact() -> Vec<u8> {
+        let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
+            .expect("compile");
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode semcode");
+        let env = functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("main function present");
+        let code_start = env.code_slice.as_ptr() as usize - bytes.as_ptr() as usize;
+        let opcode_pos = code_start + env.instr_start_offset;
+        assert_eq!(
+            bytes[opcode_pos],
+            Opcode::LoadBool as u8,
+            "expected LOAD_BOOL as main's first instruction"
+        );
+        let dst_pos = opcode_pos + 1;
+        bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
+        bytes
+    }
+
+    // Config-aware byte shim, KernelBound config: admission must now reach
+    // the shim's caller-supplied quotas, so r5000 (within KernelBound's 8192
+    // register budget) must no longer be rejected by the old hardcoded
+    // VerifiedLocal (4096) admission profile.
+    #[test]
+    fn run_verified_semcode_with_config_admits_r5000_under_kernel_bound_config() {
+        let bytes = build_r5000_register_artifact();
+        let config = ExecutionConfig::for_context(ExecutionContext::KernelBound);
+        run_verified_semcode_with_config(&bytes, config)
+            .expect("KernelBound config must admit and run an r5000 artifact");
+    }
+
+    // Same r5000 bytes, VerifiedLocal config: still rejected, proving the
+    // canonical stricter path is unaffected by the fix.
+    #[test]
+    fn run_verified_semcode_with_config_still_rejects_r5000_under_verified_local_config() {
+        let bytes = build_r5000_register_artifact();
+        let config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
+        let err = run_verified_semcode_with_config(&bytes, config)
+            .expect_err("VerifiedLocal config must still reject an r5000 artifact");
+        assert!(matches!(err, RuntimeError::VerifierRejected(_)));
+    }
+
+    // #1757 follow-up (found by adversarial review): the no-`_and_config`
+    // sibling `run_verified_semcode_with_host_and_capabilities` hardcodes
+    // KernelBound execution but was still admitting via the old
+    // hardcoded-VerifiedLocal `verify_semcode_token`. Fixed to admit under
+    // the same KernelBound quotas it executes with. r5000 (within
+    // KernelBound's 8192 register budget, over VerifiedLocal's 4096) must
+    // now be admitted and run instead of rejected at admission.
+    #[test]
+    fn run_verified_semcode_with_host_and_capabilities_admits_r5000_under_kernel_bound() {
+        let bytes = build_r5000_register_artifact();
+        let manifest = prom_cap::CapabilityManifest::new();
+        let mut host = prom_abi::RecordingHostAbi::default();
+        run_verified_semcode_with_host_and_capabilities(&bytes, &mut host, &manifest)
+            .expect("KernelBound-hardcoded shim must admit and run an r5000 artifact");
     }
 
     #[test]

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -25,7 +25,14 @@ Current verifier surface is centered on:
 
 Canonical token-producing admission path:
 
-- `verify_semcode_token`
+- `verify_semcode_token` — admits against the default `VerifiedLocal` resource
+  quota profile.
+- `verify_semcode_token_with_quotas` — identical admission logic, but the
+  caller supplies the `RuntimeQuotas` profile to admit against (e.g.
+  `KernelBound`). `verify_semcode_token` is a thin wrapper over this with
+  `RuntimeQuotas::verified_local()`. Rejection diagnostics report the budget
+  and usage from whichever profile was supplied, not a fixed profile name —
+  callers should not assume a rejection implies `VerifiedLocal` limits.
 
 Compatibility / legacy admission surface:
 
@@ -48,10 +55,12 @@ Current SemCode verification checks include:
 - jump-target validity
 - reachable control-flow closure (no end-of-stream fallthrough)
 - string and debug reference validity
-- register-budget validity
+- register-budget validity (against the caller-selected `RuntimeQuotas`
+  profile; see Public Surface)
 - program-wide runtime symbol-table budget validity (the number of *distinct*
   strings the VM will intern across every function, deduplicated by exact
-  string value program-wide - not a per-function string-table entry count)
+  string value program-wide - not a per-function string-table entry count;
+  also checked against the caller-selected `RuntimeQuotas` profile)
 - call-target validity
 - capability consistency with actual opcode usage
 

--- a/tests/golden_snapshots/public_api/sm_verify_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_lib.txt
@@ -53,4 +53,6 @@ pub fn with_decoded_envelopes<R, F>(&self, f: F) -> R where F: for<'scope> FnOnc
 #[cfg(feature = "std")]
 pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectReport> {
 #[cfg(feature = "std")]
+pub fn verify_semcode_token_with_quotas( bytes: &[u8], quotas: RuntimeQuotas, ) -> Result<VerifiedSemCode<'_>, RejectReport> {
+#[cfg(feature = "std")]
 pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {


### PR DESCRIPTION
Closes #1757
Umbrella #1617
Related qualification debt: #1755

## Root cause

`verify_semcode_token(bytes)` — the canonical public admission entry point — hardcoded `RuntimeQuotas::verified_local()` internally, with no parameter to admit against any other quota profile. `RuntimeQuotas::kernel_bound()` exists (`max_registers = 8192` vs. `verified_local()`'s `4096`) and `ExecutionContext::KernelBound` is a real execution context, but its quota profile could never participate in verification — every token, regardless of its intended execution context, was admitted against the same fixed 4096-register budget.

## Pre-fix KernelBound reproduction

An artifact whose highest live register reference is `r5000` (between VerifiedLocal's 4096 and KernelBound's 8192):
- `verify_semcode_token(bytes)` → `Reject(InvalidRegisterReference)`.
- No verifier API existed capable of asking "verify these bytes under KernelBound quotas" — confirmed by grepping sm-verify's public functions pre-fix.

## Quota ownership model

```
ExecutionContext / ExecutionConfig  -> decides quota profile
RuntimeQuotas                       -> carries limits
sm-verify                           -> validates artifact against supplied limits
```

## Mandatory safety checkpoint (answered before writing any code)

**Question:** if a token were admitted under generous KernelBound quotas but executed under a stricter config (or vice versa), does runtime independently re-validate against its own active config's quotas, or does it trust admission-time quotas?

**Answer, confirmed by direct code reading:** `Frame.regs` is a plain growable `Vec<Value>`, not a fixed-size array sized from any quota upfront. `write_reg` (`crates/sm-vm/src/semcode_vm.rs`) calls `enforce_quota(quotas, QuotaKind::Registers, required)` against `&vm.config.quotas` — the config the VM was actually constructed with **for this execution** — on every single register write, before any resize. `push_frame`'s frame/stack-depth checks work identically. This is already directly proven by the existing test `vm_enforces_configured_register_budget`, which shrinks `config.quotas.max_registers` at execution time only and the VM correctly traps it, independent of whatever admission produced the token.

**Conclusion: runtime never trusts admission-time quotas — it independently re-checks against the actively-configured execution quotas on every resource consumption.** A wider-admitted token cannot bypass a stricter runtime config. This means context-aware admission can safely be a supplied quota proof; runtime remains solely authoritative for execution consumption. Proceeding with the repair was therefore correct per the task's own design principle — this PR does not touch execution enforcement at all, only admission.

## New quota-aware API

```rust
pub fn verify_semcode_token_with_quotas(bytes: &[u8], quotas: RuntimeQuotas) -> Result<VerifiedSemCode<'_>, RejectReport>
```
contains the full admission logic that previously lived inline in `verify_semcode_token` (no duplication).

## Default VerifiedLocal compatibility

```rust
pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectReport> {
    verify_semcode_token_with_quotas(bytes, RuntimeQuotas::verified_local())
}
```
Default behavior is byte-for-byte unchanged — confirmed by the full existing sm-verify suite passing unmodified.

## Config-aware byte shim integration

Updated the byte-based compatibility shims in `crates/sm-vm/src/semcode_vm.rs` to route the caller-supplied `ExecutionConfig`'s quotas through admission instead of the hardcoded default — `run_verified_semcode_with_config`, `run_verified_semcode_with_entry_and_config`, `run_verified_semcode_with_host_and_capabilities_and_config`, `run_verified_semcode_with_application_host_and_capabilities_and_config` all now call `verify_semcode_token_with_quotas(bytes, config.quotas)`. Only `.quotas` is threaded through — not the full `ExecutionConfig` — so `trace_enabled` and other execution-mechanics fields never leak into sm-verify.

**Found by adversarial review and fixed in this PR:** `run_verified_semcode_with_host_and_capabilities` (the no-`_and_config` sibling in the same file, hardcoding `ExecutionContext::KernelBound` for execution) had the identical mismatch — it still admitted via the old hardcoded `verify_semcode_token`. Fixed the same way: build the `KernelBound` config once, use `.quotas` for admission and the config itself for execution. Added a dedicated regression test (`run_verified_semcode_with_host_and_capabilities_admits_r5000_under_kernel_bound`) and confirmed no regression to the four existing integration test files that already exercise this function (`tests/bytecode_compat.rs`, `tests/prometheus_gates.rs`, `tests/prometheus_runtime_negative_goldens.rs` — 24 tests total, all still pass).

Token-first APIs (`run_verified_entry_semcode_with_*`) were **not** touched — they operate on an already-produced token and correctly do not re-verify.

**Known follow-up, explicitly out of scope for this PR, tracked as #1822:** adversarial review also found `crates/prom-runtime/src/lib.rs`'s `ExecutionSession`/`GateExecutionSession::run_verified_semcode(_entry)` have the same class of mismatch — both already carry a caller-configurable `self.config: ExecutionConfig` (with explicit `kernel_bound()` constructors) but still admit via the hardcoded `verify_semcode_token`. This is a separate crate never included in this task's inspection scope, with its own dedicated test suite (`tests/prometheus_runtime*.rs`, `tests/prometheus_gates.rs`, `tests/prometheus_audit.rs`) this PR has not researched. Deliberately not fixed here to avoid under-scoped changes to unfamiliar territory — filed as #1822 rather than left only as PR prose, so it isn't lost once this issue closes.

## Public API snapshot

Intentional: `verify_semcode_token_with_quotas` is a new public function. `tests/golden_snapshots/public_api/sm_verify_lib.txt` regenerated via the repository's existing temp-`#[ignore]`-generator-test discipline — the delta is exactly this one addition, nothing else moved. `#1755` (admission submodule public-API coverage gap) remains separate and untouched.

## Regression matrix

1. `r5000` + default `verify_semcode_token` → Reject (VerifiedLocal, unchanged).
2. Same artifact + `verify_semcode_token_with_quotas(.., RuntimeQuotas::kernel_bound())` → Accept.
3. Register `>8191` + KernelBound verification → Reject — proves KernelBound isn't infinite.
4. Ordinary small artifact + default `verify_semcode_token` → unchanged Accept.
5. `run_verified_semcode_with_config` + `r5000` bytes + `ExecutionConfig::for_context(KernelBound)` → no longer rejected solely by the old hardcoded profile.
6. Same bytes + `ExecutionConfig::for_context(VerifiedLocal)` through the same shim → still rejects — proves the stricter canonical path is unaffected.
7. `run_verified_semcode_with_host_and_capabilities` + `r5000` → now admits under its hardcoded KernelBound profile (the sibling fix above).

Items 5–7 are the essential proof the supplied config actually reaches admission, not just that a new standalone function exists.

## Validation

- `cargo test -p sm-verify --features sm-ir/profile-rust`: 101/101 pass (97 pre-existing + 4 new)
- `cargo test -p sm-runtime-core --all-features`: 9/9 pass
- `cargo test -p sm-vm --all-features`: 109+1+23 pass (includes the 2 shim-integration tests + the sibling-fix test)
- `cargo test --test public_api_contracts`: 5/5 pass, snapshot delta is exactly the intended addition
- `cargo clippy -p sm-verify/-p sm-vm/--workspace --all-targets -- -D warnings`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

Three independent adversarial review lenses (semantic, trust/boundary, qualification) run against the committed diff before push. Trust/boundary PASSed cleanly, independently re-confirming the safety checkpoint. Semantic and qualification both surfaced the `run_verified_semcode_with_host_and_capabilities` gap (addressed above, in-scope, same file); both also surfaced the `prom-runtime` gap, deliberately left as an explicit out-of-scope follow-up rather than expanding into an unresearched crate.

## Scope

`crates/sm-runtime-core/` untouched. `run_verified_entry_semcode_with_*` (token-first APIs) untouched. `VerifiedSemCode`/`VerifiedEntrySemCode` not redesigned. `#1751`, `#1754` (independent, separate PRs), `#1752`, `#1755` (referenced, not fixed), `#1756`, `#1758`, `#1808` untouched. `crates/prom-runtime/` untouched (see known follow-up above).

## Batch conflict note

This PR and `#1751`/`#1754`'s PRs all touch `crates/sm-verify/src/lib.rs`. Individually clean now, but expect a rebase + CI rerun on whichever merges last, per the batch's own expected merge sequence.

