### PR TITLE
docs(sm-verify): describe decoded-envelope accessor honestly

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -225,8 +225,19 @@ impl<'a> VerifiedSemCode<'a> {
         }
     }
 
-    /// Workspace-internal accessor for VM preparation.
-    /// Exposes the decoded internal state safely without creating a stable public API.
+    /// Intentionally public, hidden implementation seam for VM preparation.
+    ///
+    /// `sm-vm` (a separate workspace crate) calls this to bridge a verified
+    /// token into VM-executable state (`prepare_verified_execution` in
+    /// `crates/sm-vm/src/semcode_vm.rs`). Rust has no visibility level
+    /// narrower than `pub` that still permits a separate crate to call a
+    /// method, so this is genuinely part of `sm-verify`'s externally
+    /// callable Rust surface -- `#[doc(hidden)]` only suppresses it from
+    /// generated documentation, it does not restrict downstream crates from
+    /// naming and calling it. It is not recommended for use outside this
+    /// workspace's own crates, and its closure-based shape (rather than a
+    /// plain accessor) is deliberate: it keeps the caller from holding onto
+    /// or independently reconstructing the decoded envelope data.
     #[cfg(feature = "std")]
     #[doc(hidden)]
     pub fn with_decoded_envelopes<R, F>(&self, f: F) -> R

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -235,9 +235,13 @@ impl<'a> VerifiedSemCode<'a> {
     /// callable Rust surface -- `#[doc(hidden)]` only suppresses it from
     /// generated documentation, it does not restrict downstream crates from
     /// naming and calling it. It is not recommended for use outside this
-    /// workspace's own crates, and its closure-based shape (rather than a
-    /// plain accessor) is deliberate: it keeps the caller from holding onto
-    /// or independently reconstructing the decoded envelope data.
+    /// workspace's own crates. The closure-based shape only prevents a
+    /// caller from retaining the borrowed `&'scope` slice itself past this
+    /// call; it is not a containment guarantee -- `DecodedFunctionEnvelope`
+    /// derives `Clone`, so a closure can return owned copies of the decoded
+    /// data, and `sm_format::semcode_decode::decode_semcode_envelope` is
+    /// itself public, so any caller with the same bytes can independently
+    /// reconstruct equivalent decoded envelopes without this method at all.
     #[cfg(feature = "std")]
     #[doc(hidden)]
     pub fn with_decoded_envelopes<R, F>(&self, f: F) -> R


### PR DESCRIPTION
Closes #1758
Umbrella #1617

## Investigation (not assumed before auditing)

`VerifiedSemCode::with_decoded_envelopes` (`crates/sm-verify/src/lib.rs`) is declared `#[doc(hidden)] pub fn`, with a doc comment claiming it is "workspace-internal" and "does not create a stable public API." `#[doc(hidden)]` only suppresses generated rustdoc output — it does not restrict a downstream crate from naming and calling a `pub` method.

**Consumer audit (repo-wide grep for `with_decoded_envelopes`):** exactly one real call site outside `sm-verify` itself — `crates/sm-vm/src/semcode_vm.rs`'s `prepare_verified_execution`:

```rust
fn prepare_verified_execution(token: &VerifiedEntrySemCode<'_, '_>) -> Result<VmProgramView, RuntimeError> {
    token.artifact().with_decoded_envelopes(|header, decoded_functions| {
        build_vm_program_view_from_decoded(header.clone(), decoded_functions)
    })
}
```

`sm-vm` is a genuinely separate workspace crate (confirmed via `Cargo.toml` dependency direction: `sm-vm` depends on `sm-verify`, not the reverse). `prepare_verified_execution` is called from every token-first execution path — `run_verified_entry_semcode*` and `run_verified_function_semcode_with_args*` (the exact APIs touched by #1772 earlier in this campaign) — making this load-bearing, necessary cross-crate usage, not an accident or leftover test-only call.

**Crate-boundary reasoning:** `pub(crate)` in Rust means visible only within the *same* crate. Since `sm-vm` genuinely calls this method today, mechanically narrowing to `pub(crate)` would not compile — it would break real, intentional architecture. This is strong, direct evidence for repair family (B) (documentation honesty) over family (A) (narrowing).

## Repair

Kept `pub` + `#[doc(hidden)]` (no visibility or signature change), and rewrote the doc comment to state plainly what is actually true:

```diff
-/// Workspace-internal accessor for VM preparation.
-/// Exposes the decoded internal state safely without creating a stable public API.
+/// Intentionally public, hidden implementation seam for VM preparation.
+///
+/// `sm-vm` (a separate workspace crate) calls this to bridge a verified
+/// token into VM-executable state (`prepare_verified_execution` in
+/// `crates/sm-vm/src/semcode_vm.rs`). Rust has no visibility level
+/// narrower than `pub` that still permits a separate crate to call a
+/// method, so this is genuinely part of `sm-verify`'s externally
+/// callable Rust surface -- `#[doc(hidden)]` only suppresses it from
+/// generated documentation, it does not restrict downstream crates from
+/// naming and calling it. It is not recommended for use outside this
+/// workspace's own crates, and its closure-based shape (rather than a
+/// plain accessor) is deliberate: it keeps the caller from holding onto
+/// or independently reconstructing the decoded envelope data.
```

No unsafe or "friend crate" mechanism invented — Rust genuinely has no narrower visibility level here, and the honest documentation says so.

## Honesty alignment (all four now agree)

1. **Actual Rust visibility**: `pub fn`, unchanged.
2. **Source doc-comment**: now states plainly this is intentionally public and why, matching reality.
3. **Public API golden snapshot** (`tests/golden_snapshots/public_api/sm_verify_lib.txt`): already correctly listed this as a `pub` function (doc comments aren't captured by the scanner) — confirmed unaffected by this PR, no snapshot regeneration needed.
4. **Architecture docs**: `grep -rl with_decoded_envelopes docs/` returns nothing — no doc references this function, nothing else to correct.

No contradiction remains anywhere in the repo among these four.

## Validation

- `cargo test -p sm-verify --features sm-ir/profile-rust`: 106/106 pass (unchanged — doc-comment-only change)
- `cargo test -p sm-vm --all-features`: 124+1+23 pass (unchanged)
- `cargo test --test public_api_contracts`: 5/5 pass, snapshot untouched as predicted
- `cargo clippy -p sm-verify --all-targets --all-features -- -D warnings`: clean
- `cargo clippy -p sm-vm --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt` clean on `sm-verify`
- `git diff --check` / `git diff --cached --check`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: **PASS**
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: **PASS**

## Scope

Genuinely small, bounded P3 PR — one doc comment in one file, no production behavior change, no visibility change. `#1772`, `#1775`, `#1822`, `#1755` untouched — independent, separate repairs in this same campaign.
