### PR TITLE
fix(sm-ir): preserve f64 signed-zero semantics in CrystalFold identity folds (#1710)

### DIFF
--- a/crates/sm-ir/src/passes/crystalfold.rs
+++ b/crates/sm-ir/src/passes/crystalfold.rs
@@ -630,13 +630,18 @@ fn fold_constants_and_identities(instrs: &mut Vec<IrInstr>) -> u32 {
                         cst.insert(dst, ConstVal::F64(a + b));
                         out.push(IrInstr::LoadF64 { dst, val: a + b });
                     }
+                    // x + (-0.0) == x for every x (including x == +/-0.0), so
+                    // eliding is sound. x + (+0.0) is NOT sound to elide here:
+                    // if the untracked x happens to be -0.0 at runtime,
+                    // (-0.0) + (+0.0) == +0.0 per IEEE 754, a sign change this
+                    // rewrite would silently miss. See FA-04-004 / #1710.
                     _ if dst == lhs
-                        && matches!(cst.get(&rhs), Some(ConstVal::F64(v)) if *v == 0.0) =>
+                        && matches!(cst.get(&rhs), Some(ConstVal::F64(v)) if *v == 0.0 && v.is_sign_negative()) =>
                     {
                         rewrites = rewrites.saturating_add(1);
                     }
                     _ if dst == rhs
-                        && matches!(cst.get(&lhs), Some(ConstVal::F64(v)) if *v == 0.0) =>
+                        && matches!(cst.get(&lhs), Some(ConstVal::F64(v)) if *v == 0.0 && v.is_sign_negative()) =>
                     {
                         rewrites = rewrites.saturating_add(1);
                     }
@@ -653,8 +658,13 @@ fn fold_constants_and_identities(instrs: &mut Vec<IrInstr>) -> u32 {
                         cst.insert(dst, ConstVal::F64(a - b));
                         out.push(IrInstr::LoadF64 { dst, val: a - b });
                     }
+                    // x - (+0.0) == x + (-0.0) == x for every x, so eliding is
+                    // sound. x - (-0.0) == x + (+0.0) is NOT sound: if the
+                    // untracked x happens to be -0.0 at runtime, that would
+                    // silently miss the (-0.0) + (+0.0) == +0.0 sign change.
+                    // See FA-04-004 / #1710.
                     _ if dst == lhs
-                        && matches!(cst.get(&rhs), Some(ConstVal::F64(v)) if *v == 0.0) =>
+                        && matches!(cst.get(&rhs), Some(ConstVal::F64(v)) if *v == 0.0 && v.is_sign_positive()) =>
                     {
                         rewrites = rewrites.saturating_add(1);
                     }
@@ -1178,6 +1188,182 @@ mod tests {
             module.functions[0].instrs[14],
             IrInstr::LoadBool { dst: 14, val: true },
             "quad inequality must still fold correctly"
+        );
+    }
+
+    /// FA-04-004 / #1710: `x + (+0.0)` is not a safe no-op elision when `x`'s
+    /// sign is unknown at compile time. `(-0.0) + (+0.0) == +0.0` per IEEE
+    /// 754, a sign change a bare `dst == lhs` elision would silently miss.
+    /// Register 0 is intentionally never loaded, so CrystalFold's constant
+    /// tracker has no entry for it and must treat it as an unknown runtime
+    /// value (exactly the case an in-place `x = x + 0.0` targets).
+    #[test]
+    fn crystalfold_does_not_elide_add_f64_positive_zero_when_lhs_is_untracked() {
+        let mut module = IrModule {
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadF64 { dst: 1, val: 0.0 },
+                    IrInstr::AddF64 {
+                        dst: 0,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                ],
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+        };
+
+        CrystalFoldPass.run(&mut module);
+
+        assert!(
+            module.functions[0].instrs.iter().any(|i| matches!(
+                i,
+                IrInstr::AddF64 {
+                    dst: 0,
+                    lhs: 0,
+                    rhs: 1
+                }
+            )),
+            "x + (+0.0) must not be elided when x's sign is unknown, got {:?}",
+            module.functions[0].instrs
+        );
+    }
+
+    /// Mirror of the above for the `dst == rhs` identity branch: `(+0.0) + x`
+    /// carries the same unsound elision risk by commutativity.
+    #[test]
+    fn crystalfold_does_not_elide_add_f64_positive_zero_when_rhs_is_untracked() {
+        let mut module = IrModule {
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadF64 { dst: 0, val: 0.0 },
+                    IrInstr::AddF64 {
+                        dst: 1,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                ],
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+        };
+
+        CrystalFoldPass.run(&mut module);
+
+        assert!(
+            module.functions[0].instrs.iter().any(|i| matches!(
+                i,
+                IrInstr::AddF64 {
+                    dst: 1,
+                    lhs: 0,
+                    rhs: 1
+                }
+            )),
+            "(+0.0) + x must not be elided when x's sign is unknown, got {:?}",
+            module.functions[0].instrs
+        );
+    }
+
+    /// `x + (-0.0) == x` for every x, including x == +/-0.0, so this identity
+    /// remains sound and CrystalFold should keep folding it away — proves the
+    /// #1710 fix narrows admission rather than disabling the optimization.
+    #[test]
+    fn crystalfold_still_elides_add_f64_negative_zero_when_lhs_is_untracked() {
+        let mut module = IrModule {
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadF64 { dst: 1, val: -0.0 },
+                    IrInstr::AddF64 {
+                        dst: 0,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                ],
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+        };
+
+        CrystalFoldPass.run(&mut module);
+
+        assert!(
+            !module.functions[0]
+                .instrs
+                .iter()
+                .any(|i| matches!(i, IrInstr::AddF64 { .. })),
+            "x + (-0.0) is sound to elide and must still be folded away, got {:?}",
+            module.functions[0].instrs
+        );
+    }
+
+    /// FA-04-004 / #1710: `x - (-0.0)` is not safe to elide for the same
+    /// reason as `x + (+0.0)` (subtraction is addition of the negation).
+    #[test]
+    fn crystalfold_does_not_elide_sub_f64_negative_zero_when_lhs_is_untracked() {
+        let mut module = IrModule {
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadF64 { dst: 1, val: -0.0 },
+                    IrInstr::SubF64 {
+                        dst: 0,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                ],
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+        };
+
+        CrystalFoldPass.run(&mut module);
+
+        assert!(
+            module.functions[0].instrs.iter().any(|i| matches!(
+                i,
+                IrInstr::SubF64 {
+                    dst: 0,
+                    lhs: 0,
+                    rhs: 1
+                }
+            )),
+            "x - (-0.0) must not be elided when x's sign is unknown, got {:?}",
+            module.functions[0].instrs
+        );
+    }
+
+    /// `x - (+0.0) == x` for every x, so this identity remains sound.
+    #[test]
+    fn crystalfold_still_elides_sub_f64_positive_zero_when_lhs_is_untracked() {
+        let mut module = IrModule {
+            functions: vec![IrFunction {
+                name: "main".to_string(),
+                instrs: vec![
+                    IrInstr::LoadF64 { dst: 1, val: 0.0 },
+                    IrInstr::SubF64 {
+                        dst: 0,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                ],
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+        };
+
+        CrystalFoldPass.run(&mut module);
+
+        assert!(
+            !module.functions[0]
+                .instrs
+                .iter()
+                .any(|i| matches!(i, IrInstr::SubF64 { .. })),
+            "x - (+0.0) is sound to elide and must still be folded away, got {:?}",
+            module.functions[0].instrs
         );
     }
 }


### PR DESCRIPTION
SSF-07: #1578

Fixes #1710

Baseline SHA: 65fb9b956032d25540e3617f39a15500b11b8ab8 (main, includes the #1722/#1665 slice)

## Problem

**#1710 (FA-04-004):** CrystalFold's `AddF64`/`SubF64` in-place identity
elisions (`x = x + 0.0`-shaped rewrites, i.e. `dst` aliases `lhs` or `rhs`)
match the constant zero operand with plain numeric equality (`*v == 0.0`).
Rust/IEEE-754 `==` treats `+0.0` and `-0.0` as equal, but IEEE-754 addition
is sign-sensitive exactly at zero: `(-0.0) + (+0.0) == +0.0`. When the
non-constant operand (`x`, untracked by CrystalFold's local analysis) is
`-0.0` at runtime and the constant zero being added is `+0.0`, the correct
result is `+0.0`, but eliding the instruction leaves `x`'s prior value
(`-0.0`) unchanged — a silently wrong sign that is later observable via
division (`1.0 / ±0.0 == ±Infinity`).

`docs/spec/ir.md` documents `CrystalFold v1` as a frozen, semantics-preserving
pass, and the finding notes the public `CrystalFoldPass::run(&mut IrModule)`
API does not forbid `dst` aliasing an operand — so any valid public `IrModule`
this shape can appear in is in scope for the contract, not just what the
current frontend happens to emit.

## Reproduced pre-fix behavior

Verified by temporarily reverting the sign-check guard and rerunning the new
regression tests:

- `crystalfold_does_not_elide_add_f64_positive_zero_when_lhs_is_untracked`:
  a hand-built `AddF64 { dst: 0, lhs: 0, rhs: 1 }` with `rhs` a `+0.0`
  constant and register `0` never loaded (untracked) is silently elided —
  the instruction disappears from the output entirely instead of surviving.
- Same failure mode for the `dst == rhs` `AddF64` branch and the `SubF64`
  negative-zero case.

**Important scoping note:** I first attempted a full end-to-end (source →
frontend → IR → emit → verify → VM) regression using ordinary `.sm` source
with an in-place `y += 0.0;` compound assignment, expecting it to produce the
`dst == lhs` aliased pattern. It does not — I dumped the actual lowered IR and
confirmed `crates/sm-ir/src/legacy_lowering.rs`'s current lowering always
allocates a **fresh** destination register per operation and threads values
through named `StoreVar`/`LoadVar` instructions rather than reusing a
register in place, for every source form I could construct. So this defect
is not currently reachable by compiling ordinary `.sm` programs through the
canonical frontend — it is a **public API/contract soundness gap**: nothing
stops another IR producer (or a future lowering change) from legally
constructing a `dst`-aliased `IrModule` and handing it to the documented,
public `CrystalFoldPass`, exactly parallel in shape to the #1665 malformed
`FnSig` finding in the first SSF-07 slice (public shape admits a state the
implementation doesn't actually handle soundly). Regression tests therefore
exercise the public `CrystalFoldPass::run` API directly with hand-built
`IrModule`s, which is the correct and precise layer for this specific claim.

## Root cause

`*v == 0.0` conflates `+0.0` and `-0.0`. The elision's soundness depends on
the *exact sign* of the constant zero operand, not merely its magnitude.

## Frozen invariants

- `CrystalFold v1` is a frozen, local, deterministic, semantics-preserving
  rewrite pass (`docs/spec/ir.md`, "CrystalFold v1 keeps a frozen narrow
  contract"). No rewrite may change the executable meaning of valid public IR.
- IEEE-754 `f64` arithmetic sign-of-zero behavior: `x + z` for `z ∈ {+0.0,
  -0.0}` equals `x` for every `x` when `z` is `-0.0`, but only for `x ≠ -0.0`
  when `z` is `+0.0` (mirrored for subtraction with the constant's sign
  flipped, since `a - b ≡ a + (-b)`).

## Repair design

Narrowed each identity branch to the one sign of the constant zero that is
*actually* universally sound to elide, using `f64::is_sign_negative()` /
`is_sign_positive()` (exact, bit-based, unaffected by the `==` conflation):

- `AddF64`, `dst == lhs`, constant `rhs`: elide only when `rhs` is `-0.0`
  (`x + (-0.0) == x` for every `x`).
- `AddF64`, `dst == rhs`, constant `lhs`: elide only when `lhs` is `-0.0`
  (commutative mirror of the above).
- `SubF64`, `dst == lhs`, constant `rhs`: elide only when `rhs` is `+0.0`
  (`x - (+0.0) == x` for every `x`).

The opposite sign in each case now falls through to the existing default arm,
which correctly keeps emitting the real instruction — the optimization isn't
disabled, only correctly scoped to the sign for which it's actually sound.

## Why this is fail-closed

- No new default/guess/plausible-substitute behavior. The unsound half of
  each identity is not replaced with a different guess — it simply stops
  being folded away and the real instruction is emitted, which is always
  correct (never just "less optimized," since the previous behavior for that
  half was outright wrong for the `-0.0`-vs-`+0.0` boundary case).
- Both-constant folding (`(Some(F64(a)), Some(F64(b)))`, direct `a + b`/`a -
  b`) is untouched — that path already computes exact IEEE-754 arithmetic via
  the host's own `f64` operations, which are correct.
- `MulF64`'s `*1.0` identity is untouched (out of scope: the finding is
  specifically about Add/Sub-with-zero; `x * 1.0 == x` for every `x`
  including signed zero, so no analogous sign hazard exists there).

## Fallback/bypass audit

Reviewed the changed function (`fold_constants_and_identities` in
`crates/sm-ir/src/passes/crystalfold.rs`):

- No `unwrap()`/`expect()`/`unwrap_or*` introduced.
- No new catch-all match arms; the existing `_ => { cst.remove(&dst);
  out.push(...) }` fallback arm is unchanged and was already the
  correct/conservative "don't fold, keep the real instruction" behavior — it
  now simply catches more cases (the unsound sign) than before, which is the
  fix, not a new bypass.
- No silent truncation/extension/coercion anywhere in the diff.

## Tests added

`crates/sm-ir/src/passes/crystalfold.rs`, all exercising the public
`CrystalFoldPass::run(&mut IrModule)` API directly with hand-built IR
(mirroring the existing `crystalfold_preserves_u32_equality_semantics` test
style from the prior #1730 CrystalFold repair):

- `crystalfold_does_not_elide_add_f64_positive_zero_when_lhs_is_untracked`
- `crystalfold_does_not_elide_add_f64_positive_zero_when_rhs_is_untracked`
- `crystalfold_still_elides_add_f64_negative_zero_when_lhs_is_untracked`
  (proves the fix narrows admission rather than disabling the optimization)
- `crystalfold_does_not_elide_sub_f64_negative_zero_when_lhs_is_untracked`
- `crystalfold_still_elides_sub_f64_positive_zero_when_lhs_is_untracked`

All five were confirmed to fail against the pre-fix guard (temporarily
reverted in place, then restored) before being confirmed green against the
fix. All pre-existing CrystalFold tests, including
`crystalfold_surface_stays_frozen_at_v1`, `crystalfold_idempotent`, and
`crystalfold_preserves_u32_equality_semantics`, continue to pass unchanged.

## Qualification results (exact commands, this HEAD)

```
cargo check --workspace --all-targets              -> clean
cargo test -p sm-ir                                 -> 121 passed; 0 failed
cargo test -p sm-vm                                 -> 116 passed; 0 failed (unaffected; confirms scope is IR-only)
cargo test --test public_api_contracts              -> 88 passed (public CrystalFoldPass signature unchanged, no snapshot drift)
cargo fmt -p sm-ir --check                          -> clean
cargo clippy -p sm-ir --all-targets -- -D warnings  -> clean
```

### Environment/pre-existing baseline caveats (not fixed by this PR, by design)

Same as the prior SSF-07 slice (#1854): workspace-wide `cargo fmt --check`
and `cargo clippy --workspace --all-targets -- -D warnings` fail in this
local environment on an unrelated Windows path-length OS error, and
`cargo clippy -p sm-vm` still fails on the pre-existing `VmProgramView.header`
dead-code warning (`crates/sm-vm/src/semcode_vm.rs:1017`) — this PR does not
touch `sm-vm` at all (confirmed via `git diff main -- crates/sm-vm/src/semcode_vm.rs`,
empty). Both are out of scope by design, same as last time.

CTF touched: none

## Out of scope

- `MulF64`'s `*1.0` identity (no analogous sign hazard; not part of this
  finding).
- Any interprocedural/whole-program constant propagation, or making
  CrystalFold's frontend-unreachable-but-public-API-reachable gap actually
  reachable from `.sm` source (it currently isn't, and isn't a goal).
- Any other SSF-07 abstraction area (text/collections/closures/generics-
  traits/patterns) — this remains Repair Slice 2 of an ongoing sequence.
- No global AST/IR redesign, no VM changes, no SemCode format changes.

## Remaining SSF-07 work

This PR does **not** close #1578. Candidate next slices identified during
triage (not started): FA-02-005/FA-02-006 (duplicate default `match` arm
silently overwrites, Patterns, P1), FA-02-035 (impl `Self` hard-coded to
`Record` regardless of actual target type, Generics/Traits, P1), and a
cluster of smaller Generics/Traits parser-admission gaps.
