### PR TITLE
fix(sm-vm): represent undefined registers explicitly

### DIFF
--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -60,10 +60,23 @@ pub enum Value {
     Unit,
 }
 
+/// A single register slot.
+///
+/// Physical slot existence (storage capacity) and Semantic value
+/// definition are distinct properties: a slot may exist without ever
+/// having been written by an instruction. `Value::Unit` is an ordinary
+/// Semantic value, never a stand-in for "nothing was written here" --
+/// that state is represented explicitly by `Uninitialized`.
+#[derive(Debug, Clone)]
+enum RegisterSlot {
+    Uninitialized,
+    Value(Value),
+}
+
 #[derive(Debug, Clone)]
 pub struct Frame {
     pub pc: usize,
-    pub regs: Vec<Value>,
+    regs: Vec<RegisterSlot>,
     pub locals: HashMap<SymbolId, Value>,
     pub borrowed_paths: Vec<AccessPath>,
     next_write_path: usize,
@@ -2735,9 +2748,9 @@ fn push_frame(
     }
     let initial_reg_count = 16usize.max(args.len());
     enforce_quota(&vm.config.quotas, QuotaKind::Registers, initial_reg_count)?;
-    let mut regs = vec![Value::Unit; initial_reg_count];
+    let mut regs = vec![RegisterSlot::Uninitialized; initial_reg_count];
     for (i, v) in args.into_iter().enumerate() {
-        regs[i] = v;
+        regs[i] = RegisterSlot::Value(v);
     }
     let frame = Frame {
         pc: 0,
@@ -2789,11 +2802,18 @@ fn lookup_symbol(f: &FunctionBytecode, sid: u16) -> Result<SymbolId, RuntimeErro
 }
 
 fn get_reg(vm: &VM, frame_idx: usize, r: u16) -> Result<Value, RuntimeError> {
-    vm.callstack
+    match vm
+        .callstack
         .get(frame_idx)
         .and_then(|fr| fr.regs.get(r as usize))
-        .cloned()
-        .ok_or_else(|| RuntimeError::BadFormat(format!("read invalid reg r{}", r)))
+    {
+        Some(RegisterSlot::Value(v)) => Ok(v.clone()),
+        Some(RegisterSlot::Uninitialized) => Err(RuntimeError::BadFormat(format!(
+            "read uninitialized reg r{}",
+            r
+        ))),
+        None => Err(RuntimeError::BadFormat(format!("read invalid reg r{}", r))),
+    }
 }
 
 fn set_reg(vm: &mut VM, frame_idx: usize, r: u16, v: Value) -> Result<(), RuntimeError> {
@@ -2812,9 +2832,9 @@ fn write_reg(
     if frame.regs.len() <= r {
         let required = r + 1;
         enforce_quota(quotas, QuotaKind::Registers, required)?;
-        frame.regs.resize(required, Value::Unit);
+        frame.regs.resize(required, RegisterSlot::Uninitialized);
     }
-    frame.regs[r] = v;
+    frame.regs[r] = RegisterSlot::Value(v);
     Ok(())
 }
 
@@ -4048,6 +4068,17 @@ mod tests {
     // the function's code-slice start (recovered via pointer arithmetic,
     // since `code_slice` is a genuine subslice of `bytes`) plus
     // `instr_start_offset`.
+    //
+    // #1770 follow-up: `let a: bool = true;` also emits a STORE_VAR
+    // immediately after LOAD_BOOL, reading the same register LOAD_BOOL
+    // wrote (`src`), to bind it to local `a`. Relocating only LOAD_BOOL's
+    // `dst` to r5000 without also relocating STORE_VAR's `src` left the
+    // original register (r0) referenced-but-never-written -- which used to
+    // read back as a fail-open `Value::Unit` (the exact #1770 bug) and
+    // silently worked by accident. Now that undefined reads are correctly
+    // rejected, both operands of this load/store pair must be relocated
+    // together so the artifact stays internally consistent; the r5000
+    // register-budget property under test is otherwise unaffected.
     fn build_r5000_register_artifact() -> Vec<u8> {
         let mut bytes = compile_program_to_semcode("fn main() { let a: bool = true; return; }")
             .expect("compile");
@@ -4066,6 +4097,16 @@ mod tests {
         );
         let dst_pos = opcode_pos + 1;
         bytes[dst_pos..dst_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
+        // LOAD_BOOL is [opcode:1][dst:u16][val:u8] = 4 bytes; STORE_VAR
+        // follows immediately as [opcode:1][sid:u16][src:u16].
+        let store_var_pos = opcode_pos + 4;
+        assert_eq!(
+            bytes[store_var_pos],
+            Opcode::StoreVar as u8,
+            "expected STORE_VAR immediately after LOAD_BOOL"
+        );
+        let store_var_src_pos = store_var_pos + 1 + 2;
+        bytes[store_var_src_pos..store_var_src_pos + 2].copy_from_slice(&5000u16.to_le_bytes());
         bytes
     }
 
@@ -5818,6 +5859,226 @@ mod tests {
         ]);
         let res = run_map_get_test_program(&bytes).expect("run");
         assert_eq!(res, Value::Unit);
+    }
+
+    /// B5 layout evidence: `RegisterSlot` has the same layout as the stdlib
+    /// `Option<Value>` alternative would have. This locks in the *relative*
+    /// comparison the representation decision was based on; it does not by
+    /// itself bound `Value`'s own size (a Rust layout detail of the
+    /// compiler/target, not a semantic contract this test should gate) --
+    /// the concrete `size_of::<Value>() == size_of::<Option<Value>>() ==
+    /// size_of::<RegisterSlot>() == 80` measurement is recorded as PR
+    /// evidence instead.
+    #[test]
+    fn register_slot_layout_matches_option_value() {
+        assert_eq!(
+            std::mem::size_of::<RegisterSlot>(),
+            std::mem::size_of::<Option<Value>>(),
+            "RegisterSlot must not cost more than the stdlib Option<Value> alternative"
+        );
+    }
+
+    // --- #1770 (FA-09-002, umbrella #1617) regression matrix ---------------
+    //
+    // `push_frame` used to materialize at least 16 register slots with
+    // `Value::Unit` regardless of arguments, and `write_reg` filled any gap
+    // created by a high-register write the same way. That made "physical
+    // slot exists" and "a Semantic value was actually defined here"
+    // indistinguishable: an entirely undefined register read back as a
+    // plausible `Unit` instead of failing. Built with `emit_ir_to_semcode`
+    // directly for the same reason as #1771's tests: precise control over
+    // exactly which registers are written, independent of what the
+    // source-level compiler happens to allocate.
+
+    fn build_register_init_test_program(functions: Vec<IrFunction>) -> Vec<u8> {
+        emit_ir_to_semcode(&functions, false).expect("emit register-init test program")
+    }
+
+    fn ret_only_function(name: &str, src: Option<u16>) -> IrFunction {
+        IrFunction {
+            name: name.to_string(),
+            instrs: vec![IrInstr::Ret { src }],
+            ownership_events: Vec::new(),
+        }
+    }
+
+    /// B12.1 + B13 cross-layer defense: a zero-arg entry reading `r0` with
+    /// no preceding definition must be rejected by the VM even though the
+    /// verifier (lacking #1756's definite-assignment proof) admits it.
+    #[test]
+    fn frame_reads_zero_arg_entry_register_as_uninitialized_error() {
+        let bytes = build_register_init_test_program(vec![ret_only_function("main", Some(0))]);
+        let token = verify_semcode_token(&bytes)
+            .expect("verifier currently has no definite-assignment proof (#1756) and must accept");
+        let entry = token.require_entry("main").expect("entry");
+        let err = run_verified_function_semcode_with_args(&entry, "main", vec![])
+            .expect_err("VM must independently reject the undefined read");
+        assert_eq!(
+            err,
+            RuntimeError::BadFormat("read uninitialized reg r0".to_string())
+        );
+    }
+
+    /// B12.2: a write to a high register must not materialize the gap
+    /// below it as legitimate values; a never-written register in that gap
+    /// must still fail as uninitialized (not succeed with a fabricated
+    /// `Unit`).
+    #[test]
+    fn write_high_register_then_read_gap_is_uninitialized_error() {
+        let bytes = build_register_init_test_program(vec![IrFunction {
+            name: "main".to_string(),
+            instrs: vec![
+                IrInstr::LoadI32 { dst: 100, val: 1 },
+                IrInstr::Ret { src: Some(50) },
+            ],
+            ownership_events: Vec::new(),
+        }]);
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("main").expect("entry");
+        let err = run_verified_function_semcode_with_args(&entry, "main", vec![])
+            .expect_err("gap register must remain uninitialized");
+        assert_eq!(
+            err,
+            RuntimeError::BadFormat("read uninitialized reg r50".to_string())
+        );
+    }
+
+    /// B12.3 + B12.9: `Value::Unit` remains an ordinary, readable value once
+    /// genuinely written -- including via a real `CALL` whose callee
+    /// returns unit (`Ret { src: None }`), proving the call's destination
+    /// register becomes explicitly initialized rather than only
+    /// incidentally holding `Unit` by virtue of unwritten storage.
+    #[test]
+    fn explicit_unit_write_then_read_succeeds_and_call_result_is_initialized() {
+        let bytes = build_register_init_test_program(vec![
+            ret_only_function("helper", None),
+            IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::Call {
+                        dst: Some(5),
+                        name: "helper".to_string(),
+                        args: vec![],
+                    },
+                    IrInstr::Ret { src: Some(5) },
+                ],
+                ownership_events: Vec::new(),
+            },
+        ]);
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("main").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "main", vec![]).expect("run");
+        assert_eq!(res, Value::Unit);
+    }
+
+    /// B12.4 + B12.5 (single-argument half): exactly one supplied argument
+    /// defines `r0`; a sibling register that was never supplied and never
+    /// written must remain uninitialized, not "magically" defined.
+    #[test]
+    fn single_argument_initializes_only_r0() {
+        let bytes = build_register_init_test_program(vec![
+            ret_only_function("main", None),
+            ret_only_function("read_r0", Some(0)),
+            ret_only_function("read_r1", Some(1)),
+        ]);
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("main").expect("entry");
+
+        let ok = run_verified_function_semcode_with_args(&entry, "read_r0", vec![Value::I32(42)])
+            .expect("supplied arg register must be defined");
+        assert_eq!(ok, Value::I32(42));
+
+        let err = run_verified_function_semcode_with_args(&entry, "read_r1", vec![Value::I32(42)])
+            .expect_err("unsupplied sibling register must not be magically defined");
+        assert_eq!(
+            err,
+            RuntimeError::BadFormat("read uninitialized reg r1".to_string())
+        );
+    }
+
+    /// B12.5 (multiple-arguments half): exactly the supplied registers are
+    /// initialized -- not one more.
+    #[test]
+    fn multiple_arguments_initialize_exactly_supplied_registers() {
+        let bytes = build_register_init_test_program(vec![
+            ret_only_function("main", None),
+            ret_only_function("read_r1", Some(1)),
+            ret_only_function("read_r2", Some(2)),
+        ]);
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("main").expect("entry");
+        let args = vec![Value::I32(1), Value::I32(2)];
+
+        let ok = run_verified_function_semcode_with_args(&entry, "read_r1", args.clone())
+            .expect("second supplied arg register must be defined");
+        assert_eq!(ok, Value::I32(2));
+
+        let err = run_verified_function_semcode_with_args(&entry, "read_r2", args)
+            .expect_err("register past the supplied argument count must be uninitialized");
+        assert_eq!(
+            err,
+            RuntimeError::BadFormat("read uninitialized reg r2".to_string())
+        );
+    }
+
+    /// B12.10: a `CALL` with no destination operand must define no
+    /// register at all -- not even incidentally.
+    #[test]
+    fn call_without_destination_creates_no_register_definition() {
+        let bytes = build_register_init_test_program(vec![
+            ret_only_function("helper", None),
+            IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::Call {
+                        dst: None,
+                        name: "helper".to_string(),
+                        args: vec![],
+                    },
+                    IrInstr::Ret { src: Some(7) },
+                ],
+                ownership_events: Vec::new(),
+            },
+        ]);
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("main").expect("entry");
+        let err = run_verified_function_semcode_with_args(&entry, "main", vec![])
+            .expect_err("no-dst call must not define r7");
+        assert_eq!(
+            err,
+            RuntimeError::BadFormat("read uninitialized reg r7".to_string())
+        );
+    }
+
+    /// B12.11: a `ClosureCall`'s result register is initialized the same
+    /// way a plain `CALL`'s is.
+    #[test]
+    fn closure_call_result_initialization_preserved() {
+        let bytes = build_register_init_test_program(vec![
+            ret_only_function("closure_target", Some(0)),
+            IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadI32 { dst: 0, val: 77 },
+                    IrInstr::MakeClosure {
+                        dst: 1,
+                        name: "closure_target".to_string(),
+                        captures: vec![],
+                    },
+                    IrInstr::ClosureCall {
+                        dst: Some(2),
+                        closure: 1,
+                        arg: 0,
+                    },
+                    IrInstr::Ret { src: Some(2) },
+                ],
+                ownership_events: Vec::new(),
+            },
+        ]);
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("main").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, "main", vec![]).expect("run");
+        assert_eq!(res, Value::I32(77));
     }
 
     #[test]

