### PR TITLE
test(sm-vm): prove invocation rejection and determinism contracts

### DIFF
--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -126,24 +126,65 @@ mod tests {
         );
     }
 
+    /// #1774 (FA-09-006): the original `test_6_reject_wrong_argument_count`
+    /// ended with `assert!(res.is_ok() || res.is_err())`, which is true for
+    /// every possible `Result` and therefore proves nothing about whether
+    /// the wrong count was actually rejected. `b` is unused by the body on
+    /// purpose: since #1773, `validate_call_arguments` rejects an argument-
+    /// count mismatch inside `push_frame`, before the frame -- and therefore
+    /// the body -- ever runs, with a distinct `TypeMismatchRuntime`.
+    /// Mutation-tested by temporarily disabling that boundary check: `b`'s
+    /// parameter binding still gets one unconditional `StoreVar` read of its
+    /// argument register during lowering regardless of whether the body
+    /// later references `b`, so execution does not silently succeed --
+    /// instead it falls through to a materially worse, VM-internals-leaking
+    /// `RuntimeError::BadFormat("read uninitialized reg r1")`. Asserting the
+    /// specific `TypeMismatchRuntime` variant (not just `is_err()`) is what
+    /// distinguishes the clean boundary rejection this test protects from
+    /// that fallback failure mode.
     #[test]
-    fn test_6_reject_wrong_argument_count() {
-        let src = "fn need_two(a: i32, b: i32) -> i32 { return a + b; } fn main() { return; }";
+    fn rejects_missing_unused_argument_at_invocation_boundary() {
+        let src = "fn need_two(a: i32, b: i32) -> i32 { return a; } fn main() { return; }";
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("need_two").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, vec![Value::I32(5)]);
-        assert!(res.is_ok() || res.is_err());
+        let err = run_verified_function_semcode_with_args(&entry, vec![Value::I32(5)])
+            .expect_err("a missing argument for an unused parameter must still be rejected");
+        assert!(
+            matches!(err, RuntimeError::TypeMismatchRuntime(_)),
+            "expected a boundary argument-count rejection (TypeMismatchRuntime) from \
+             validate_call_arguments, got {err:?}"
+        );
     }
 
+    /// #1774 (FA-09-006): the original `test_7_reject_wrong_argument_type`
+    /// invoked `add_one(x: i32) { x + 1 }` with a `Quad` argument. `x` is
+    /// used by `AddI32`, so that rejection only proves a downstream
+    /// arithmetic opcode can reject a bad runtime shape -- not that the
+    /// call boundary itself checks the declared parameter type. Here `x` is
+    /// supplied correctly and `unused` is wrong-typed but never read by the
+    /// body: if `validate_call_arguments`'s family check were removed, this
+    /// call would never read the mistyped `unused` register and would
+    /// silently *succeed* with `Value::I32(7)`, so a failure here can only
+    /// come from the invocation boundary, never from body semantics.
     #[test]
