### PR TITLE
test(public-api): inventory sm-verify admission modules

### DIFF
--- a/tests/golden_snapshots/public_api/sm_verify_hello_pending_admission.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_hello_pending_admission.txt
@@ -1,0 +1,20 @@
+source: crates/sm-verify/src/hello_pending_admission.rs
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloPendingPolicyInput {
+pub operation_kind: String,
+pub payload_type: String,
+pub capability_observation_sink: String,
+pub sink_available: bool,
+pub audit_policy: String,
+pub audit_available: bool,
+pub deterministic_order: bool,
+pub requested_host_channel: Option<String>,
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloPendingPolicyReason {
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloPendingPolicyResult {
+#[cfg(feature = "std")]
+pub fn evaluate_hello_pending_policy(input: &HelloPendingPolicyInput) -> HelloPendingPolicyResult {

--- a/tests/golden_snapshots/public_api/sm_verify_hello_real_semcode_admission.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_hello_real_semcode_admission.txt
@@ -1,0 +1,15 @@
+source: crates/sm-verify/src/hello_real_semcode_admission.rs
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlledObservationAdmissionKind {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloRealSemCodeAdmissionInput {
+pub ops: Vec<HelloRealSemCodeAdmissionOp>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloRealSemCodeAdmissionOp {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloRealSemCodeAdmissionDecision {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloRealSemCodeAdmissionError {
+pub fn builtin_call_controlled_observation_admission( name: &str, ) -> Option<ControlledObservationAdmissionKind> {
+pub fn admit_controlled_text_observation_shape( text: &str, ) -> Result<ControlledObservationAdmissionKind, HelloRealSemCodeAdmissionError> {
+pub fn admit_hello_real_semcode_skeleton( input: &HelloRealSemCodeAdmissionInput, ) -> HelloRealSemCodeAdmissionDecision {

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -51,6 +51,14 @@ const TARGETS: &[(&str, &str)] = &[
         "tests/golden_snapshots/public_api/sm_verify_lib.txt",
     ),
     (
+        "crates/sm-verify/src/hello_pending_admission.rs",
+        "tests/golden_snapshots/public_api/sm_verify_hello_pending_admission.txt",
+    ),
+    (
+        "crates/sm-verify/src/hello_real_semcode_admission.rs",
+        "tests/golden_snapshots/public_api/sm_verify_hello_real_semcode_admission.txt",
+    ),
+    (
         "crates/sm-vm/src/lib.rs",
         "tests/golden_snapshots/public_api/sm_vm_lib.txt",
     ),


### PR DESCRIPTION
Closes #1755
Umbrella #1617
Residual scanner limitation: #1808

## Root cause

`tests/public_api_contracts.rs`'s `TARGETS` list only paired `crates/sm-verify/src/lib.rs` with a snapshot for the `sm-verify` crate. `sm-verify` declares two public submodules — `pub mod hello_pending_admission;` and `pub mod hello_real_semcode_admission;` (confirmed live via `grep -n "^pub mod" crates/sm-verify/src/lib.rs`) — whose public structs, enums, and functions are genuinely part of the crate's reachable public API but were never independently snapshotted. The scanner's `normalized_public_surface()` is purely textual per source file; it does not recursively expand `pub mod` declarations into the files they name. `sm-vm` already has this exact multi-file pattern handled correctly (`lib.rs` + `semcode_vm.rs` both in `TARGETS`), confirming multi-file surfaces are expected to be listed separately when they matter.

## Pre-fix mutate/revert proof (both run against unmodified code, before any TARGETS change)

1. Added `pub fn temp_probe_1755_pending_admission() {}` to `hello_pending_admission.rs` → `cargo test --test public_api_contracts` **stayed green** (5/5 pass). Reverted (`git checkout --`).
2. Added `pub fn temp_probe_1755_real_semcode_admission() {}` to `hello_real_semcode_admission.rs` → **stayed green** (5/5 pass). Reverted.

Both confirm the guard was genuinely blind to these two files' public surfaces.

## Repair

Added both files to `TARGETS`:

```rust
(
    "crates/sm-verify/src/hello_pending_admission.rs",
    "tests/golden_snapshots/public_api/sm_verify_hello_pending_admission.txt",
),
(
    "crates/sm-verify/src/hello_real_semcode_admission.rs",
    "tests/golden_snapshots/public_api/sm_verify_hello_real_semcode_admission.txt",
),
```

Snapshot content generated by the repository's own `normalized_public_surface()` function (a temporary `#[ignore]`'d generator test printed the real output for both files via `cargo test --test public_api_contracts -- --ignored --nocapture`, then was removed before this commit) — not hand-authored.

## #1808 boundary — exact claim, not overclaimed

Per the task's own instruction, this PR does **not** claim these submodule surfaces are now fully, semantically frozen at every detail level. The precise claim is: *these files now participate in the existing public API scanner.*

Confirmed the residual: temporarily added a new variant (`TempProbe1808NewVariant`) to the already-tracked `HelloPendingPolicyReason` enum in `hello_pending_admission.rs` (now inventoried by this PR) and re-ran the guard. It **stayed green** — the scanner records only the `pub enum HelloPendingPolicyReason {` declaration line, not its variant bodies, so a genuine, real public-surface change (a new match-arm callers would need to handle) is invisible to it even after this fix. Reverted. This is exactly #1808's documented limitation (enum variant bodies / multi-line values not captured) and confirms it still applies to these files — #1808 itself is not touched or fixed here.

## Post-fix mutate/revert proof (both run with the TARGETS change in place)

1. Added `pub fn temp_probe_1755_pending_admission_postfix() {}` to `hello_pending_admission.rs` → `cargo test --test public_api_contracts` **correctly FAILED**: `assertion left == right failed: public API inventory drifted for crates/sm-verify/src/hello_pending_admission.rs`. Reverted; suite green again.
2. Added `pub fn temp_probe_1755_real_semcode_admission_postfix() {}` to `hello_real_semcode_admission.rs` → **correctly FAILED** with the identical drift assertion for that file. Reverted; suite green again.

Both confirm the new `TARGETS` entries are genuinely active and wired to the real files, not accidentally inert.

## Validation

- `cargo test --test public_api_contracts`: 5/5 pass
- `cargo test -p sm-verify --features sm-ir/profile-rust`: 106/106 pass (unchanged — no production code touched)
- `cargo clippy -p sm-verify --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt` clean on the root crate (owns `tests/`)
- `git diff --check` / `git diff --cached --check`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

## Scope

No production code changed — this is a test-infrastructure-only PR (`tests/public_api_contracts.rs` plus two new golden snapshot files). `#1808` (scanner's enum-variant/multi-line blind spot) referenced but not fixed. `#1772`, `#1775`, `#1822`, `#1758` untouched — independent, separate repairs in this same campaign.
