### PR TITLE
fix(sm-ir): preserve u32 equality in CrystalFold

### DIFF
--- a/crates/sm-ir/src/passes/crystalfold.rs
+++ b/crates/sm-ir/src/passes/crystalfold.rs
@@ -870,6 +870,7 @@ fn const_eq(a: ConstVal, b: ConstVal) -> bool {
         (ConstVal::Bool(x), ConstVal::Bool(y)) => x == y,
         (ConstVal::F64(x), ConstVal::F64(y)) => x == y,
         (ConstVal::I32(x), ConstVal::I32(y)) => x == y,
+        (ConstVal::U32(x), ConstVal::U32(y)) => x == y,
         (ConstVal::Fx(x), ConstVal::Fx(y)) => x == y,
         _ => false,
     }
@@ -1033,6 +1034,150 @@ mod tests {
                 changed: false,
                 num_rewrites: 0,
             }
+        );
+    }
+
+    #[test]
+    fn crystalfold_preserves_u32_equality_semantics() {
+        let mut module = IrModule {
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadU32 { dst: 0, val: 7 },
+                    IrInstr::LoadU32 { dst: 1, val: 7 },
+                    IrInstr::CmpEq {
+                        dst: 2,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                    IrInstr::CmpNe {
+                        dst: 3,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                    IrInstr::LoadU32 { dst: 4, val: 8 },
+                    IrInstr::CmpEq {
+                        dst: 5,
+                        lhs: 0,
+                        rhs: 4,
+                    },
+                    IrInstr::CmpNe {
+                        dst: 6,
+                        lhs: 0,
+                        rhs: 4,
+                    },
+                ],
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+        };
+
+        CrystalFoldPass.run(&mut module);
+
+        assert_eq!(
+            module.functions[0].instrs[2],
+            IrInstr::LoadBool { dst: 2, val: true },
+            "7u32 == 7u32 must fold to true"
+        );
+        assert_eq!(
+            module.functions[0].instrs[3],
+            IrInstr::LoadBool { dst: 3, val: false },
+            "7u32 != 7u32 must fold to false"
+        );
+        assert_eq!(
+            module.functions[0].instrs[5],
+            IrInstr::LoadBool { dst: 5, val: false },
+            "7u32 == 8u32 must fold to false"
+        );
+        assert_eq!(
+            module.functions[0].instrs[6],
+            IrInstr::LoadBool { dst: 6, val: true },
+            "7u32 != 8u32 must fold to true"
+        );
+    }
+
+    /// Regression guard for #1730: inserting the `(U32, U32)` arm into
+    /// `const_eq` must not disturb equality folding for any other admitted
+    /// same-family pair.
+    #[test]
+    fn crystalfold_const_eq_other_families_unaffected() {
+        let mut module = IrModule {
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadBool { dst: 0, val: true },
+                    IrInstr::LoadBool { dst: 1, val: true },
+                    IrInstr::CmpEq {
+                        dst: 2,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                    IrInstr::LoadI32 { dst: 3, val: 5 },
+                    IrInstr::LoadI32 { dst: 4, val: 6 },
+                    IrInstr::CmpEq {
+                        dst: 5,
+                        lhs: 3,
+                        rhs: 4,
+                    },
+                    IrInstr::LoadF64 { dst: 6, val: 1.5 },
+                    IrInstr::LoadF64 { dst: 7, val: 1.5 },
+                    IrInstr::CmpNe {
+                        dst: 8,
+                        lhs: 6,
+                        rhs: 7,
+                    },
+                    IrInstr::LoadFx { dst: 9, val: 3 },
+                    IrInstr::LoadFx { dst: 10, val: 3 },
+                    IrInstr::CmpEq {
+                        dst: 11,
+                        lhs: 9,
+                        rhs: 10,
+                    },
+                    IrInstr::LoadQ {
+                        dst: 12,
+                        val: QuadVal::T,
+                    },
+                    IrInstr::LoadQ {
+                        dst: 13,
+                        val: QuadVal::F,
+                    },
+                    IrInstr::CmpNe {
+                        dst: 14,
+                        lhs: 12,
+                        rhs: 13,
+                    },
+                ],
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+        };
+
+        CrystalFoldPass.run(&mut module);
+
+        assert_eq!(
+            module.functions[0].instrs[2],
+            IrInstr::LoadBool { dst: 2, val: true },
+            "bool equality must still fold correctly"
+        );
+        assert_eq!(
+            module.functions[0].instrs[5],
+            IrInstr::LoadBool { dst: 5, val: false },
+            "i32 equality must still fold correctly"
+        );
+        assert_eq!(
+            module.functions[0].instrs[8],
+            IrInstr::LoadBool { dst: 8, val: false },
+            "f64 inequality must still fold correctly"
+        );
+        assert_eq!(
+            module.functions[0].instrs[11],
+            IrInstr::LoadBool { dst: 11, val: true },
+            "fx equality must still fold correctly"
+        );
+        assert_eq!(
+            module.functions[0].instrs[14],
+            IrInstr::LoadBool { dst: 14, val: true },
+            "quad inequality must still fold correctly"
         );
     }
 }