-    fn test_7_reject_wrong_argument_type() {
-        let src = "fn add_one(x: i32) -> i32 { return x + 1; } fn main() { return; }";
+    fn rejects_wrong_unused_argument_family_at_invocation_boundary() {
+        let src = "fn add_one(x: i32, unused: bool) -> i32 { return x + 1; } fn main() { return; }";
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("add_one").expect("entry");
-        let res = run_verified_function_semcode_with_args(&entry, vec![Value::Quad(QuadVal::T)]);
-        assert!(res.is_err());
+        let err = run_verified_function_semcode_with_args(
+            &entry,
+            vec![Value::I32(7), Value::Text("wrong".into())],
+        )
+        .expect_err(
+            "a wrong-family argument in a parameter the body never reads must still be rejected",
+        );
+        assert!(
+            matches!(err, RuntimeError::TypeMismatchRuntime(_)),
+            "expected a boundary family rejection (TypeMismatchRuntime) from \
+             validate_call_arguments, got {err:?}"
+        );
     }
 
     #[test]
@@ -162,18 +203,36 @@ mod tests {
         assert!(token_res.is_err());
     }
 
+    /// #1774 (FA-09-006): the original `test_10_deterministic_repeated_
+    /// invocation` called `double(i)` for five *different* values of `i`,
+    /// each exactly once. That proves `double(i) == 2*i` holds for five
+    /// distinct inputs, not that repeated execution of the *same* verified
+    /// SemCode/entry/argument state yields the same result every time --
+    /// the actual claim `docs/spec/vm.md`'s Determinism Rule makes (same
+    /// verified SemCode input, execution config, and entry function). This
+    /// version holds the SemCode bytes, the resolved entry token, and the
+    /// argument vector fixed and invokes the identical call ten times.
+    /// `double` is a pure, host-effect-free function, matching the
+    /// Determinism Rule's scope: it makes no claim about host-backed
+    /// effects, wall-clock timing, or external scheduling.
     #[test]
-    fn test_10_deterministic_repeated_invocation() {
+    fn repeated_identical_invocation_is_deterministic() {
         let src = "fn double(x: i32) -> i32 { return x * 2; } fn main() { return; }";
         let bytes = compile_program_to_semcode(src).expect("compile");
         let token = verify_semcode_token(&bytes).expect("verify");
         let entry = token.require_entry("double").expect("entry");
 
-        for i in 1..=5 {
-            let res =
-                run_verified_function_semcode_with_args(&entry, vec![Value::I32(i)]).expect("run");
-            assert_eq!(res, Value::I32(i * 2));
-        }
+        let results: Vec<Value> = (0..10)
+            .map(|_| {
+                run_verified_function_semcode_with_args(&entry, vec![Value::I32(21)]).expect("run")
+            })
+            .collect();
+        assert!(
+            results.iter().all(|r| *r == results[0]),
+            "repeated invocation of identical SemCode/entry/argument state must yield an \
+             identical result every time, got {results:?}"
+        );
+        assert_eq!(results[0], Value::I32(42));
     }
 
     // --- #1653 / #1750 (umbrella #1617) regression matrix -----------------

--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -165,8 +165,9 @@ mod tests {
     /// supplied correctly and `unused` is wrong-typed but never read by the
     /// body: if `validate_call_arguments`'s family check were removed, this
     /// call would never read the mistyped `unused` register and would
-    /// silently *succeed* with `Value::I32(7)`, so a failure here can only
-    /// come from the invocation boundary, never from body semantics.
+    /// silently *succeed* with `Value::I32(8)` (`x + 1`), so a failure here
+    /// can only come from the invocation boundary, never from body
+    /// semantics.
     #[test]
     fn rejects_wrong_unused_argument_family_at_invocation_boundary() {
         let src = "fn add_one(x: i32, unused: bool) -> i32 { return x + 1; } fn main() { return; }";

--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -162,11 +162,16 @@ mod tests {
     /// used by `AddI32`, so that rejection only proves a downstream
     /// arithmetic opcode can reject a bad runtime shape -- not that the
     /// call boundary itself checks the declared parameter type. Here `x` is
-    /// supplied correctly and `unused` is wrong-typed but never read by the
-    /// body: if `validate_call_arguments`'s family check were removed, this
-    /// call would never read the mistyped `unused` register and would
-    /// silently *succeed* with `Value::I32(8)` (`x + 1`), so a failure here
-    /// can only come from the invocation boundary, never from body
+    /// supplied correctly and `unused` is wrong-typed but never used in a
+    /// family-sensitive operation: like `b` above, `unused`'s parameter
+    /// register is still read by its own unconditional `StoreVar` binding,
+    /// but `StoreVar` does not inspect the stored `Value`'s family -- it
+    /// only fails on an undefined *source* register, not a wrong-family
+    /// one. So if `validate_call_arguments`'s family check were removed,
+    /// the mistyped value would be read and stored without complaint, the
+    /// body would never semantically use it, and the call would silently
+    /// *succeed* with `Value::I32(8)` (`x + 1`) -- a failure here can
+    /// therefore only come from the invocation boundary, never from body
     /// semantics.
     #[test]
     fn rejects_wrong_unused_argument_family_at_invocation_boundary() {


### PR DESCRIPTION
Closes #1774 (FA-09-006). Umbrella #1617. Depends on merged #1773 / #1838.

Base SHA: `0b071727d8d06af03a3eb05d7c349beb76bc5f9f` (origin/main after #1838 merged, confirmed via `git merge-base --is-ancestor`).

## Root purpose

#1774 is a qualification gap, not an implementation defect: three tests beside `sm-vm`'s public verified-invocation helpers in `crates/sm-vm/src/lib.rs` claim stronger guarantees than their assertions actually prove. #1773 already established the real callable contract (SIG0 metadata → verifier static arity proof → VM runtime-family validation via `validate_call_arguments`, fused into `push_frame`). This PR makes the existing tests prove what their names claim — no production code changed.

## Re-verification against current main (not the pre-#1773 audit snapshot)

Confirmed #1838 did not touch these three tests — they still had their original, weak bodies:

| Test | Old claim | Why it was insufficient |
|---|---|---|
| `test_6_reject_wrong_argument_count` | rejects wrong arg count | `assert!(res.is_ok() \|\| res.is_err())` — true for every possible `Result`, cannot fail |
| `test_7_reject_wrong_argument_type` | rejects wrong arg type at the invocation boundary | used `add_one(x: i32) { x + 1 }` — `x` is read by `AddI32`, so the rejection only proves a downstream arithmetic opcode rejects a bad shape, not that the call boundary itself checks the declared type |
| `test_10_deterministic_repeated_invocation` | repeated invocation is deterministic | looped `double(i)` for `i in 1..=5`, a *different* input each iteration — proves `double(i) == 2*i` for 5 distinct inputs, not that repeating the *same* input/state yields the same result |

Also audited the permanent #1773 regressions already in `crates/sm-vm/src/semcode_vm.rs` (`public_invocation_rejects_family_mismatch_in_unused_parameter`, `verified_entry_route_rejects_zero_args_for_parameterized_function`, etc.) to avoid duplicate coverage — those use the low-level `IrFunction` builder and cover different call routes (internal `Opcode::Call`, `ClosureCall`, zero-arg verified-entry routes); none of them cover the source-compiled, args-taking public helper's partial-argument-count case or the true repeated-identical-invocation case, so the repairs below are additive, not redundant.

## Repairs

All three repaired using an **unused second parameter**, so the invocation boundary (`validate_call_arguments`) is the only thing that can produce the rejection — never body semantics:

### `rejects_missing_unused_argument_at_invocation_boundary`
```rust
fn need_two(a: i32, b: i32) -> i32 { return a; }
```
Supplies only `[I32(5)]` (missing `b`, which the body never reads). Asserts the specific `RuntimeError::TypeMismatchRuntime` variant.

**Mutation-tested** (temporarily commented out the `validate_call_arguments` call in `push_frame`, ran the test, then reverted — see below): the call does **not** silently succeed. `b`'s parameter binding still emits one unconditional `StoreVar` read of its argument register during lowering regardless of whether the body later references `b`, so with the boundary check disabled the call instead falls through to `RuntimeError::BadFormat("read uninitialized reg r1")` — a materially different, VM-internals-leaking failure. Asserting the specific `TypeMismatchRuntime` variant (not just `is_err()`) is exactly what discriminates the clean boundary rejection this test protects from that fallback failure mode.

### `rejects_wrong_unused_argument_family_at_invocation_boundary`
```rust
fn add_one(x: i32, unused: bool) -> i32 { return x + 1; }
```
Supplies `[I32(7), Text("wrong")]` — `x` is correctly typed and used; `unused` is wrong-family and never read. Asserts `TypeMismatchRuntime`.

**Mutation-tested** the same way: with `validate_call_arguments` disabled, this call silently succeeds with `Ok(Value::I32(8))` — confirming the assertion depends entirely on the boundary check, never on downstream body semantics.

### `repeated_identical_invocation_is_deterministic`
```rust
fn double(x: i32) -> i32 { return x * 2; }
```
Holds the SemCode bytes, the resolved entry token, and the argument vector (`I32(21)`) fixed across 10 invocations; asserts all 10 results are identical. Matches exactly what `docs/spec/vm.md`'s Determinism Rule promises (same verified SemCode input, execution config, entry function) — no claim about host effects, timing, or scheduling. `double` is pure/host-effect-free.

### Mutation-test evidence (both new invocation-boundary tests fail without #1773's check)
```
test tests::rejects_missing_unused_argument_at_invocation_boundary ... FAILED
  panicked: expected a boundary argument-count rejection (TypeMismatchRuntime) from
  validate_call_arguments, got BadFormat("read uninitialized reg r1")

test tests::rejects_wrong_unused_argument_family_at_invocation_boundary ... FAILED
  panicked: a wrong-family argument in a parameter the body never reads must still be
  rejected: I32(8)

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 112 filtered out
```
(`push_frame`'s `validate_call_arguments` call was reverted immediately after capturing this evidence; `git diff --stat` confirms only `crates/sm-vm/src/lib.rs` changed in the final commit.)

## Scope

No production code changed. This is a test-only, qualification-focused PR, as expected.

## Validation

- `cargo test -p sm-vm --all-features`: 143 + 1 + 23 passed, 0 failed (1 ignored, pre-existing)
- `cargo test --workspace --all-features`: 0 failed
- `cargo clippy -p sm-vm --all-targets --all-features -- -D warnings`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt -p sm-vm -- --check`: clean
- `git diff --check`: clean
- `pwsh -NoProfile -File scripts/admission_guard.ps1 -PRReady`: PASS
- `pwsh -NoProfile -File tools/7hell/run_ci.ps1`: PASS