--- a/docs/architecture/svm_verified_execution_core.md
+++ b/docs/architecture/svm_verified_execution_core.md
@@ -9,10 +9,15 @@ GPU/Vulkan backend work, verifier changes, SemCode changes, or P5-A.
 
 - current active execution path: scalar `sm-vm`
 - verified execution requires SemCode admission
-- public VM API unchanged
-- production VM behavior unchanged
+- public VM API unchanged, except the narrow #1770 correctness hardening below
+- production VM behavior unchanged, except the narrow #1770 correctness hardening below
 - Pulsar P4 evidence closed and evidence-repaired
 - Pulsar P5-A blocked by current profiling evidence
+- `#1770` (umbrella #1617): `Frame.regs` was privatized (`pub regs: Vec<Value>` ->
+  private `Vec<RegisterSlot>`) and undefined register reads now deterministically
+  fail instead of silently reading back a fail-open `Value::Unit`. This is a
+  narrow safety-invariant repair, not the kind of new-behavior/API-widening
+  scope this document otherwise gates.
 
 ## 2. Current verified execution pipeline
 
@@ -51,7 +56,7 @@ Raw SemCode Bytes
 | Component | Current implementation meaning | Notes |
 |---|---|---|
 | Frame Stack | VM call stack | `VM.callstack` |
