### PR TITLE
fix(calls): preserve source argument evaluation order and validate FnSig metadata (#1722 #1665)

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -977,12 +977,68 @@ pub fn builtin_sig(name: &str) -> Option<FnSig> {
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrderedCallArgs {
+    /// Final argument expression for each declared parameter slot, in
+    /// parameter order (defaults substituted). Used for per-slot type
+    /// checking and for the final argument-register order handed to the
+    /// callee.
+    pub slots: Vec<ExprId>,
+    /// Parameter slot indices in the order their expressions must be
+    /// *evaluated*: explicitly supplied arguments in source (left-to-right)
+    /// order, followed by defaulted slots in parameter order.
+    ///
+    /// Named-argument slot assignment and source evaluation order are
+    /// separate concerns: named arguments only ever reorder `slots`, never
+    /// `eval_order`'s relative order of explicitly written argument
+    /// expressions.
+    pub eval_order: Vec<usize>,
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+fn validate_fn_sig_call_metadata(
+    call_name: SymbolId,
+    sig: &FnSig,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    if let Some(param_names) = sig.param_names.as_ref() {
+        if param_names.len() != sig.params.len() {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "function '{}' has malformed signature: {} parameter name(s) declared for {} parameter(s)",
+                    resolve_symbol_name(arena, call_name)?,
+                    param_names.len(),
+                    sig.params.len(),
+                ),
+            });
+        }
+    }
+    if let Some(param_defaults) = sig.param_defaults.as_ref() {
+        if param_defaults.len() != sig.params.len() {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "function '{}' has malformed signature: {} parameter default(s) declared for {} parameter(s)",
+                    resolve_symbol_name(arena, call_name)?,
+                    param_defaults.len(),
+                    sig.params.len(),
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub fn reorder_call_args(
     call_name: SymbolId,
     args: &[CallArg],
     sig: &FnSig,
     arena: &AstArena,
-) -> Result<Vec<ExprId>, FrontendError> {
+) -> Result<OrderedCallArgs, FrontendError> {
+    validate_fn_sig_call_metadata(call_name, sig, arena)?;
+
     let has_named = args.iter().any(|arg| arg.name.is_some());
     if !has_named {
         if args.len() > sig.params.len() {
@@ -997,10 +1053,12 @@ pub fn reorder_call_args(
             });
         }
         let mut ordered = vec![None; sig.params.len()];
+        let mut eval_order = Vec::with_capacity(args.len());
         for (idx, arg) in args.iter().enumerate() {
             ordered[idx] = Some(arg.value);
+            eval_order.push(idx);
         }
-        return finalize_ordered_call_args(call_name, ordered, sig, arena, args.len());
+        return finalize_ordered_call_args(call_name, ordered, sig, arena, args.len(), eval_order);
     }
 
     let Some(param_names) = sig.param_names.as_ref() else {
@@ -1014,6 +1072,7 @@ pub fn reorder_call_args(
     };
 
     let mut ordered = vec![None; sig.params.len()];
+    let mut eval_order = Vec::with_capacity(args.len());
     let mut positional_index = 0usize;
     let mut named_seen = false;
     for arg in args {
@@ -1040,6 +1099,7 @@ pub fn reorder_call_args(
                 });
             }
             ordered[param_index] = Some(arg.value);
+            eval_order.push(param_index);
         } else {
             if named_seen {
                 return Err(FrontendError {
@@ -1059,11 +1119,12 @@ pub fn reorder_call_args(
                 });
             }
             ordered[positional_index] = Some(arg.value);
+            eval_order.push(positional_index);
             positional_index += 1;
         }
     }
 
-    finalize_ordered_call_args(call_name, ordered, sig, arena, args.len())
+    finalize_ordered_call_args(call_name, ordered, sig, arena, args.len(), eval_order)
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -1073,7 +1134,8 @@ fn finalize_ordered_call_args(
     sig: &FnSig,
     arena: &AstArena,
     provided_count: usize,
-) -> Result<Vec<ExprId>, FrontendError> {
+    mut eval_order: Vec<usize>,
+) -> Result<OrderedCallArgs, FrontendError> {
     let param_names = sig.param_names.as_ref();
     let param_defaults = sig.param_defaults.as_ref();
     for idx in 0..ordered.len() {
@@ -1086,6 +1148,7 @@ fn finalize_ordered_call_args(
             .flatten();
         if let Some(default_expr) = default_expr {
             ordered[idx] = Some(default_expr);
+            eval_order.push(idx);
             continue;
         }
         if let Some(param_names) = param_names {
@@ -1108,7 +1171,10 @@ fn finalize_ordered_call_args(
             ),
         });
     }
-    Ok(ordered.into_iter().flatten().collect())
+    Ok(OrderedCallArgs {
+        slots: ordered.into_iter().flatten().collect(),
+        eval_order,
+    })
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -2876,7 +2876,7 @@ fn infer_expr_type(
                 // First pass: build substitution map from arguments whose
                 // expected param type is a TypeVar.
                 let mut subst: BTreeMap<SymbolId, Type> = BTreeMap::new();
-                for (i, arg) in ordered_args.iter().enumerate() {
+                for (i, arg) in ordered_args.slots.iter().enumerate() {
                     if let Type::TypeVar(tid) = &sig.params[i] {
                         if subst.contains_key(tid) {
                             // Already bound — verify consistency below.
@@ -2936,7 +2936,7 @@ fn infer_expr_type(
                     sig.params.iter().map(|p| subst_apply(p, &subst)).collect();
                 let concrete_ret = subst_apply(&sig.ret, &subst);
                 // Second pass: check every argument against its concrete type.
-                for (i, arg) in ordered_args.iter().enumerate() {
+                for (i, arg) in ordered_args.slots.iter().enumerate() {
                     let expected_ty = concrete_params[i].clone();
                     let at = infer_expr_type_with_expected(
                         *arg,
@@ -2976,7 +2976,7 @@ fn infer_expr_type(
                 }
                 return Ok(concrete_ret);
             }
-            for (i, arg) in ordered_args.iter().enumerate() {
+            for (i, arg) in ordered_args.slots.iter().enumerate() {
                 let expected_ty = sig.params[i].clone();
                 let at = infer_expr_type_with_expected(
                     *arg,
@@ -3271,6 +3271,184 @@ mod tests {
         let program = parse_program(src)?;
         let plans = derive_validation_plan_table(&program)?;
         Ok((program, plans))
+    }
+
+    // FA-02-033 / #1665: a public, externally-constructible `FnSig` whose
+    // `param_names`/`param_defaults` length disagrees with `params` must be
+    // rejected as a deterministic `FrontendError` by every consumer of the
+    // public `FnTable` API, never allowed to reach the indexing logic in
+    // `reorder_call_args`/`finalize_ordered_call_args` and panic.
+    fn well_formed_add_program() -> Program {
+        let src = r#"
+            fn callee(a: i32, b: i32) -> i32 {
+                return a + b;
+            }
+
+            fn caller() -> i32 {
+                return callee(1, 2);
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        parse_program(src).expect("well-formed program should parse")
+    }
+
+    fn callee_and_caller(program: &Program) -> (SymbolId, &Function) {
+        let callee_id = *program
+            .arena
+            .symbol_to_id
+            .get("callee")
+            .expect("callee symbol exists");
+        let caller = program
+            .functions
+            .iter()
+            .find(|f| program.arena.try_symbol_name(f.name) == Some("caller"))
+            .expect("caller function exists");
+        (callee_id, caller)
+    }
+
+    // Dedicated program for the short-`param_names` case: the caller omits
+    // an argument (no default exists for it), which drives execution into
+    // `finalize_ordered_call_args`'s missing-argument branch. That branch
+    // indexes `param_names[idx]` directly (not via `.get`), so a
+    // shorter-than-`params` `param_names` indexes out of bounds and panics
+    // pre-fix, exactly as FA-02-033 describes.
+    fn program_with_missing_argument_call() -> Program {
+        let src = r#"
+            fn callee(a: i32, b: i32) -> i32 {
+                return a + b;
+            }
+
+            fn caller() -> i32 {
+                return callee(1);
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        parse_program(src).expect("well-formed program should parse")
+    }
+
+    // Dedicated program for the long-`param_names` case: the caller names
+    // an argument `c`, an identifier with no corresponding declared
+    // parameter. Once the table is mutated so `param_names` contains an
+    // extra `c` entry beyond `params`' length, `position()` resolves `c` to
+    // an index `>= ordered.len()`, and `ordered[param_index]` indexes out
+    // of bounds and panics pre-fix, exactly as FA-02-033 describes.
+    fn program_with_named_call_referencing_extra_name() -> Program {
+        let src = r#"
+            fn callee(a: i32, b: i32) -> i32 {
+                return a + b;
+            }
+
+            fn caller() -> i32 {
+                return callee(c = 1, a = 2, b = 3);
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        parse_program(src).expect("well-formed program should parse")
+    }
+
+    #[test]
+    fn malformed_fn_sig_param_names_shorter_than_params_fails_closed() {
+        let program = program_with_missing_argument_call();
+        let mut table = build_fn_table(&program).expect("canonical table builds");
+        let (callee_id, caller) = callee_and_caller(&program);
+        let sig = table.get_mut(&callee_id).expect("callee signature exists");
+        let mut names = sig.param_names.clone().expect("callee has param names");
+        names.pop();
+        sig.param_names = Some(names);
+
+        let err = type_check_function_with_table(caller, &program.arena, &table)
+            .expect_err("short param_names must fail closed, not panic");
+        assert!(
+            err.message.contains("malformed signature"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn malformed_fn_sig_param_names_longer_than_params_fails_closed() {
+        let program = program_with_named_call_referencing_extra_name();
+        let mut table = build_fn_table(&program).expect("canonical table builds");
+        let (callee_id, caller) = callee_and_caller(&program);
+        let sig = table.get_mut(&callee_id).expect("callee signature exists");
+        let mut names = sig.param_names.clone().expect("callee has param names");
+        let extra_c = *program
+            .arena
+            .symbol_to_id
+            .get("c")
+            .expect("'c' interned from the named call argument");
+        names.push(extra_c);
+        sig.param_names = Some(names);
+
+        let err = type_check_function_with_table(caller, &program.arena, &table)
+            .expect_err("long param_names must fail closed, not panic");
+        assert!(
+            err.message.contains("malformed signature"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn malformed_fn_sig_param_defaults_shorter_than_params_fails_closed() {
+        let program = well_formed_add_program();
+        let mut table = build_fn_table(&program).expect("canonical table builds");
+        let (callee_id, caller) = callee_and_caller(&program);
+        let sig = table.get_mut(&callee_id).expect("callee signature exists");
+        let mut defaults = sig
+            .param_defaults
+            .clone()
+            .expect("callee has param defaults");
+        defaults.pop();
+        sig.param_defaults = Some(defaults);
+
+        let err = type_check_function_with_table(caller, &program.arena, &table)
+            .expect_err("short param_defaults must fail closed, not panic");
+        assert!(
+            err.message.contains("malformed signature"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn malformed_fn_sig_param_defaults_longer_than_params_fails_closed() {
+        let program = well_formed_add_program();
+        let mut table = build_fn_table(&program).expect("canonical table builds");
+        let (callee_id, caller) = callee_and_caller(&program);
+        let sig = table.get_mut(&callee_id).expect("callee signature exists");
+        let mut defaults = sig
+            .param_defaults
+            .clone()
+            .expect("callee has param defaults");
+        defaults.push(None);
+        sig.param_defaults = Some(defaults);
+
+        let err = type_check_function_with_table(caller, &program.arena, &table)
+            .expect_err("long param_defaults must fail closed, not panic");
+        assert!(
+            err.message.contains("malformed signature"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn canonical_fn_sig_continues_to_typecheck_via_public_table_api() {
+        let program = well_formed_add_program();
+        let table = build_fn_table(&program).expect("canonical table builds");
+        let (_, caller) = callee_and_caller(&program);
+        type_check_function_with_table(caller, &program.arena, &table)
+            .expect("well-formed FnSig via the public FnTable API must still typecheck");
     }
 
     #[test]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -4118,11 +4118,17 @@ fn lower_expr_with_expected(
                 });
             };
             let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
-            let mut regs = Vec::new();
-            for (i, arg) in ordered_args.iter().enumerate() {
-                let expected_arg_ty = sig.params[i].clone();
+            // Evaluate argument expressions in source order (eval_order), but
+            // place each resulting register into its declared parameter slot
+            // so the call's register list stays in parameter order. Named
+            // arguments only ever reorder slot assignment, never evaluation
+            // order — see FA-04-016 / #1722.
+            let mut regs: Vec<Option<u16>> = vec![None; ordered_args.slots.len()];
+            for &slot in &ordered_args.eval_order {
+                let arg = ordered_args.slots[slot];
+                let expected_arg_ty = sig.params[slot].clone();
                 let (r, t) = lower_expr_with_expected(
-                    *arg,
+                    arg,
                     arena,
                     next,
                     out,
@@ -4140,15 +4146,16 @@ fn lower_expr_with_expected(
                         pos: 0,
                         message: format!(
                             "arg {} for '{}' has type {:?}, expected {:?}",
-                            i,
+                            slot,
                             resolve_symbol_name(arena, *name)?,
                             t,
                             expected_arg_ty
                         ),
                     });
                 }
-                regs.push(r);
+                regs[slot] = Some(r);
             }
+            let regs: Vec<u16> = regs.into_iter().flatten().collect();
             if sig.ret == Type::Unit {
                 return Err(FrontendError {
                     pos: 0,
@@ -9707,10 +9714,13 @@ fn lower_expr_stmt_with_parts(
             });
         };
         let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
-        let mut regs = Vec::new();
-        for (i, arg) in ordered_args.iter().enumerate() {
+        // See the call-expression path above (FA-04-016 / #1722): evaluate in
+        // source order, assign into declared parameter slots.
+        let mut regs: Vec<Option<u16>> = vec![None; ordered_args.slots.len()];
+        for &slot in &ordered_args.eval_order {
+            let arg = ordered_args.slots[slot];
             let (r, t) = lower_expr_with_expected(
-                *arg,
+                arg,
                 arena,
                 next,
                 out,
@@ -9719,22 +9729,23 @@ fn lower_expr_stmt_with_parts(
                 fn_table,
                 record_table,
                 adt_table,
-                Some(sig.params[i].clone()),
+                Some(sig.params[slot].clone()),
                 ret_ty.clone(),
                 closure_state,
             )?;
-            if t != sig.params[i] {
+            if t != sig.params[slot] {
                 return Err(FrontendError {
                     pos: 0,
                     message: format!(
                         "arg {} for '{}' type mismatch",
-                        i,
+                        slot,
                         resolve_symbol_name(arena, *name)?
                     ),
                 });
             }
-            regs.push(r);
+            regs[slot] = Some(r);
         }
+        let regs: Vec<u16> = regs.into_iter().flatten().collect();
         let dst = if sig.ret == Type::Unit {
             None
         } else {
@@ -10507,6 +10518,81 @@ mod opt_tests {
     }
 
     #[test]
+    fn lower_named_arguments_evaluates_in_source_order_not_parameter_order() {
+        // FA-04-016 / #1722: `scale(factor = 3.0, x = 2.0)` must evaluate
+        // `factor`'s expression (3.0) before `x`'s expression (2.0) because
+        // it is written first in source, even though `x` is the declared
+        // first parameter. Named-argument slot assignment (x <- 2.0,
+        // factor <- 3.0) must not change evaluation order.
+        let src = r#"
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+            fn main() {
+                let total: f64 = scale(factor = 3.0, x = 2.0);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("named arguments should lower");
+        let main = &ir[1];
+        let load_order: Vec<f64> = main
+            .instrs
+            .iter()
+            .filter_map(|instr| match instr {
+                IrInstr::LoadF64 { val, .. }
+                    if (*val - 2.0).abs() < f64::EPSILON || (*val - 3.0).abs() < f64::EPSILON =>
+                {
+                    Some(*val)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            load_order,
+            vec![3.0, 2.0],
+            "expected source-order evaluation (factor=3.0 loaded before x=2.0), got {:?}",
+            load_order
+        );
+    }
+
+    #[test]
+    fn lower_named_arguments_evaluates_in_source_order_for_call_statement() {
+        // FA-04-016 / #1722: the call-statement lowering path (a bare,
+        // Unit-returning call used as a statement) owns independent
+        // lowering logic from the call-expression path and must preserve
+        // the same source-order evaluation guarantee.
+        let src = r#"
+            fn take(x: f64, factor: f64) {
+                return;
+            }
+            fn main() {
+                take(factor = 3.0, x = 2.0);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("named arguments should lower");
+        let main = &ir[1];
+        let load_order: Vec<f64> = main
+            .instrs
+            .iter()
+            .filter_map(|instr| match instr {
+                IrInstr::LoadF64 { val, .. }
+                    if (*val - 2.0).abs() < f64::EPSILON || (*val - 3.0).abs() < f64::EPSILON =>
+                {
+                    Some(*val)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            load_order,
+            vec![3.0, 2.0],
+            "expected source-order evaluation (factor=3.0 loaded before x=2.0), got {:?}",
+            load_order
+        );
+    }
+
+    #[test]
     fn lowering_rejects_builtin_named_arguments() {
         let src = r#"
             fn main() {
@@ -10519,6 +10605,49 @@ mod opt_tests {
         assert!(err
             .message
             .contains("named arguments are not supported for builtin 'sqrt'"));
+    }
+
+    #[test]
+    fn lower_mixed_named_arguments_and_trailing_default_evaluates_in_source_order() {
+        // FA-04-016 / #1722: named-argument reordering must still preserve
+        // source-order evaluation when combined with a trailing default
+        // parameter. `combo(b = 3.0, a = 1.0)` writes `b` before `a`, and
+        // `c`'s default (a compiler-synthesized, non-source expression) is
+        // evaluated last, after every explicitly written argument.
+        let src = r#"
+            fn combo(a: f64, b: f64, c: f64 = 9.0) -> f64 = a + b + c;
+            fn main() {
+                let total: f64 = combo(b = 3.0, a = 1.0);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("mixed named/default call should lower");
+        let main = &ir[1];
+        let load_order: Vec<f64> = main
+            .instrs
+            .iter()
+            .filter_map(|instr| match instr {
+                IrInstr::LoadF64 { val, .. }
+                    if [1.0, 3.0, 9.0]
+                        .iter()
+                        .any(|expected| (*val - expected).abs() < f64::EPSILON) =>
+                {
+                    Some(*val)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            load_order,
+            vec![3.0, 1.0, 9.0],
+            "expected source-order evaluation (b=3.0, then a=1.0, then c's default=9.0 last), got {:?}",
+            load_order
+        );
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::Call { name, args, .. } if name == "combo" && args.len() == 3)));
     }
 
     #[test]

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -4806,6 +4806,66 @@ mod tests {
         );
     }
 
+    #[test]
+    fn vm_evaluates_named_call_expression_arguments_in_source_order() {
+        // FA-04-016 / #1722, real pipeline proof: `add(b = ten / zero,
+        // a = min_val % neg_one)` writes `b`'s expression first in source
+        // even though `a` is the declared first parameter. `b`'s expression
+        // traps with DivisionByZero; `a`'s expression traps with
+        // ArithmeticOverflow instead. Only one of the two instructions ever
+        // executes (the VM halts on the first trap), so which trap kind
+        // surfaces is a direct, deterministic witness of evaluation order:
+        // source order traps DivisionByZero, parameter order would trap
+        // ArithmeticOverflow.
+        let src = r#"
+            fn add(a: i32, b: i32) -> i32 {
+                return a + b;
+            }
+
+            fn main() {
+                let ten: i32 = 10;
+                let zero: i32 = 0;
+                let min_val: i32 = 0 - 2147483647 - 1;
+                let neg_one: i32 = 0 - 1;
+                let x: i32 = add(b = ten / zero, a = min_val % neg_one);
+                assert(x == 0);
+                return;
+            }
+        "#;
+        assert_traps_under_all_opt_levels(
+            src,
+            "named call-expression argument 'b' (division by zero) is written before 'a' (overflow) in source and must trap first",
+            RuntimeTrap::DivisionByZero,
+        );
+    }
+
+    #[test]
+    fn vm_evaluates_named_call_statement_arguments_in_source_order() {
+        // FA-04-016 / #1722, real pipeline proof for the independent
+        // call-statement lowering path: same distinguishing-trap construction
+        // as vm_evaluates_named_call_expression_arguments_in_source_order,
+        // but with a Unit-returning function invoked as a bare statement.
+        let src = r#"
+            fn take(a: i32, b: i32) {
+                return;
+            }
+
+            fn main() {
+                let ten: i32 = 10;
+                let zero: i32 = 0;
+                let min_val: i32 = 0 - 2147483647 - 1;
+                let neg_one: i32 = 0 - 1;
+                take(b = ten / zero, a = min_val % neg_one);
+                return;
+            }
+        "#;
+        assert_traps_under_all_opt_levels(
+            src,
+            "named call-statement argument 'b' (division by zero) is written before 'a' (overflow) in source and must trap first",
+            RuntimeTrap::DivisionByZero,
+        );
+    }
+
     #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_u32_literal_compare_path() {

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -224,8 +224,15 @@ Current named-argument call semantics:
 - named arguments are currently supported only for ordinary user-defined
   functions
 - positional arguments may appear only before the first named argument
-- after resolution, named arguments reorder to the declared parameter order
-  before ordinary argument type-checking and lowering
+- named arguments only reorder *parameter-slot assignment* to the declared
+  parameter order; they never change *evaluation order* — argument
+  expressions are still evaluated left-to-right in source (written) order per
+  Deterministic Evaluation Order above, then each evaluated value is placed
+  into the parameter slot its name (or position) resolved to, before
+  ordinary argument type-checking
+- a defaulted parameter's initializer is not source-written at the call site
+  and is evaluated after every explicitly written argument, in parameter
+  order
 - each required non-default parameter must receive exactly one argument in the
   current contract
 


### PR DESCRIPTION
SSF-07: #1578

Fixes #1722
Fixes #1665

Baseline SHA: cca4aa57baf0a2d8ba4e68dc4ad50470a1147801

## Problem

**#1722 (FA-04-016):** ordinary call lowering called `reorder_call_args(...)` to
rearrange named arguments into declared-parameter order, then lowered/evaluated
the *reordered* vector directly. So `f(b: expr_b, a: expr_a)` for `fn f(a, b)`
evaluated `expr_a` before `expr_b` — contradicting the frozen
"call arguments are evaluated left-to-right" rule in
`docs/spec/source_semantics.md`. Both independent lowering paths
(call-expression, call-statement) in `crates/sm-ir/src/legacy_lowering.rs` had
this bug.

**#1665 (FA-02-033):** the public `FnSig` struct exposes `params`,
`param_names`, and `param_defaults` as independently constructible fields, and
`type_check_function_with_table(...)` accepts a caller-supplied public
`FnTable`. `reorder_call_args`/`finalize_ordered_call_args` indexed
`param_names[idx]` / `ordered[param_index]` without validating their lengths
against `params`, so a malformed externally-constructed `FnSig` could panic
instead of failing closed with a `FrontendError`.

## Reproduced pre-fix behavior

- **#1722**, real pipeline (source → frontend → IR → emit → verify → VM): a
  call `add(b = ten / zero, a = min_val % neg_one)` — where `b`'s expression
  traps `DivisionByZero` and `a`'s expression traps `ArithmeticOverflow` — is
  expected to trap `DivisionByZero` first (b is written first in source).
  Pre-fix, it trapped `ArithmeticOverflow` instead (a evaluated first, matching
  parameter order, not source order). Same result for both the call-expression
  and call-statement paths. At the IR level, `scale(factor = 3.0, x = 2.0)`
  emitted `LoadF64(2.0)` before `LoadF64(3.0)` pre-fix (parameter order);
  should be `LoadF64(3.0)` before `LoadF64(2.0)` (source order).
- **#1665**: with `param_names` shortened below `params.len()` and a call
  missing an argument, `finalize_ordered_call_args` panicked
  `index out of bounds: the len is 1 but the index is 1` indexing
  `param_names[idx]`. With `param_names` lengthened beyond `params.len()` and
  a named call referencing the extra name, `reorder_call_args` panicked
  `index out of bounds: the len is 2 but the index is 2` indexing
  `ordered[param_index]`.

Both were verified to fail exactly this way by temporarily reverting the fix
in place, rerunning the new regression tests, and confirming the specific
failure/panic, then restoring the fix and confirming green.

## Root cause

Both defects share one root cause: `reorder_call_args`'s public contract
conflated two independent concerns — *which parameter slot an argument value
lands in* (named-argument resolution) and *evaluation order* (source position)
— and separately, never validated that its two independently-`pub` optional
metadata vectors (`param_names`, `param_defaults`) were consistent in length
with `params` before indexing them.

## Frozen invariants

- Call argument expressions are evaluated left-to-right in **source** order
  (`docs/spec/source_semantics.md`, Deterministic Evaluation Order). Named
  arguments determine destination parameter slot only; they must never reorder
  expression evaluation.
- `FnSig.param_names.len() == FnSig.params.len()` and
  `FnSig.param_defaults.len() == FnSig.params.len()` whenever those optional
  fields are `Some`, enforced before any indexing depends on them.

## Repair design

- `reorder_call_args` now returns `OrderedCallArgs { slots: Vec<ExprId>,
  eval_order: Vec<usize> }` instead of a bare `Vec<ExprId>`. `slots` keeps the
  existing per-parameter-slot semantics (defaults substituted). `eval_order`
  lists parameter-slot indices in the order their expressions must be
  *evaluated*: explicitly written arguments in source order, then defaulted
  slots (not source-written; const-safe by existing contract) appended last in
  parameter order.
- Both `crates/sm-ir/src/legacy_lowering.rs` call-lowering paths now iterate
  `eval_order` to decide lowering/evaluation order, writing each resulting
  register into its `slots` index, then flatten into the final parameter-order
  register list for `IrInstr::Call`.
- `crates/sm-front/src/typecheck.rs`'s three (type-checking only, no
  evaluation-order concern) call sites were updated to read
  `ordered_args.slots` instead of the old bare vector — no behavior change.
- New `validate_fn_sig_call_metadata` runs first, unconditionally, at the top
  of `reorder_call_args` (the single choke point every caller of a `FnSig`
  reaches before any `param_names`/`param_defaults` indexing), rejecting any
  length mismatch with a `FrontendError` before `finalize_ordered_call_args`
  can index either vector.
- `docs/spec/source_semantics.md`'s named-argument section was corrected: it
  previously described reordering as happening "before ordinary argument
  type-checking and lowering" in a way that read as authorizing parameter-order
  evaluation. It now explicitly states named arguments reorder slot assignment
  only, per the frozen Deterministic Evaluation Order rule above it, and that
  default initializers (not source-written) evaluate after explicit arguments.

## Why this is fail-closed

- Positional-only calls are unaffected: `eval_order` reduces to `0..params.len()`
  when there are no named arguments, byte-for-byte the same order as before.
- The malformed-`FnSig` fix rejects with a structured `FrontendError` before
  any indexing occurs — there is no code path left where a length-mismatched
  `param_names`/`param_defaults` reaches `finalize_ordered_call_args`'s
  indexing logic.
- No new default, guess, or plausible-substitute behavior was introduced for
  any unknown/malformed state — malformed metadata is rejected, never
  silently truncated, extended, or fabricated.

## Fallback/bypass audit

Reviewed the full changed control-flow neighborhood in
`crates/sm-front/src/lib.rs`, `crates/sm-front/src/typecheck.rs`, and
`crates/sm-ir/src/legacy_lowering.rs`:

- No `unwrap()`/`expect()`/`unwrap_or*` introduced. The existing
  `.get(idx)...flatten()` pattern for default lookup is unchanged (already
  bounds-safe; kept as-is).
- The `ordered.into_iter().flatten()` / new `regs.into_iter().flatten()`
  patterns rely on `eval_order` being a permutation of `0..slots.len()` by
  construction (every slot is filled by construction: explicit args plus
  finalize's default-fill loop), not on masking an error — matches the
  existing `finalize_ordered_call_args` idiom already used in this file.
- No `if let Ok/Some` silent-continuation branches added.
- No catch-all match arms added.
- The one observable behavior change (malformed-`FnSig` positional calls that
  previously silently succeeded using inconsistent metadata now reject) is the
  intended fail-closed repair, not a new fallback.

## Tests added

- `crates/sm-ir/src/legacy_lowering.rs`:
  `lower_named_arguments_evaluates_in_source_order_not_parameter_order`
  (call-expression path, IR instruction order),
  `lower_named_arguments_evaluates_in_source_order_for_call_statement`
  (call-statement path, IR instruction order),
  `lower_mixed_named_arguments_and_trailing_default_evaluates_in_source_order`
  (named reordering + trailing default interaction). Strengthened the
  existing `lower_named_arguments_to_ordinary_call_order` test's coverage
  scope is unchanged (kept, not weakened); the new tests assert actual order.
- `crates/sm-vm/src/semcode_vm.rs`:
  `vm_evaluates_named_call_expression_arguments_in_source_order`,
  `vm_evaluates_named_call_statement_arguments_in_source_order` — full
  pipeline (source → frontend → IR → emit → verify → VM), asserting the
  specific `RuntimeTrap` kind that fires, which is only possible if evaluation
  order is source order.
- `crates/sm-front/src/typecheck.rs`:
  `malformed_fn_sig_param_names_shorter_than_params_fails_closed`,
  `malformed_fn_sig_param_names_longer_than_params_fails_closed`,
  `malformed_fn_sig_param_defaults_shorter_than_params_fails_closed`,
  `malformed_fn_sig_param_defaults_longer_than_params_fails_closed`, and
  `canonical_fn_sig_continues_to_typecheck_via_public_table_api` (well-formed
  `FnSig` via the public `FnTable` API is unaffected), all exercising
  `type_check_function_with_table`.

All new tests were confirmed to fail (two of them via literal panic,
reproducing the exact issue text) against the pre-fix code by temporarily
reverting the production changes in place, then confirmed to pass after
restoring the fix.

## Qualification results (exact commands, this HEAD)

```
cargo test -p sm-front            -> 488 passed; 0 failed
cargo test -p sm-ir               -> 116 passed; 0 failed
cargo test -p sm-vm               -> 116 passed; 0 failed
cargo test --test call_shape_surface_qualification -> 1 passed
cargo test --test public_api_contracts             -> 88 passed (incl. public_api_inventory_matches_checked_in_contract_snapshots — no golden-snapshot update needed)
cargo clippy -p sm-front -p sm-ir --all-targets -- -D warnings -> clean
cargo fmt -p sm-front -p sm-ir -p sm-vm --check                -> clean
```

### Environment/pre-existing baseline caveats (not fixed by this PR, by design)

- Workspace-wide `cargo fmt --check` and `cargo clippy --workspace
  --all-targets -- -D warnings` fail in this local environment with a Windows
  path-length OS error (`Имя файла или его расширение имеет слишком большую
  длину`, i.e. "file name or extension too long") unrelated to any file this
  PR touches — a local/environment limitation, not a code issue.
- `cargo clippy -p sm-vm --all-targets -- -D warnings` fails on exactly one
  pre-existing `dead_code` warning: `VmProgramView.header` is never read
  (`crates/sm-vm/src/semcode_vm.rs:1017`). Confirmed via `git diff origin/main
  -- crates/sm-vm/src/semcode_vm.rs` that this PR's only change to that file
  is the two new tests appended after line 4806 — nowhere near the flagged
  struct — and the field is identical, unused, on `origin/main` before this
  PR. Left unfixed per scope discipline; not registered as a new finding here
  since it is pre-existing platform debt outside #1722/#1665.

CTF touched: none

## Out of scope

- The `VmProgramView.header` dead-code warning above.
- The Windows path-length limitation on workspace-wide `fmt`/`clippy`
  invocations in this environment.
- Any other SSF-07 abstraction (numeric/text/collection/closure/generic/
  trait/pattern policy) — this PR is Repair Slice 1 only.
- No global AST/IR redesign, no VM changes, no SemCode format changes, no
  unrelated renaming or cleanup.

## Remaining SSF-07 work

This PR does **not** close #1578. After this slice merges, SSF-07 continues
with the live closure matrix (numeric/text/collection/closure/generic/trait/
pattern policy) per #1578's acceptance criteria, selected by severity →
semantic/trust impact → dependency order → smallest coherent repair radius.
