### PR TITLE
fix(sm-vm): propagate map default register errors

### DIFF
--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -2243,11 +2243,10 @@ where
                     ));
                 };
                 let key = map_key_from_value(get_reg(vm, frame_idx, key_reg)?)?;
-                let result = pairs
-                    .iter()
-                    .find(|(k, _)| k == &key)
-                    .map(|(_, v)| v.clone())
-                    .unwrap_or_else(|| get_reg(vm, frame_idx, default_reg).unwrap_or(Value::Unit));
+                let result = match pairs.iter().find(|(k, _)| k == &key) {
+                    Some((_, v)) => v.clone(),
+                    None => get_reg(vm, frame_idx, default_reg)?,
+                };
                 set_reg(vm, frame_idx, dst, result)?;
                 next_pc = cur - f.instr_start;
             }
@@ -3729,6 +3728,7 @@ mod tests {
         OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,
         OWNERSHIP_SECTION_TAG,
     };
+    use sm_ir::{emit_ir_to_semcode, IrFunction, IrInstr};
     use sm_runtime_core::{
         ExecutionConfig, ExecutionContext, PathComponent, QuotaExceeded, QuotaKind, RuntimeTrap,
     };
@@ -5621,6 +5621,203 @@ mod tests {
                 used: 16,
             })
         );
