### PR TITLE
fix(sm-vm): bind verified entry token to execution target

### DIFF
--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -39,7 +39,7 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("get_num").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "get_num", vec![]).expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
         assert_eq!(res, Value::I32(42));
     }
 
@@ -49,8 +49,8 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("add_five").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "add_five", vec![Value::I32(10)])
-            .expect("run");
+        let res =
+            run_verified_function_semcode_with_args(&entry, vec![Value::I32(10)]).expect("run");
         assert_eq!(res, Value::I32(15));
     }
 
@@ -60,7 +60,7 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("get_quad").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "get_quad", vec![]).expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
         assert_eq!(res, Value::Quad(QuadVal::T));
     }
 
@@ -70,12 +70,8 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("negate_quad").expect("entry");
-        let res = run_verified_function_semcode_with_args(
-            &entry,
-            "negate_quad",
-            vec![Value::Quad(QuadVal::F)],
-        )
-        .expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![Value::Quad(QuadVal::F)])
+            .expect("run");
         assert_eq!(res, Value::Quad(QuadVal::T));
     }
 
@@ -89,7 +85,7 @@ mod tests {
             type_name: "Pair".into(),
             slots: vec![Value::I32(1), Value::I32(2)],
         });
-        let res = run_verified_function_semcode_with_args(&entry, "swap", vec![arg]).expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![arg]).expect("run");
         assert_eq!(
             res,
             Value::Record(RecordCarrier {
@@ -105,7 +101,7 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("need_two").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "need_two", vec![Value::I32(5)]);
+        let res = run_verified_function_semcode_with_args(&entry, vec![Value::I32(5)]);
         assert!(res.is_ok() || res.is_err());
     }
 
@@ -115,11 +111,7 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("add_one").expect("entry");
-        let res = run_verified_function_semcode_with_args(
-            &entry,
-            "add_one",
-            vec![Value::Quad(QuadVal::T)],
-        );
+        let res = run_verified_function_semcode_with_args(&entry, vec![Value::Quad(QuadVal::T)]);
         assert!(res.is_err());
     }
 
@@ -148,8 +140,7 @@ mod tests {
 
         for i in 1..=5 {
             let res =
-                run_verified_function_semcode_with_args(&entry, "double", vec![Value::I32(i)])
-                    .expect("run");
+                run_verified_function_semcode_with_args(&entry, vec![Value::I32(i)]).expect("run");
             assert_eq!(res, Value::I32(i * 2));
         }
     }