-| Frame Registers | frame-local `Vec<Value>` | not a hardware register file |
+| Frame Registers | frame-local, private `Vec<RegisterSlot>` (`Uninitialized` or `Value`) | not a hardware register file; undefined reads fail deterministically (#1770) |
 | Locals | `HashMap<SymbolId, Value>` | deterministic runtime locals |
 | Execution Loop | opcode dispatch loop | scalar `sm-vm` execution |
 | Capability Checker | host capability boundary | no authority widening |
@@ -135,7 +140,7 @@ flowchart LR
 
     subgraph CORE["Verified Execution Core"]
         STACK["Frame Stack"]
-        REGS["Frame Registers Vec<Value>"]
+        REGS["Frame Registers Vec<RegisterSlot> private"]
         LOCALS["Locals HashMap<SymbolId, Value>"]
         CAP["Capability Checker"]
         ABI["Prometheus Host ABI Bridge"]
@@ -163,8 +168,8 @@ flowchart LR
 This document does not claim:
 
 - VM performance improved;
-- public VM API changed;
-- production VM behavior changed;
+- public VM API changed, beyond the narrow #1770 `Frame.regs` privatization noted in Section 1;
+- production VM behavior changed, beyond the narrow #1770 undefined-register fail-closed repair noted in Section 1;
 - Pulsar is runtime-integrated;
 - P5-A is open;
 - P5-B is approved;

--- a/docs/spec/vm.md
+++ b/docs/spec/vm.md
@@ -144,6 +144,14 @@ Current frame model includes:
 - function identity
 - optional return destination
 
+Register storage capacity and register initialization are independent:
+a register slot may physically exist without ever having been defined by
+an instruction. `Value::Unit` is an ordinary Semantic value, never a
+stand-in for "nothing was written here." A read of an undefined register
+deterministically fails; it must never be treated as `Value::Unit` by
+default. This runtime defense is independent of and does not replace
+verifier dataflow proof of definite assignment.
+
 Current function-bytecode model includes:
 
 - function name

--- a/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
+++ b/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
@@ -10,7 +10,6 @@ pub enum Value {
 #[derive(Debug, Clone)]
 pub struct Frame {
 pub pc: usize,
-pub regs: Vec<Value>,
 pub locals: HashMap<SymbolId, Value>,
 pub borrowed_paths: Vec<AccessPath>,
 pub func: String,


### PR DESCRIPTION
Closes #1770
Umbrella #1617
Related: #1756, #1771

## Root cause

`Frame.regs` was `Vec<Value>`. `push_frame` pre-filled at least `max(16, args.len())` slots with `Value::Unit` regardless of how many arguments were actually supplied, and `write_reg` filled any gap created by a high-register write the same way (`frame.regs.resize(required, Value::Unit)`). Physical slot existence therefore silently implied Semantic definition: a register that no instruction had ever written still read back as the plausible, valid value `Value::Unit` instead of failing.

Two concrete fail-open paths, reproduced pre-fix:

- **Fresh zero-arg frame, `RET r0`** with no preceding definition → `Ok(Value::Unit)` (should deterministically error).
- **`write r100` then `read r50`**: the resize gap `r16..r99` materializes as `Value::Unit`; reading `r50` (never written) → `Ok(Value::Unit)` (should deterministically error).

## Frame.regs access audit (repo-wide)

Searched the whole repository for `Frame {` construction and `.regs` access outside `crates/sm-vm/src/semcode_vm.rs`. Every other hit (`semantic-core-exec`'s own `Frame`/`regs`, `semantic-core-quad`/`ton618-core`/`ton618_legacy`'s `QuadroReg` register banks, `prom-ui*`'s `DrawFrame`/`UiFrame`, `sm-front`/`sm-ir`'s `LoopTypeFrame`/`LoopLoweringFrame`, `smc-cli`'s `WorkControlFrame`) is an unrelated type in an unrelated domain.

Within `sm-vm` itself, exactly **three functions** touch register storage, all in the same file:

1. **Who constructs `Frame`?** Only `push_frame()` — a single struct-literal site.
2. **Who mutates `.regs`?** Only `push_frame()` (initial argument population) and `write_reg()`.
3. **Who reads `.regs` directly?** Only `get_reg()`. All 46 `set_reg(...)` call sites across every register-defining opcode (`LOAD_*`, arithmetic, `CALL`, `ClosureCall`, `Make*`, `LoadVar`, etc.) route through this single chokepoint — confirmed by grep, not assumed.
4. **Does any external crate rely on mutable `Frame.regs`?** No. The only external reference anywhere in the repo is a blanket type re-export in `src/lib.rs` (`pub use sm_vm::{..., Frame, ...}`), never a field access or construction.
5. **Can the invariant be protected without breaking an intentional public contract?** Yes — privatizing `regs` costs zero external consumers; the type re-export itself is unaffected by field visibility.

## Representation decision

Compared per the task's own checkpoint:

- **Rejected outright**: `pub regs: Vec<Value>` + a separate `initialized_regs: Vec<bool>` sidecar — external (or even just careless internal) mutation of one without the other creates split-brain state. The invariant must be protected structurally by the type, not by convention between two vectors.
- **`Value::__Uninitialized` sentinel**: rejected — a storage-layer concern has no business leaking into the public `Value` enum, which is real Semantic language state.
- **Bitmap + separate value vector**: not pursued — no BitVec dependency was justified by any measured need, and it's still two allocations instead of one.
- **Chosen: `Vec<RegisterSlot>`** (private), where `enum RegisterSlot { Uninitialized, Value(Value) }`. One allocation per register file (not two), and the invariant is enforced by the type itself: nothing outside `get_reg`/`write_reg`/`push_frame` can ever construct a slot, because `RegisterSlot` and `Frame.regs` are both private to this module.

`Option<Value>` would have been structurally identical, but a dedicated enum keeps `RegisterSlot::Uninitialized` from reading like the *language's* Option/Result semantics (which `Value` already supports as an ADT) at each `get_reg`/`write_reg` call site.

### Layout evidence

```
size_of::<Value>()          = 80
size_of::<Option<Value>>()  = 80
size_of::<RegisterSlot>()   = 80
```

Rust's niche-filling enum layout optimization makes the wrapper free — `RegisterSlot` costs nothing over bare `Value`. Locked in as a permanent test (`register_slot_layout_matches_option_value`) comparing `RegisterSlot` against `Option<Value>` — the relative comparison the representation decision was actually based on. The concrete `80 == 80 == 80` numbers above are recorded as PR evidence rather than baked into the test as a `size_of::<Value>()` gate, since `Value`'s own layout is a compiler/target implementation detail the test shouldn't need to pin (reviewer nit, addressed in the post-rebase commit). Allocation count is unchanged: one `Vec` per frame, exactly as before.

## Fix

- `get_reg` now distinguishes a missing physical slot from a present-but-uninitialized one:
  - `None` (index ≥ `regs.len()`) → `RuntimeError::BadFormat("read invalid reg r{n}")` (unchanged wording/behavior).
  - `Some(RegisterSlot::Uninitialized)` → `RuntimeError::BadFormat("read uninitialized reg r{n}")` (new).
  - `Some(RegisterSlot::Value(v))` → `Ok(v.clone())`.
  No new public `RuntimeError` variant — both cases reuse the existing `BadFormat(String)`.
- `push_frame` fills fresh slots with `RegisterSlot::Uninitialized`; only registers actually supplied as arguments become `RegisterSlot::Value(arg)`.
- `write_reg` resizes gaps with `RegisterSlot::Uninitialized`, then writes the target slot as `RegisterSlot::Value(v)`. Quota enforcement (`enforce_quota` before resize) is untouched — same call, same position, same ordering.
- `Frame.regs` is now a private field (dropped `pub`); `RegisterSlot` is a private enum. No new public inspection API was added — the repo-wide audit found no live consumer that needs one, and the task's own instruction was explicit: don't invent API proactively, and never re-add something like `regs_mut(&mut self) -> &mut Vec<Value>` (that would recreate exactly this bug).

## Pre-fix reproduction (confirmed empirically)

All 5 of the following new tests were run against the pre-fix code first and failed with exactly `Ok(Value::Unit)` (not the expected error), then passed after the fix:

- `frame_reads_zero_arg_entry_register_as_uninitialized_error`
- `write_high_register_then_read_gap_is_uninitialized_error`
- `single_argument_initializes_only_r0` (its second assertion)
- `multiple_arguments_initialize_exactly_supplied_registers` (its second assertion)
- `call_without_destination_creates_no_register_definition`

Two tests that exercise *genuine* definition (not the bug) passed on both old and new code, as expected: `explicit_unit_write_then_read_succeeds_and_call_result_is_initialized`, `closure_call_result_initialization_preserved`.

## Regression matrix (`crates/sm-vm/src/semcode_vm.rs`, `semcode_vm::tests`)

All built via `emit_ir_to_semcode` directly (not the source-level compiler) for the same reason as #1771's tests: precise, unambiguous control over which registers are written, independent of what a source-level program happens to allocate.

1. `frame_reads_zero_arg_entry_register_as_uninitialized_error` — fresh zero-arg frame, `RET r0` → `BadFormat("read uninitialized reg r0")` (was `Ok(Unit)`). Also the **cross-layer defense-in-depth proof** (B13): the test explicitly confirms `verify_semcode_token` still admits this artifact (no #1756 definite-assignment proof exists yet) while the VM independently rejects it at execution.
2. `write_high_register_then_read_gap_is_uninitialized_error` — write `r100`, read `r50` → `BadFormat("read uninitialized reg r50")` (was `Ok(Unit)`).
3. `explicit_unit_write_then_read_succeeds_and_call_result_is_initialized` — a real `CALL` to a function returning unit (`Ret{src: None}`) writes its destination register with a genuine `Value::Unit`; reading it back succeeds. Proves `Unit` itself is never rejected, and that `CALL`'s destination becomes properly initialized (not just incidentally `Unit` from stale storage).
4. `single_argument_initializes_only_r0` — one supplied argument defines `r0` (reads succeed); the untouched sibling `r1` is not "magically" defined (reads fail as uninitialized).
5. `multiple_arguments_initialize_exactly_supplied_registers` — two supplied arguments define exactly `r0`/`r1`; `r2` (one past the supplied count) remains uninitialized.
6. `call_without_destination_creates_no_register_definition` — a no-dst `CALL` defines nothing at all, not even incidentally.
7. `closure_call_result_initialization_preserved` — `ClosureCall`'s result register is initialized the same way a plain `CALL`'s is.
8. `register_slot_layout_matches_option_value` — layout evidence, locked in as a permanent assertion.

Matrix items not covered by a new test are covered by the pre-existing suite, unmodified and still green:
- **Ordinary source program unchanged** (item 6 of the task's own numbering): the full existing `vm_runs_*` / `test_N_*` suite (~90 tests compiled from real source programs) passes unchanged.
- **Quota preservation** (items 7–8): `vm_enforces_configured_register_budget` and `vm_enforces_configured_frame_budget` pass unchanged — `enforce_quota`'s call site, position, and ordering relative to resize were not touched.

## Collateral fixture fix (found by this change, in-scope)

Two pre-existing tests from #1757 (`run_verified_semcode_with_config_admits_r5000_under_kernel_bound_config`, `run_verified_semcode_with_host_and_capabilities_admits_r5000_under_kernel_bound`) broke under the fix. Their shared fixture (`build_r5000_register_artifact`) compiles `fn main() { let a: bool = true; return; }` and relocates only `LOAD_BOOL`'s `dst` operand to `r5000`, leaving the immediately-following `STORE_VAR`'s `src` operand still pointing at the *original* register (r0) — which was never written after the relocation. Pre-#1770 this read back as a fail-open `Value::Unit` and worked by accident, exercising a bug this same PR fixes. Fixed by relocating both operands of the load/store pair together, so the fixture stays internally consistent; the r5000 register-budget property under test is unaffected. Confirmed all three r5000 tests (including the `VerifiedLocal`-still-rejects negative case) pass.

## Cross-layer note (B13)

Test 1 above is deliberately also the cross-layer proof: the verifier (no #1756 fix yet) still admits a zero-arg `RET r0` artifact, but the VM's own representation now independently rejects it at execution. This confirms the runtime defense in this PR does not depend on or wait for #1756's verifier-side definite-assignment proof — matching the task's explicit "VM defense remains independent of verifier" requirement.

## Public API

`Frame.regs` is no longer public. `tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt` updated to remove the one line (`pub regs: Vec<Value>,`) — confirmed via `public_api_inventory_matches_checked_in_contract_snapshots` that this is the *only* delta. Documented here as intentional safety hardening per the task's own instruction; no new public API was added.

## Doc

`docs/spec/vm.md`, Function And Frame Model section:

> Register storage capacity and register initialization are independent: a register slot may physically exist without ever having been defined by an instruction. `Value::Unit` is an ordinary Semantic value, never a stand-in for "nothing was written here." A read of an undefined register deterministically fails; it must never be treated as `Value::Unit` by default. This runtime defense is independent of and does not replace verifier dataflow proof of definite assignment.

## Review lenses

- **Invariant**: no public API can mutate a register's value without also updating its definedness — `regs` is private, `RegisterSlot` is private, and the only three functions that ever touch either are the ones changed in this PR.
- **Semantic**: `Value::Unit` remains fully constructible and readable once genuinely written (tests 1, 3).
- **Performance**: register-file allocation count is unchanged (one `Vec` per frame); `RegisterSlot`'s layout costs nothing over `Value` (measured, not assumed).
- **API**: public surface only shrank (one field privatized); no new public API was added, matching "do not invent API proactively."
- **Boundary**: the VM rejects undefined reads independent of and prior to #1756's verifier-side fix (test 1's cross-layer assertion).
- **Qualification**: both original Unit-materialization bugs (fresh-r0, write-then-gap) are confirmed RED on pre-fix code, GREEN after.

## Validation

- `cargo test -p sm-vm --all-features`: 124+1+23 pass (111 pre-batch baseline + 5 from #1771, now merged to main + 8 new: 7 regression + 1 layout evidence)
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 106/106 pass (unchanged)
- `cargo test -p sm-runtime-core --all-features`: 9/9 pass (unchanged)
- `cargo test --test public_api_contracts`: 5/5 pass — the one intentional snapshot delta described above
- `cargo test --lib` (root `semantic_language` crate, which re-exports `Frame` as a type): 7/7 pass, unaffected
- `cargo clippy -p sm-vm --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `git diff --check` / `git diff --cached --check`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

## Post-review status

Independently reviewed live; approved with one P2 (doc drift, fixed in `e9c68cc2`, thread resolved) and one P3 nit (layout-test naming/wording, fixed above). Rebased onto `main` after #1771 (#1823) merged as `edfb8084` — one mechanical two-insertion conflict in `crates/sm-vm/src/semcode_vm.rs` (both PRs added new test blocks at the same location; resolved by keeping both blocks concatenated, no semantic overlap) and clean auto-merges in `docs/spec/vm.md` and the public-API snapshot. Joint qualification re-run post-rebase confirms both PRs' regression matrices pass together: MAP_GET miss+invalid register, MAP_GET hit+invalid default, undefined low register, high-write gap, and explicit-Unit cases all green side by side (13/13). Full local suite, clippy, `admission_guard.ps1 -PRReady`, and `7hell` all re-run and green on the rebased HEAD; force-pushed for fresh hosted CI before merge.

## Scope

`crates/sm-verify/`, `crates/sm-runtime-core/`, `crates/sm-format/`, `crates/sm-ir/` untouched. No SemCode format/revision change. #1756 (verifier-side definite-assignment proof) and #1771 (`MAP_GET`'s own error-swallow) are independent, separate repairs — not started or touched by this PR. This PR only changes what "physically present" means for register storage; #1771's `MAP_GET` fix is compatible with (and independent of) this change — a rebase check is expected once both are ready per the batch's own merge-order note.

## Batch conflict note

Touches `Frame`, `push_frame`, `get_reg`, `write_reg`; `Opcode::MapGet`'s own region is untouched by this PR. Rebased onto main after #1771 (#1823) merged — see Post-review status above.