+    }
+
+    // --- #1771 (FA-09-003, umbrella #1617) regression matrix ---------------
+    //
+    // `Opcode::MapGet`'s missing-key path reads `default_reg` lazily (only
+    // when the key is absent) via `get_reg(vm, frame_idx, default_reg)`.
+    // Built with `emit_ir_to_semcode` directly (bypassing the source-level
+    // `map_get(...)` builtin) specifically so `default_val` can reference a
+    // register the program never writes — the source-level builtin always
+    // lowers its third argument expression into a register write before
+    // `IrInstr::MapGet` is emitted, which would make "physically absent
+    // default register" unconstructible from source.
+    //
+    // `push_frame` materializes at least 16 register slots regardless of
+    // arguments, so `r100` is guaranteed physically absent from a fresh
+    // zero-arg frame in every case below that uses it, and no instruction
+    // in these programs writes a register anywhere near that high.
+
+    /// Builds a two-function program (`helper` returns unit; `main` runs
+    /// `main_instrs`) via direct IR emission.
+    fn build_map_get_test_program(main_instrs: Vec<IrInstr>) -> Vec<u8> {
+        emit_ir_to_semcode(
+            &[
+                IrFunction {
+                    name: "helper".to_string(),
+                    instrs: vec![IrInstr::Ret { src: None }],
+                    ownership_events: Vec::new(),
+                },
+                IrFunction {
+                    name: "main".to_string(),
+                    instrs: main_instrs,
+                    ownership_events: Vec::new(),
+                },
+            ],
+            false,
+        )
+        .expect("emit map_get test program")
+    }
+
+    fn run_map_get_test_program(bytes: &[u8]) -> Result<Value, RuntimeError> {
+        let token = verify_semcode_token(bytes).expect("verifier must accept: default_reg is a legal in-budget register reference regardless of physical materialization");
+        let entry = token.require_entry("main").expect("entry");
+        run_verified_function_semcode_with_args(&entry, "main", vec![])
+    }
+
+    /// A5.1: missing key + valid initialized default register -> exact
+    /// default value.
+    #[test]
+    fn map_get_missing_key_returns_initialized_default_register_value() {
+        let bytes = build_map_get_test_program(vec![
+            IrInstr::MapEmpty { dst: 0 },
+            IrInstr::LoadI32 { dst: 1, val: 1 },
+            IrInstr::LoadI32 { dst: 2, val: 10 },
+            IrInstr::MapSet {
+                dst: 0,
+                map: 0,
+                key: 1,
+                val: 2,
+            },
+            IrInstr::LoadI32 { dst: 3, val: 2 }, // requested key (absent: map only has key 1)
+            IrInstr::LoadI32 { dst: 4, val: 999 }, // initialized default
+            IrInstr::MapGet {
+                dst: 5,
+                map: 0,
+                key: 3,
+                default_val: 4,
+            },
+            IrInstr::Ret { src: Some(5) },
+        ]);
+        let res = run_map_get_test_program(&bytes).expect("run");
+        assert_eq!(res, Value::I32(999));
+    }
+
+    /// A5.2 (the core #1771 regression): missing key + a `default_reg` that
+    /// is numerically in-budget but physically absent from the frame must
+    /// propagate `get_reg`'s own read error, not fabricate `Value::Unit`.
+    ///
+    /// Confirmed RED against the pre-fix `unwrap_or(Value::Unit)` swallow
+    /// (returned `Ok(Value::Unit)` instead of this error) before the
+    /// production fix in this same PR was applied.
+    #[test]
+    fn map_get_missing_key_with_physically_absent_default_register_propagates_error() {
+        let bytes = build_map_get_test_program(vec![
+            IrInstr::MapEmpty { dst: 0 },
+            IrInstr::LoadI32 { dst: 1, val: 1 },
+            IrInstr::LoadI32 { dst: 2, val: 10 },
+            IrInstr::MapSet {
+                dst: 0,
+                map: 0,
+                key: 1,
+                val: 2,
+            },
+            IrInstr::LoadI32 { dst: 3, val: 2 }, // requested key (absent)
+            IrInstr::MapGet {
+                dst: 5,
+                map: 0,
+                key: 3,
+                default_val: 100, // never written anywhere in this program
+            },
+            IrInstr::Ret { src: Some(5) },
+        ]);
+        let err = run_map_get_test_program(&bytes).expect_err("must propagate the read error");
+        assert_eq!(
+            err,
+            RuntimeError::BadFormat("read invalid reg r100".to_string())
+        );
+    }
+
+    /// A5.3: present key + physically absent default register -> the map
+    /// value is returned and `default_reg` is never observed (laziness
+    /// boundary case).
+    #[test]
+    fn map_get_present_key_ignores_physically_absent_default_register() {
+        let bytes = build_map_get_test_program(vec![
+            IrInstr::MapEmpty { dst: 0 },
+            IrInstr::LoadI32 { dst: 1, val: 1 },
+            IrInstr::LoadI32 { dst: 2, val: 10 },
+            IrInstr::MapSet {
+                dst: 0,
+                map: 0,
+                key: 1,
+                val: 2,
+            },
+            IrInstr::LoadI32 { dst: 3, val: 1 }, // requested key (present)
+            IrInstr::MapGet {
+                dst: 5,
+                map: 0,
+                key: 3,
+                default_val: 100, // never written; must not be read
+            },
+            IrInstr::Ret { src: Some(5) },
+        ]);
+        let res = run_map_get_test_program(&bytes).expect("run");
+        assert_eq!(res, Value::I32(10));
+    }
+
+    /// A5.4: present key + valid default register -> the map value still
+    /// wins over the default.
+    #[test]
+    fn map_get_present_key_prefers_map_value_over_valid_default() {
+        let bytes = build_map_get_test_program(vec![
+            IrInstr::MapEmpty { dst: 0 },
+            IrInstr::LoadI32 { dst: 1, val: 1 },
+            IrInstr::LoadI32 { dst: 2, val: 10 },
+            IrInstr::MapSet {
+                dst: 0,
+                map: 0,
+                key: 1,
+                val: 2,
+            },
+            IrInstr::LoadI32 { dst: 3, val: 1 }, // requested key (present)
+            IrInstr::LoadI32 { dst: 4, val: 999 }, // valid default, must be ignored
+            IrInstr::MapGet {
+                dst: 5,
+                map: 0,
+                key: 3,
+                default_val: 4,
+            },
+            IrInstr::Ret { src: Some(5) },
+        ]);
+        let res = run_map_get_test_program(&bytes).expect("run");
+        assert_eq!(res, Value::I32(10));
+    }
+
+    /// A5.5: the default register genuinely, explicitly holds `Value::Unit`
+    /// (written by a real call to a function that returns unit) -> the
+    /// missing-key result is a legitimate `Unit`, proving `Unit` itself is
+    /// never rejected -- only a *fabricated* `Unit` (from a swallowed read
+    /// error) is forbidden.
+    #[test]
+    fn map_get_missing_key_with_explicit_unit_default_returns_legitimate_unit() {
+        let bytes = build_map_get_test_program(vec![
+            IrInstr::MapEmpty { dst: 0 },
+            IrInstr::LoadI32 { dst: 1, val: 1 },
+            IrInstr::LoadI32 { dst: 2, val: 10 },
+            IrInstr::MapSet {
+                dst: 0,
+                map: 0,
+                key: 1,
+                val: 2,
+            },
+            IrInstr::LoadI32 { dst: 3, val: 2 }, // requested key (absent)
+            IrInstr::Call {
+                dst: Some(4),
+                name: "helper".to_string(),
+                args: vec![],
+            }, // r4 = Value::Unit, via a real RET-with-no-src write
+            IrInstr::MapGet {
+                dst: 5,
+                map: 0,
+                key: 3,
+                default_val: 4,
+            },
+            IrInstr::Ret { src: Some(5) },
+        ]);
+        let res = run_map_get_test_program(&bytes).expect("run");
+        assert_eq!(res, Value::Unit);
     }
 
     #[test]

--- a/docs/spec/vm.md
+++ b/docs/spec/vm.md
@@ -115,6 +115,10 @@ Contract rule:
 - quota exhaustion must preserve the exceeded quota kind, limit, and usage
 - malformed or unsupported bytecode must not be treated as a successful run
 
+`MAP_GET` evaluates its default register only on a key miss. Failure to
+read the default register is a runtime error. `MAP_GET` must never
+convert a register-read failure into `Value::Unit`.
+
 ## Determinism Rule
 
 The VM must behave deterministically for the same:


### PR DESCRIPTION
Closes #1771
Umbrella #1617
Related: #1770, #1756

## Root cause

`Opcode::MapGet`'s missing-key path was:

```rust
let result = pairs
    .iter()
    .find(|(k, _)| k == &key)
    .map(|(_, v)| v.clone())
    .unwrap_or_else(|| get_reg(vm, frame_idx, default_reg).unwrap_or(Value::Unit));
```