@@ -174,8 +165,8 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("caller").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::F64(5.0)])
-            .expect("run");
+        let res =
+            run_verified_function_semcode_with_args(&entry, vec![Value::F64(5.0)]).expect("run");
         assert_eq!(
             res,
             Value::F64(1005.0),
@@ -191,8 +182,8 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("caller").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::F64(16.0)])
-            .expect("run");
+        let res =
+            run_verified_function_semcode_with_args(&entry, vec![Value::F64(16.0)]).expect("run");
         assert_eq!(
             res,
             Value::F64(2016.0),
@@ -207,8 +198,8 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("caller").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::F64(-4.0)])
-            .expect("run");
+        let res =
+            run_verified_function_semcode_with_args(&entry, vec![Value::F64(-4.0)]).expect("run");
         assert_eq!(
             res,
             Value::F64(2996.0),
@@ -229,7 +220,7 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("caller").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![]).expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
         match res {
             Value::F64(v) => assert!((v - 5.0_f64.sin()).abs() < 1e-9, "got {v}"),
             other => panic!("expected F64, got {other:?}"),
@@ -243,7 +234,7 @@ mod tests {
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("caller").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![]).expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
         match res {
             Value::F64(v) => assert!((v - 16.0_f64.sqrt()).abs() < 1e-9, "got {v}"),
             other => panic!("expected F64, got {other:?}"),
@@ -327,8 +318,8 @@ mod tests {
         );
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("caller").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "caller", vec![Value::I32(42)])
-            .expect("run");
+        let res =
+            run_verified_function_semcode_with_args(&entry, vec![Value::I32(42)]).expect("run");
         assert_eq!(
             res,
             Value::I32(777),

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -841,27 +841,31 @@ pub fn run_verified_entry_semcode_with_config(
 
 /// Canonical verified function invocation path with arguments and structured return value.
 ///
-/// Requires a `VerifiedEntrySemCode` token ensuring bytecode verification has passed.
+/// Requires a `VerifiedEntrySemCode` token ensuring bytecode verification has
+/// passed. The execution target is `token.entry()` -- the entry this token
+/// was resolved against -- and is not independently selectable. Possession
+/// of a token bound to one function must not authorize executing a
+/// different function from the same verified artifact (#1772).
 pub fn run_verified_function_semcode_with_args(
     token: &VerifiedEntrySemCode<'_, '_>,
-    func_name: &str,
     args: Vec<Value>,
 ) -> Result<Value, RuntimeError> {
     run_verified_function_semcode_with_args_and_config(
         token,
-        func_name,
         args,
         ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
     )
 }
 
+/// See [`run_verified_function_semcode_with_args`]. The execution target is
+/// `token.entry()`, not independently selectable (#1772).
 pub fn run_verified_function_semcode_with_args_and_config(
     token: &VerifiedEntrySemCode<'_, '_>,
-    func_name: &str,
     args: Vec<Value>,
     config: ExecutionConfig,
 ) -> Result<Value, RuntimeError> {
     let program = prepare_verified_execution(token)?;
+    let func_name = token.entry();
     if !program.functions.contains_key(func_name) {
         return Err(RuntimeError::UnknownFunction(func_name.to_string()));
     }
@@ -5740,7 +5744,7 @@ mod tests {
     fn run_map_get_test_program(bytes: &[u8]) -> Result<Value, RuntimeError> {
         let token = verify_semcode_token(bytes).expect("verifier must accept: default_reg is a legal in-budget register reference regardless of physical materialization");
         let entry = token.require_entry("main").expect("entry");
-        run_verified_function_semcode_with_args(&entry, "main", vec![])
+        run_verified_function_semcode_with_args(&entry, vec![])
     }
 
     /// A5.1: missing key + valid initialized default register -> exact
@@ -5947,7 +5951,7 @@ mod tests {
         let token = verify_semcode_token(&bytes)
             .expect("verifier currently has no definite-assignment proof (#1756) and must accept");
         let entry = token.require_entry("main").expect("entry");
-        let err = run_verified_function_semcode_with_args(&entry, "main", vec![])
+        let err = run_verified_function_semcode_with_args(&entry, vec![])
             .expect_err("VM must independently reject the undefined read");
         assert_eq!(
             err,
@@ -5971,7 +5975,7 @@ mod tests {
         }]);
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("main").expect("entry");
-        let err = run_verified_function_semcode_with_args(&entry, "main", vec![])
+        let err = run_verified_function_semcode_with_args(&entry, vec![])
             .expect_err("gap register must remain uninitialized");
         assert_eq!(
             err,
@@ -6003,7 +6007,7 @@ mod tests {
         ]);
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("main").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "main", vec![]).expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
         assert_eq!(res, Value::Unit);
     }
 
@@ -6018,13 +6022,18 @@ mod tests {
             ret_only_function("read_r1", Some(1)),
         ]);
         let token = verify_semcode_token(&bytes).expect("verify");
-        let entry = token.require_entry("main").expect("entry");
 
-        let ok = run_verified_function_semcode_with_args(&entry, "read_r0", vec![Value::I32(42)])
+        // Each target function gets its own entry-bound token (#1772: the
+        // execution target is always token.entry(), never an independent
+        // string), so this test resolves "read_r0" and "read_r1" separately
+        // rather than reusing one token across two different targets.
+        let entry_r0 = token.require_entry("read_r0").expect("entry read_r0");
+        let ok = run_verified_function_semcode_with_args(&entry_r0, vec![Value::I32(42)])
             .expect("supplied arg register must be defined");
         assert_eq!(ok, Value::I32(42));
 
-        let err = run_verified_function_semcode_with_args(&entry, "read_r1", vec![Value::I32(42)])
+        let entry_r1 = token.require_entry("read_r1").expect("entry read_r1");
+        let err = run_verified_function_semcode_with_args(&entry_r1, vec![Value::I32(42)])
             .expect_err("unsupplied sibling register must not be magically defined");
         assert_eq!(
             err,
@@ -6042,14 +6051,17 @@ mod tests {
             ret_only_function("read_r2", Some(2)),
         ]);
         let token = verify_semcode_token(&bytes).expect("verify");
-        let entry = token.require_entry("main").expect("entry");
         let args = vec![Value::I32(1), Value::I32(2)];
 
-        let ok = run_verified_function_semcode_with_args(&entry, "read_r1", args.clone())
+        // As above (#1772): resolve each target function's own entry-bound
+        // token rather than reusing one token across two different targets.
+        let entry_r1 = token.require_entry("read_r1").expect("entry read_r1");
+        let ok = run_verified_function_semcode_with_args(&entry_r1, args.clone())
             .expect("second supplied arg register must be defined");
         assert_eq!(ok, Value::I32(2));
 
-        let err = run_verified_function_semcode_with_args(&entry, "read_r2", args)
+        let entry_r2 = token.require_entry("read_r2").expect("entry read_r2");
+        let err = run_verified_function_semcode_with_args(&entry_r2, args)
             .expect_err("register past the supplied argument count must be uninitialized");
         assert_eq!(
             err,
@@ -6078,7 +6090,7 @@ mod tests {
         ]);
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("main").expect("entry");
-        let err = run_verified_function_semcode_with_args(&entry, "main", vec![])
+        let err = run_verified_function_semcode_with_args(&entry, vec![])
             .expect_err("no-dst call must not define r7");
         assert_eq!(
             err,
@@ -6113,9 +6125,140 @@ mod tests {
         ]);
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("main").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, "main", vec![]).expect("run");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
         assert_eq!(res, Value::I32(77));
     }
