### PR TITLE
fix(prom-runtime): admit with configured runtime quotas

### DIFF
--- a/crates/prom-runtime/src/lib.rs
+++ b/crates/prom-runtime/src/lib.rs
@@ -11,7 +11,7 @@ use prom_state::{
     StateUpdate, StateValidationError,
 };
 use sm_runtime_core::{ExecutionConfig, ExecutionContext};
-use sm_verify::{verify_semcode_token, EntryResolutionError};
+use sm_verify::{verify_semcode_token_with_quotas, EntryResolutionError};
 use sm_vm::{run_verified_entry_semcode_with_host_and_capabilities_and_config, RuntimeError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -369,7 +369,8 @@ impl<'a, H: PrometheusHostAbi, C: CapabilityChecker> ExecutionSession<'a, H, C> 
         bytes: &[u8],
         entry: &str,
     ) -> Result<(), RuntimeError> {
-        let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+        let token = verify_semcode_token_with_quotas(bytes, self.config.quotas)
+            .map_err(RuntimeError::VerifierRejected)?;
         let entry_token = token.require_entry(entry).map_err(|err| match err {
             EntryResolutionError::MissingEntry { entry } => RuntimeError::UnknownFunction(entry),
         })?;
@@ -536,7 +537,8 @@ impl<'a, B: GateBinding, C: CapabilityChecker> GateExecutionSession<'a, B, C> {
         entry: &str,
     ) -> Result<(), RuntimeError> {
         let mut host = GateHostAdapter::new(self.registry, self.binding);
-        let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+        let token = verify_semcode_token_with_quotas(bytes, self.config.quotas)
+            .map_err(RuntimeError::VerifierRejected)?;
         let entry_token = token.require_entry(entry).map_err(|err| match err {
             EntryResolutionError::MissingEntry { entry } => RuntimeError::UnknownFunction(entry),
         })?;

--- a/tests/prometheus_runtime.rs
+++ b/tests/prometheus_runtime.rs
@@ -3,7 +3,7 @@ use semantic_language::prom_abi::{AbiValue, RecordingHostAbi};
 use semantic_language::prom_cap::{CapabilityKind, CapabilityManifest};
 use semantic_language::prom_gates::{DeterministicGateMock, GateDescriptor, GateId, GateRegistry};
 use semantic_language::prom_runtime::{ExecutionSession, GateExecutionSession};
-use semantic_language::runtime_core::ExecutionContext;
+use semantic_language::runtime_core::{ExecutionConfig, ExecutionContext};
 use semantic_language::semcode_vm::RuntimeError;
 
 fn runtime_program() -> Vec<IrFunction> {
@@ -310,4 +310,97 @@ fn execution_session_denies_clock_read_without_manifest_capability() {
 
     drop(session);
     assert_eq!(host.clock_reads, 0);
+}
+
+// --- #1822 (umbrella #1617) regression matrix -------------------------
+//
+// `ExecutionSession`/`GateExecutionSession::run_verified_semcode_entry`
+// used to admit via the hardcoded-default `verify_semcode_token(bytes)`
+// (VerifiedLocal's 4096-register budget) regardless of `self.config`,
+// even when the session was explicitly constructed with `kernel_bound()`
+// (8192). Built directly via `emit_ir_to_semcode` -- a single `LoadI32`
+// into `r5000` (between the two budgets) followed by a `Ret` reading it
+// back -- rather than the older raw-byte-patching idiom, for the same
+// reason established elsewhere in this campaign: full, unambiguous
+// control over the exact register referenced.
+
+fn r5000_program() -> Vec<IrFunction> {
+    vec![IrFunction {
+        name: "main".to_string(),
+        instrs: vec![
+            IrInstr::LoadI32 { dst: 5000, val: 1 },
+            IrInstr::Ret { src: Some(5000) },
+        ],
+        ownership_events: Vec::new(),
+    }]
+}
+
+#[test]
+fn execution_session_kernel_bound_admits_r5000() {
+    let bytes = emit_ir_to_semcode(&r5000_program(), false).expect("emit");
+    let manifest = CapabilityManifest::new();
+    let metadata = manifest.metadata();
+    let mut host = RecordingHostAbi::default();
+    let mut session = ExecutionSession::kernel_bound(&mut host, &manifest, metadata);
+    session
+        .run_verified_semcode(&bytes)
+        .expect("KernelBound session must admit and run an r5000 artifact");
+}
+
+#[test]
+fn execution_session_verified_local_rejects_r5000() {
+    let bytes = emit_ir_to_semcode(&r5000_program(), false).expect("emit");
+    let manifest = CapabilityManifest::new();
+    let metadata = manifest.metadata();
+    let mut host = RecordingHostAbi::default();
+    let mut session = ExecutionSession::new(
+        &mut host,
+        &manifest,
+        ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+        metadata,
+    );
+    let err = session
+        .run_verified_semcode(&bytes)
+        .expect_err("VerifiedLocal session must still reject an r5000 artifact");
+    assert!(
+        matches!(err, RuntimeError::VerifierRejected(_)),
+        "expected VerifierRejected, got {err:?}"
+    );
+}
+
+#[test]
+fn gate_execution_session_kernel_bound_admits_r5000() {
+    let bytes = emit_ir_to_semcode(&r5000_program(), false).expect("emit");
+    let registry = GateRegistry::new();
+    let manifest = CapabilityManifest::new();
+    let metadata = manifest.metadata();
+    let mut binding = DeterministicGateMock::new();
+    let mut session =
+        GateExecutionSession::kernel_bound(&registry, &mut binding, &manifest, metadata);
+    session
+        .run_verified_semcode(&bytes)
+        .expect("KernelBound gate session must admit and run an r5000 artifact");
+}
+
+#[test]
+fn gate_execution_session_verified_local_rejects_r5000() {
+    let bytes = emit_ir_to_semcode(&r5000_program(), false).expect("emit");
+    let registry = GateRegistry::new();
+    let manifest = CapabilityManifest::new();
+    let metadata = manifest.metadata();
+    let mut binding = DeterministicGateMock::new();
+    let mut session = GateExecutionSession::new(
+        &registry,
+        &mut binding,
+        &manifest,
+        ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+        metadata,
+    );
+    let err = session
+        .run_verified_semcode(&bytes)
+        .expect_err("VerifiedLocal gate session must still reject an r5000 artifact");
+    assert!(
+        matches!(err, RuntimeError::VerifierRejected(_)),
+        "expected VerifierRejected, got {err:?}"
+    );
 }


### PR DESCRIPTION
Closes #1822
Umbrella #1617
Follow-up to #1757 / PR #1821

## Root cause

`ExecutionSession`/`GateExecutionSession::run_verified_semcode_entry` (`crates/prom-runtime/src/lib.rs`) each already carry a caller-supplied `self.config: ExecutionConfig` — including explicit `kernel_bound()` constructors — and pass `self.config` through to actual execution (`run_verified_entry_semcode_with_host_and_capabilities_and_config(&entry_token, ..., self.config)`). But admission was still performed via the hardcoded-default `sm_verify::verify_semcode_token(bytes)` (`VerifiedLocal`'s 4096-register budget), regardless of `self.config.quotas`. A `kernel_bound()`-constructed session (8192 registers) still could not admit any SemCode exceeding `VerifiedLocal`'s 4096-register budget — the same class of admission/execution quota-profile mismatch #1757 fixed for `sm-vm`'s byte-based compatibility shims.

## Live call-site audit

| Call site | admits via |
|---|---|
| `ExecutionSession::run_verified_semcode` | delegates to `run_verified_semcode_entry` |
| `ExecutionSession::run_verified_semcode_entry` | `verify_semcode_token(bytes)` — hardcoded, **fixed** |
| `GateExecutionSession::run_verified_semcode` | delegates to `run_verified_semcode_entry` |
| `GateExecutionSession::run_verified_semcode_entry` | `verify_semcode_token(bytes)` — hardcoded, **fixed** |

Confirmed via `grep -n "verify_semcode_token" crates/prom-runtime/src/lib.rs`: exactly these two call sites in the whole crate, both fixed. No other admission path exists in `prom-runtime`.

## Repair

Routed `self.config.quotas` (`RuntimeQuotas` is `Copy`, no clone needed) into `verify_semcode_token_with_quotas` (added by #1757) at both call sites, instead of the hardcoded-default `verify_semcode_token`:

```diff
-let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
+let token = verify_semcode_token_with_quotas(bytes, self.config.quotas)
+    .map_err(RuntimeError::VerifierRejected)?;
```

Only `.quotas` is threaded through, matching #1757's own established pattern of not passing the entire `ExecutionConfig` into `sm-verify` (`trace_enabled` and other execution-mechanics fields stay out of the verifier's concern). No token-first API was touched — those correctly do not re-verify.

## Pre-fix reproduction

Built directly via `emit_ir_to_semcode` (a single `LoadI32` into `r5000` — between `VerifiedLocal`'s 4096 and `KernelBound`'s 8192 budgets — followed by a `Ret` reading it back), not the older raw-byte-patching idiom, for the same reason established elsewhere in this campaign: full, unambiguous control over the exact register referenced.

Confirmed RED (both new "kernel_bound admits r5000" tests run against the pre-fix code first, before the production fix was applied):

```
execution_session_kernel_bound_admits_r5000:
  VerifierRejected(RejectReport { diagnostics: [VerificationDiagnostic {
    code: InvalidRegisterReference, function: Some("main"), offset: Some(5000),
    message: "function references register r5000, exceeding the register budget of 4096" }] })

gate_execution_session_kernel_bound_admits_r5000:
  identical VerifierRejected(InvalidRegisterReference) result
```

Both `..._verified_local_rejects_r5000` negative tests already passed pre-fix (correctly rejecting either way), confirming the isolated bug was specifically in the KernelBound-admits path.

## Regression matrix (`tests/prometheus_runtime.rs`)

1. `execution_session_kernel_bound_admits_r5000` — `ExecutionSession::kernel_bound` + r5000 → admission succeeds and executes (was `VerifierRejected`, now `Ok`).
2. `execution_session_verified_local_rejects_r5000` — `ExecutionSession::new(..., VerifiedLocal, ...)` + same r5000 bytes → still `VerifierRejected` (proves the stricter canonical path is unaffected — the critical proof that configured quotas now *take effect* without *weakening* anything).
3. `gate_execution_session_kernel_bound_admits_r5000` — `GateExecutionSession::kernel_bound` + r5000 → same correct admitting behavior as item 1.
4. `gate_execution_session_verified_local_rejects_r5000` — `GateExecutionSession::new(..., VerifiedLocal, ...)` + r5000 → same correct rejecting behavior as item 2.
5. Ordinary programs through the normal default-quota path: all 9 pre-existing tests in this file (all using `kernel_bound()`, various real programs exercising `GateRead`/`GateWrite`/`StateQuery`/`StateUpdate`/`EventPost`/`ClockRead`) pass unchanged — none of them were near the register-budget boundary, so nothing regresses for the common case.

## Doc

Checked `docs/spec/runtime.md` (the only doc referencing `ExecutionSession`/`GateExecutionSession`). Its existing "Session Rule" already states "session context is explicit through `ExecutionConfig` / `ExecutionContext`" — that was already the intended contract; this fix makes it true rather than silently violated. No doc text was inaccurate and needed correcting; no new section added (narrow bug fix, not a new invariant).

## Validation

- `cargo test -p prom-runtime --all-features`: 8/8 pass (unchanged)
- `cargo test --test prometheus_runtime`: 13/13 pass (9 baseline + 4 new)
- `cargo test --test prometheus_audit/prometheus_gates/prometheus_runtime_compat_matrix/prometheus_runtime_goldens/prometheus_runtime_matrix/prometheus_runtime_negative_goldens/prometheus_semantic_runtime`: all pass, unchanged (re-derived the full affected-file list live via `grep -l "ExecutionSession\|GateExecutionSession\|run_verified_semcode" tests/prometheus_*.rs` rather than trusting the issue's own list as exhaustive — found 8 files total, all green)
- `cargo test -p sm-vm --all-features`: 124+1+23 pass, unaffected
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 106/106 pass, unaffected
- `cargo test --test public_api_contracts`: 5/5 pass — zero public API delta (only internal admission-call implementation changed, no signature touched)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt` clean on `prom-runtime` and the root crate (owns `tests/`)
- `git diff --check` / `git diff --cached --check`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

**Noted, not fixed here (pre-existing, unrelated, confirmed reproducing on clean main):** `cargo clippy -p prom-runtime --all-targets --all-features -- -D warnings` (and even without `--all-features`) fails with `error: field 'header' is never read` in `crates/sm-vm/src/semcode_vm.rs`'s `VmProgramView` — a Cargo feature-unification artifact of building `prom-runtime` in isolation vs. the unified workspace build (the mandatory `cargo clippy --workspace --all-targets` gate above does not hit this; that's the command `admission_guard.ps1` actually runs). Verified via `git stash` that this reproduces identically with all of this PR's changes removed, confirming it predates and is unrelated to this fix — the same class of environmental quirk already documented in this campaign for `sm-verify --all-features` test runs. No new issue filed; noted here for the record only, since it is not part of any real gate this PR must pass.

## Scope

`crates/sm-verify/`, `crates/sm-vm/`, token-first APIs untouched — `verify_semcode_token_with_quotas` (from #1757) already provided everything this fix needed. No token/config architecture redesign. No expansion beyond `ExecutionSession`/`GateExecutionSession`'s two admission call sites. `#1772`, `#1775`, `#1755`, `#1758` untouched — independent, separate repairs in this same campaign.