`get_reg` already correctly classifies a register outside the materialized frame as `RuntimeError::BadFormat("read invalid reg r{}", r)`. The `.unwrap_or(Value::Unit)` inside the fallback closure caught that real error and substituted a fabricated `Value::Unit`, so a structurally invalid register reference silently became a successful `Unit` result instead of a runtime error. This is independent of #1770 — even a perfectly-initialized register file would still hit this bug for a default register that is simply out of the current frame's bounds.

## Pre-fix reproduction

Built directly via `emit_ir_to_semcode` (bypassing the source-level `map_get(...)` builtin, which always lowers its third argument into a register write before emitting `IrInstr::MapGet` — making "default register physically absent from the frame" unconstructible from source). A program with a one-entry map, a missing requested key, and `default_val: 100` (never written anywhere; `push_frame` only materializes `max(16, args.len())` slots for a zero-arg `main`, i.e. 16):

- `verify_semcode_token` → **Accept** (r100 is numerically within the default 4096-register budget; the verifier proves range, not definition — see #1756).
- Direct `get_reg(vm, frame_idx, 100)` → `RuntimeError::BadFormat("read invalid reg r100")` (confirmed authoritative).
- Pre-fix `MAP_GET` → swallowed that error and returned `Ok(Value::Unit)`.

Confirmed empirically: the new regression test `map_get_missing_key_with_physically_absent_default_register_propagates_error` was run against the pre-fix code first and failed with exactly `Unit` (not the panic message) before the production fix was applied, then passed after.

## Fix

```rust
let result = match pairs.iter().find(|(k, _)| k == &key) {
    Some((_, v)) => v.clone(),
    None => get_reg(vm, frame_idx, default_reg)?,
};
```

`default_reg` is read lazily — only on a key miss — and any read failure now propagates via `?` instead of being caught and replaced.

## Regression matrix (all in `crates/sm-vm/src/semcode_vm.rs`, `semcode_vm::tests`)

1. `map_get_missing_key_returns_initialized_default_register_value` — missing key + valid initialized default → exact default value.
2. `map_get_missing_key_with_physically_absent_default_register_propagates_error` — missing key + physically absent default register → `RuntimeError::BadFormat("read invalid reg r100")` (was `Ok(Value::Unit)` pre-fix).
3. `map_get_present_key_ignores_physically_absent_default_register` — present key + physically absent default register → map value returned, default register never observed (laziness boundary case; passes on both old and new code, confirming laziness itself was never broken — only the error-swallow on the miss path was).
4. `map_get_present_key_prefers_map_value_over_valid_default` — present key + valid default → map value still wins.
5. `map_get_missing_key_with_explicit_unit_default_returns_legitimate_unit` — default register holds a *genuine*, explicitly-written `Value::Unit` (via a real call to a function that returns unit, so the proof doesn't depend on incidental pre-#1770 frame pre-fill semantics) → missing-key result is legitimately `Unit`. Proves `Unit` itself is never rejected — only a *fabricated* `Unit` from a swallowed read error is forbidden.

## Doc

`docs/spec/vm.md`, Trap And Error Model section:

> `MAP_GET` evaluates its default register only on a key miss. Failure to read the default register is a runtime error. `MAP_GET` must never convert a register-read failure into `Value::Unit`.

## Review lenses

- **Semantic**: `Value::Unit` is only ever returned when a real, successfully-read register contains it (case 5) — never as a substitute for a read error.
- **Laziness**: present-key execution never calls `get_reg` on `default_reg` (cases 3–4); confirmed unconditionally, not just when the register happens to be valid.
- **Boundary**: `get_reg` remains the sole authority for register readability — the fix adds no parallel/duplicate validity check.
- **Qualification**: test 2 confirmed genuinely RED against pre-fix code (returned `Unit`, not the expected error) before the fix landed, then GREEN after.

## Validation

- `cargo test -p sm-vm --all-features`: 116+1+23 pass (111+1+23 baseline + 5 new)
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 106/106 pass (unchanged)
- `cargo test -p sm-ir --all-features`: 104/104 pass (unchanged)
- `cargo test --test public_api_contracts`: 5/5 pass — no public API surface changed by this PR, snapshot untouched
- `cargo clippy -p sm-vm --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `git diff --check` / `git diff --cached --check`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

## Scope

`crates/sm-verify/`, `crates/sm-runtime-core/`, `crates/sm-format/`, `crates/sm-ir/` untouched. No SemCode format/revision change. #1770 (register-file initialization) and #1756 (definite-assignment verifier proof) are independent, separate repairs — not started or touched by this PR. This PR only removes the error-to-`Unit` coercion; it does not change what counts as "physically present" (that's #1770's scope).

## Batch conflict note

Independent branch from clean main; does not touch any file #1770's PR is expected to touch overlapping regions of (`crates/sm-vm/src/semcode_vm.rs`, different functions — `Opcode::MapGet` vs. `push_frame`/`get_reg`/`write_reg`/`Frame`). A rebase check is still expected per the batch's own merge-order note once both are ready.