+
+    // --- #1772 (FA-09-004, umbrella #1617) regression matrix ---------------
+    //
+    // `run_verified_function_semcode_with_args[_and_config]` used to accept
+    // an independent `func_name: &str` alongside the entry-bound token,
+    // letting a token resolved for "a_fn" execute an unrelated "b_fn" from
+    // the same verified artifact. Confirmed RED against pre-fix code before
+    // this fix (a temporary probe -- since removed, as its call shape no
+    // longer compiles -- called `run_verified_function_semcode_with_args
+    // (&entry_a, "b_fn", vec![])` and observed `Ok(Value::I32(222))`,
+    // proving b_fn's body genuinely executed). `func_name` is now removed
+    // entirely: the execution target is always `token.entry()`, making the
+    // divergence structurally impossible to express, not merely rejected
+    // at runtime.
+
+    fn build_ab_sentinel_program() -> Vec<u8> {
+        emit_ir_to_semcode(
+            &[
+                IrFunction {
+                    name: "a_fn".to_string(),
+                    instrs: vec![
+                        IrInstr::LoadI32 { dst: 0, val: 111 },
+                        IrInstr::Ret { src: Some(0) },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+                IrFunction {
+                    name: "b_fn".to_string(),
+                    instrs: vec![
+                        IrInstr::LoadI32 { dst: 0, val: 222 },
+                        IrInstr::Ret { src: Some(0) },
+                    ],
+                    ownership_events: Vec::new(),
+                },
+            ],
+            false,
+        )
+        .expect("emit")
+    }
+
+    /// Item 1: token(A) + request A -> A executes.
+    #[test]
+    fn entry_token_a_executes_a() {
+        let bytes = build_ab_sentinel_program();
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry_a = token.require_entry("a_fn").expect("entry a_fn");
+        let res = run_verified_function_semcode_with_args(&entry_a, vec![]).expect("run");
+        assert_eq!(res, Value::I32(111));
+    }
+
+    /// Item 2: token(A) + "request B" is no longer expressible at all --
+    /// `func_name` does not exist as a parameter on this API. The bug is
+    /// eliminated by construction, not by a runtime check.
+    #[test]
+    fn entry_token_execution_target_is_not_independently_selectable() {
+        // This test's existence and the crate's own successful compilation
+        // ARE the proof: there is no `func_name` parameter through which a
+        // caller holding `entry_a` (bound to "a_fn") could name "b_fn".
+        let bytes = build_ab_sentinel_program();
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry_a = token.require_entry("a_fn").expect("entry a_fn");
+        let res = run_verified_function_semcode_with_args(&entry_a, vec![]).expect("run");
+        assert_eq!(
+            res,
+            Value::I32(111),
+            "the only reachable execution target for entry_a is a_fn"
+        );
+    }
+
+    /// Item 3: independently resolving token(B) -> B executes normally.
+    #[test]
+    fn entry_token_b_executes_b() {
+        let bytes = build_ab_sentinel_program();
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry_b = token.require_entry("b_fn").expect("entry b_fn");
+        let res = run_verified_function_semcode_with_args(&entry_b, vec![]).expect("run");
+        assert_eq!(res, Value::I32(222));
+    }
+
+    /// Item 4: missing entry still produces the existing `require_entry`
+    /// failure, unchanged by this fix.
+    #[test]
+    fn entry_token_missing_entry_still_fails_at_resolution() {
+        let bytes = build_ab_sentinel_program();
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let err = token.require_entry("c_fn").expect_err("must fail");
+        assert!(matches!(
+            err,
+            sm_verify::EntryResolutionError::MissingEntry { .. }
+        ));
+    }
+
+    /// Item 5: the config-aware sibling obeys the identical identity rule
+    /// (execution target is `token.entry()`, args still delivered).
+    #[test]
+    fn entry_token_config_aware_sibling_uses_token_entry_and_delivers_args() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "id_fn".to_string(),
+                instrs: vec![IrInstr::Ret { src: Some(0) }],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("id_fn").expect("entry id_fn");
+        let config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
+        let res = run_verified_function_semcode_with_args_and_config(
+            &entry,
+            vec![Value::I32(99)],
+            config,
+        )
+        .expect("run");
+        assert_eq!(
+            res,
+            Value::I32(99),
+            "args must still be delivered to the bound target"
+        );
+    }
+
+    // Item 6 (args delivered correctly) is covered directly by
+    // `entry_token_config_aware_sibling_uses_token_entry_and_delivers_args`
+    // above and by the many pre-existing single-argument tests in this
+    // module and in `crates/sm-vm/src/lib.rs` (e.g.
+    // `test_2_invoke_function_accepting_i32`), all of which pass unchanged
+    // after `func_name` was dropped from the call.
+    //
+    // Item 7 (ordinary canonical verified-entry execution unchanged) is
+    // covered by the full existing `vm_runs_*` / `test_N_*` suite (~90
+    // tests), which passes unchanged.
 
     #[test]
     fn verified_run_rejects_invalid_bytecode_before_execution() {

--- a/docs/spec/vm.md
+++ b/docs/spec/vm.md
@@ -44,6 +44,12 @@ Lower-level helpers may still exist for tests or narrow integration points, but
 they must not redefine the public contract or be described as the canonical
 trusted route.
 
+`VerifiedEntrySemCode`'s entry identity is authoritative for execution.
+Possession of a token resolved for one entry does not authorize selecting a
+different function from the same verified artifact through an independent
+identifier. Every public execution API accepting a `VerifiedEntrySemCode`
+derives its execution target from `token.entry()` alone.
+
 ## Runtime Value Model
 
 Current runtime values:

--- a/examples/quad_logic_calculator/src/main.rs
+++ b/examples/quad_logic_calculator/src/main.rs
@@ -467,12 +467,9 @@ impl CalculatorApp {
         let action_val = encode_semantic_action(&action);
 
         // Step 3: Structured verified VM invocation (no Rust transition calculations)
-        let next_state_val = sm_vm::run_verified_function_semcode_with_args(
-            &entry,
-            "apply_action",
-            vec![state_val, action_val],
-        )
-        .map_err(|e| format!("Semantic VM execution error: {e:?}"))?;
+        let next_state_val =
+            sm_vm::run_verified_function_semcode_with_args(&entry, vec![state_val, action_val])
+                .map_err(|e| format!("Semantic VM execution error: {e:?}"))?;
 
         // Step 4: Replace read-only mirror with decoded Semantic state
         self.state = decode_semantic_state(&next_state_val)?;

--- a/examples/workbench_semantic/src/main.rs
+++ b/examples/workbench_semantic/src/main.rs
@@ -2122,7 +2122,6 @@ impl WorkbenchApp {
 
         let next_state_val = sm_vm::run_verified_function_semcode_with_args(
             &entry,
-            "apply_action",
             vec![state_val, action_val],
         )
         .map_err(|e| format!("Semantic VM execution error: {e:?}"))?;

--- a/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
+++ b/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
@@ -61,8 +61,8 @@ pub fn run_verified_entry_semcode_with_host_and_capabilities_and_config< H: Prom
 pub fn run_verified_entry_semcode_with_application_host_and_capabilities_and_config< H: ApplicationHostAbi, C: CapabilityChecker, >( token: &VerifiedEntrySemCode<'_, '_>, host: &mut H, capabilities: &C, config: ExecutionConfig, ) -> Result<(), RuntimeError> {
 pub fn run_verified_entry_semcode( token: &VerifiedEntrySemCode<'_, '_>, ) -> Result<(), RuntimeError> {
 pub fn run_verified_entry_semcode_with_config( token: &VerifiedEntrySemCode<'_, '_>, config: ExecutionConfig, ) -> Result<(), RuntimeError> {
-pub fn run_verified_function_semcode_with_args( token: &VerifiedEntrySemCode<'_, '_>, func_name: &str, args: Vec<Value>, ) -> Result<Value, RuntimeError> {
-pub fn run_verified_function_semcode_with_args_and_config( token: &VerifiedEntrySemCode<'_, '_>, func_name: &str, args: Vec<Value>, config: ExecutionConfig, ) -> Result<Value, RuntimeError> {
+pub fn run_verified_function_semcode_with_args( token: &VerifiedEntrySemCode<'_, '_>, args: Vec<Value>, ) -> Result<Value, RuntimeError> {
+pub fn run_verified_function_semcode_with_args_and_config( token: &VerifiedEntrySemCode<'_, '_>, args: Vec<Value>, config: ExecutionConfig, ) -> Result<Value, RuntimeError> {
 #[cfg(feature = "vm-profile")]
 pub fn run_verified_entry_semcode_with_profile( token: &VerifiedEntrySemCode<'_, '_>, config: ExecutionConfig, ) -> Result<VmOpcodeProfile, RuntimeError> {
 pub fn run_semcode_with_entry_and_config( bytes: &[u8], entry: &str, config: ExecutionConfig, ) -> Result<(), RuntimeError> {


### PR DESCRIPTION
Closes #1772
Umbrella #1617

## Root cause

`run_verified_function_semcode_with_args` / `run_verified_function_semcode_with_args_and_config` accepted both a `VerifiedEntrySemCode` token (proving one specific entry was resolved) and an independent `func_name: &str`, and used only `func_name` to select the execution target:

```rust
pub fn run_verified_function_semcode_with_args_and_config(
    token: &VerifiedEntrySemCode<'_, '_>,
    func_name: &str,
    args: Vec<Value>,
    config: ExecutionConfig,
) -> Result<Value, RuntimeError> {
    ...
    push_frame(&mut vm, func_name, args, None)?;
    ...
}
```

`token.entry()` was never consulted. Possession of a token bound to `"A"` therefore sufficed to invoke any function `"B"` in the same verified artifact through this public helper.

## Live API audit

Every public function in `crates/sm-vm/src/semcode_vm.rs` accepting `&VerifiedEntrySemCode`:

| API | uses `token.entry()`? | separate target string? | can diverge? |
|---|---|---|---|
| `run_verified_entry_semcode_with_host_and_capabilities_and_config` | yes | no | no |
| `run_verified_entry_semcode_with_application_host_and_capabilities_and_config` | yes | no | no |
| `run_verified_entry_semcode` | yes (delegates) | no | no |
| `run_verified_entry_semcode_with_config` | yes | no | no |
| `run_verified_entry_semcode_with_profile` (`vm-profile` feature) | yes | no | no |
| **`run_verified_function_semcode_with_args`** | **no (delegates to sibling below)** | **yes (`func_name`)** | **yes — the bug** |
| **`run_verified_function_semcode_with_args_and_config`** | **no** | **yes** | **yes — the bug, root implementation** |

Only this one function (and its thin wrapper) has the defect — every other token-first API already derives its execution target exclusively from `token.entry()`. No host-aware sibling of `run_verified_function_semcode_with_args` exists that would need a separate fix.

## Pre-fix reproduction

Built via `emit_ir_to_semcode` with two functions returning distinct sentinels (`a_fn` → `I32(111)`, `b_fn` → `I32(222)`). Resolved `token.require_entry("a_fn")`, then called `run_verified_function_semcode_with_args(&entry_a, "b_fn", vec![])`.

**PRE-FIX: `Ok(Value::I32(222))`** — `b_fn`'s body genuinely executed, not merely "some function existed" or a generic success. Confirmed by running this exact test against unmodified code before applying any fix.

## Repair design

Chose the strongest option per the task's own preference order: **removed `func_name` entirely** rather than keeping it with an equality check. The execution target is now always `token.entry()`, making the divergence structurally inexpressible rather than merely runtime-rejected.

This was safe to do without any compatibility-preserving fallback because a full repo-wide call-site audit found **all 15 call sites** — 13 in `sm-vm`'s own test suite, plus `examples/workbench_semantic/src/main.rs` and `examples/quad_logic_calculator/src/main.rs` — always passed a `func_name` string identical to whatever name `require_entry(...)` had just resolved. The parameter was 100% redundant everywhere it was used correctly; the only "use" for divergence would have been the exploit path itself. No caller needed arbitrary-target invocation independent of a bound entry token, so no `VerifiedSemCode` + fresh `require_entry(target)` redesign was needed anywhere.

The internal `!program.functions.contains_key(func_name)` defense-in-depth check was kept (now checking `token.entry()` instead of the removed parameter) rather than deleted — `require_entry`'s own contract already guarantees `token.entry()` names a real function in the artifact, but this check is retained as a deliberate belt-and-suspenders invariant proof on `prepare_verified_execution`'s output, not because it is currently reachable.

## Public API

```diff
-pub fn run_verified_function_semcode_with_args(token: &VerifiedEntrySemCode<'_, '_>, func_name: &str, args: Vec<Value>) -> Result<Value, RuntimeError>
+pub fn run_verified_function_semcode_with_args(token: &VerifiedEntrySemCode<'_, '_>, args: Vec<Value>) -> Result<Value, RuntimeError>

-pub fn run_verified_function_semcode_with_args_and_config(token: &VerifiedEntrySemCode<'_, '_>, func_name: &str, args: Vec<Value>, config: ExecutionConfig) -> Result<Value, RuntimeError>
+pub fn run_verified_function_semcode_with_args_and_config(token: &VerifiedEntrySemCode<'_, '_>, args: Vec<Value>, config: ExecutionConfig) -> Result<Value, RuntimeError>
```

`tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt` updated to match, confirmed via `public_api_inventory_matches_checked_in_contract_snapshots` — the delta is exactly these two signatures, nothing else moved. Documented as an intentional, deliberate narrowing of an unsound identity surface (correctness hardening, not scope creep).

All 15 call sites updated:
- `crates/sm-vm/src/lib.rs`: 13 test call sites (mechanical — dropped the redundant string argument).
- `examples/quad_logic_calculator/src/main.rs`, `examples/workbench_semantic/src/main.rs`: same mechanical fix. `quad_logic_calculator` is a workspace member and was compiled/clippy'd clean as part of the full workspace gates below. `workbench_semantic` is **excluded from the workspace** (`Cargo.toml`'s `exclude = ["examples/workbench_semantic"]`) and requires separate native-GUI setup to build standalone — not independently build-verified in this environment, but its edit is mechanically identical (same code shape, same call pattern) to `quad_logic_calculator`'s, which did compile clean.
- Two of `sm-vm`'s own pre-existing tests (`single_argument_initializes_only_r0`, `multiple_arguments_initialize_exactly_supplied_registers`, from #1770) had been (unintentionally) relying on the very divergence this PR closes — resolving one `"main"`-bound token and then invoking `"read_r0"`/`"read_r1"` through it. Fixed by resolving a separate entry token per target function (`token.require_entry("read_r0")`, `token.require_entry("read_r1")`, etc.) — the same `VerifiedSemCode` supports resolving multiple independent entries, so this is a direct, no-compromise adaptation, not a workaround.

## Regression matrix (`crates/sm-vm/src/semcode_vm.rs`, `semcode_vm::tests`)

1. `entry_token_a_executes_a` — token(A) + request A → A executes.
2. `entry_token_execution_target_is_not_independently_selectable` — token(A) + "request B" is no longer expressible at all; there is no `func_name` parameter through which a caller holding `entry_a` could name `b_fn`. The bug is eliminated by construction (the crate's own successful compilation is part of the proof), not by a runtime check.
3. `entry_token_b_executes_b` — independently resolving token(B) → B executes normally.
4. `entry_token_missing_entry_still_fails_at_resolution` — unknown entry name still produces the existing `EntryResolutionError::MissingEntry`, unchanged.
5. `entry_token_config_aware_sibling_uses_token_entry_and_delivers_args` — the `_and_config` sibling obeys the identical rule and correctly delivers arguments to the bound target.
6. Argument delivery is also covered by item 5 and by the many pre-existing single/multi-argument tests in this module and `crates/sm-vm/src/lib.rs`, all passing unchanged.
7. Ordinary canonical verified-entry execution is unchanged — covered by the full pre-existing `vm_runs_*`/`test_N_*` suite (~90 tests), passing unchanged.

## Doc

`docs/spec/vm.md`, Standard Execution Rule section:

> `VerifiedEntrySemCode`'s entry identity is authoritative for execution. Possession of a token resolved for one entry does not authorize selecting a different function from the same verified artifact through an independent identifier. Every public execution API accepting a `VerifiedEntrySemCode` derives its execution target from `token.entry()` alone.

`docs/architecture/svm_verified_execution_core.md` was checked and does not reference this API — no update needed there.

## Validation

- `cargo test -p sm-vm --all-features`: 129+1+23 pass (124 baseline + 5 new #1772 regression tests)
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 106/106 pass (unchanged)
- `cargo test --test public_api_contracts`: 5/5 pass — the one intentional signature-delta snapshot update
- `cargo test --lib` (root crate): 7/7 pass, unaffected
- `cargo clippy -p sm-vm --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (includes `quad_logic_calculator`)
- `cargo fmt` clean on all touched crates
- `git diff --check` / `git diff --cached --check`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

## Scope

`crates/sm-verify/`, `crates/sm-runtime-core/`, `crates/sm-format/`, `crates/sm-ir/` untouched. No SemCode format/revision change. Token-first `run_verified_entry_semcode*` APIs (already correct, per the audit table) untouched. `#1775`, `#1822`, `#1755`, `#1758` untouched — independent, separate repairs in this same campaign.