--- a/tests/ir_opt_boundaries.rs
+++ b/tests/ir_opt_boundaries.rs
@@ -1,5 +1,12 @@
 use std::fs;
 
+use sm_ir::{
+    emit_ir_to_semcode,
+    passes::{crystalfold::CrystalFoldPass, IrModule, OptPass},
+    validate_ir, IrFunction, IrInstr,
+};
+use sm_vm::{run_verified_semcode, RuntimeError};
+
 #[test]
 fn lowering_does_not_embed_crystalfold_logic() {
     let src =
@@ -29,4 +36,159 @@ fn lowering_does_not_embed_crystalfold_logic() {
         !src.contains("remove_unreachable_until_label"),
         "reachability cleanup helpers must live in sm-ir passes"
     );
+}
+
+/// Runs `instrs` as `main` twice through the real pipeline — once unoptimized
+/// (O0) and once through the real `CrystalFoldPass` (O1) — via the same
+/// emit -> verify -> execute path production code uses, and returns
+/// (o0_result, o1_result) so callers can assert they agree.
+fn run_under_o0_and_o1(
+    instrs: Vec<IrInstr>,
+) -> (Result<(), RuntimeError>, Result<(), RuntimeError>) {
+    let function = IrFunction {
+        name: "main".to_string(),
+        instrs,
+        ownership_events: Vec::new(),
+        params: Vec::new(),
+    };
+    validate_ir(&function).expect("raw IR must remain structurally admitted");
+
+    let o0_bytes = emit_ir_to_semcode(std::slice::from_ref(&function), false).expect("emit O0");
+    sm_verify::verify_semcode_token(&o0_bytes).expect("O0 must pass verifier admission");
+    let o0_result = run_verified_semcode(&o0_bytes);
+
+    let mut o1_module = IrModule {
+        functions: vec![function],
+    };
+    CrystalFoldPass.run(&mut o1_module);
+    let o1_bytes = emit_ir_to_semcode(&o1_module.functions, false).expect("emit O1");
+    sm_verify::verify_semcode_token(&o1_bytes).expect("O1 must pass verifier admission");
+    let o1_result = run_verified_semcode(&o1_bytes);
+
+    (o0_result, o1_result)
+}
+
+/// FA-04-024 / #1730: CrystalFold's `const_eq` omits a `(ConstVal::U32,
+/// ConstVal::U32)` arm and falls through to `_ => false`, so `CmpEq`/`CmpNe`
+/// folding on tracked-constant u32 operands can silently disagree with
+/// unoptimized (O0) execution. Each case below asserts a u32 comparison via
+/// `assert(...)`, so a wrong fold flips a passing program into a runtime
+/// `AssertionFailed` trap under O1 while O0 (which evaluates `CmpEq`/`CmpNe`
+/// at runtime, not compile time) stays correct — a real, observable
+/// divergence through the actual optimizer/verifier/VM pipeline, not just a
+/// private-helper unit check.
+#[test]
+fn crystalfold_u32_equality_matches_unoptimized_execution() {
+    let cases: Vec<(&str, Vec<IrInstr>)> = vec![
+        (
+            "equal_zero_cmpeq",
+            vec![
+                IrInstr::LoadU32 { dst: 0, val: 0 },
+                IrInstr::LoadU32 { dst: 1, val: 0 },
+                IrInstr::CmpEq {
+                    dst: 2,
+                    lhs: 0,
+                    rhs: 1,
+                },
+                IrInstr::Assert { cond: 2 },
+                IrInstr::Ret { src: None },
+            ],
+        ),
+        (
+            "equal_seven_cmpeq",
+            vec![
+                IrInstr::LoadU32 { dst: 0, val: 7 },
+                IrInstr::LoadU32 { dst: 1, val: 7 },
+                IrInstr::CmpEq {
+                    dst: 2,
+                    lhs: 0,
+                    rhs: 1,
+                },
+                IrInstr::Assert { cond: 2 },
+                IrInstr::Ret { src: None },
+            ],
+        ),
+        (
+            "equal_u32_max_cmpeq",
+            vec![
+                IrInstr::LoadU32 {
+                    dst: 0,
+                    val: u32::MAX,
+                },
+                IrInstr::LoadU32 {
+                    dst: 1,
+                    val: u32::MAX,
+                },
+                IrInstr::CmpEq {
+                    dst: 2,
+                    lhs: 0,
+                    rhs: 1,
+                },
+                IrInstr::Assert { cond: 2 },
+                IrInstr::Ret { src: None },
+            ],
+        ),
+        (
+            "equal_seven_cmpne_negated",
+            vec![
+                IrInstr::LoadU32 { dst: 0, val: 7 },
+                IrInstr::LoadU32 { dst: 1, val: 7 },
+                IrInstr::CmpNe {
+                    dst: 2,
+                    lhs: 0,
+                    rhs: 1,
+                },
+                IrInstr::BoolNot { dst: 3, src: 2 },
+                IrInstr::Assert { cond: 3 },
+                IrInstr::Ret { src: None },
+            ],
+        ),
+        (
+            "unequal_seven_eight_cmpeq_negated",
+            vec![
+                IrInstr::LoadU32 { dst: 0, val: 7 },
+                IrInstr::LoadU32 { dst: 1, val: 8 },
+                IrInstr::CmpEq {
+                    dst: 2,
+                    lhs: 0,
+                    rhs: 1,
+                },
+                IrInstr::BoolNot { dst: 3, src: 2 },
+                IrInstr::Assert { cond: 3 },
+                IrInstr::Ret { src: None },
+            ],
+        ),
+        (
+            "unequal_seven_eight_cmpne",
+            vec![
+                IrInstr::LoadU32 { dst: 0, val: 7 },
+                IrInstr::LoadU32 { dst: 1, val: 8 },
+                IrInstr::CmpNe {
+                    dst: 2,
+                    lhs: 0,
+                    rhs: 1,
+                },
+                IrInstr::Assert { cond: 2 },
+                IrInstr::Ret { src: None },
+            ],
+        ),
+    ];
+
+    for (name, instrs) in cases {
+        let (o0_result, o1_result) = run_under_o0_and_o1(instrs);
+
+        assert!(
+            o0_result.is_ok(),
+            "case {name}: unoptimized (O0) execution must pass a correct u32 comparison, got {o0_result:?}"
+        );
+        assert!(
+            o1_result.is_ok(),
+            "case {name}: CrystalFold (O1) must not change the observable result of a valid u32 comparison, got {o1_result:?}"
+        );
+        assert_eq!(
+            o0_result.is_ok(),
+            o1_result.is_ok(),
+            "case {name}: O0 and O1 disagree on pass/trap outcome (O0={o0_result:?}, O1={o1_result:?})"
+        );
+    }
 }


### PR DESCRIPTION
## SSF-07

First Phase-B repair slice for #1578.

## Fixes

Fixes #1730.

## Problem

CrystalFold tracks `ConstVal::U32`, but `const_eq()` omitted the
`U32/U32` case and fell through to `false`.

This made O1 capable of changing valid u32 equality/inequality semantics.

## Repair

Add explicit same-family U32 equality to the authoritative `const_eq()`
implementation.

## Qualification

- pre-fix O0/O1 regression demonstrated
- equal U32 values
- unequal U32 values
- CmpEq
- CmpNe
- existing equality families preserved
- workspace regression
- clippy `-D warnings`

## Non-goals

- no #1729 changes
- no #1710 changes
- no CrystalFold redesign
- no SSF-07 contract widening