### PR TITLE
fix(front): reject duplicate match default arms (#1637 #1638)

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -2418,6 +2418,12 @@ impl<'a> Parser<'a> {
                         message: "default '_' arm in match currently cannot have guard".to_string(),
                     });
                 }
+                if default.is_some() {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "match cannot have more than one default '_' arm".to_string(),
+                    });
+                }
                 self.expect(TokenKind::FatArrow, "expected '=>' after '_'")?;
                 let block = self.parse_block()?;
                 default = Some(block);
@@ -2448,6 +2454,12 @@ impl<'a> Parser<'a> {
                     return Err(FrontendError {
                         pos: self.pos(),
                         message: "default '_' arm in match currently cannot have guard".to_string(),
+                    });
+                }
+                if default.is_some() {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "match cannot have more than one default '_' arm".to_string(),
                     });
                 }
                 self.expect(TokenKind::FatArrow, "expected '=>' after '_'")?;
@@ -4804,6 +4816,134 @@ fn main() {
         assert!(err
             .message
             .contains("default '_' arm in match currently cannot have guard"));
+    }
+
+    // FA-02-006 / #1638: a match expression must accept at most one default
+    // '_' arm. A second default previously overwrote the first silently
+    // (`default = Some(block)` with no prior-state check) instead of being
+    // rejected. See the sibling FA-02-005 / #1637 statement-match tests
+    // below for the identical rule applied to statement-form match.
+
+    #[test]
+    fn rustlike_parser_accepts_match_expression_with_no_default_arm() {
+        let src = r#"
+fn main() {
+    let value: f64 = match T {
+        T => { 1.0 }
+    };
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("match expression with no default arm should parse");
+        let func = &program.functions[0];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected leading let statement");
+        };
+        let Expr::Match(match_expr) = program.arena.expr(*value) else {
+            panic!("expected match expression");
+        };
+        assert_eq!(match_expr.arms.len(), 1);
+        assert!(match_expr.default.is_none());
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_duplicate_default_match_expression_arm() {
+        let src = r#"
+fn main() {
+    let value: f64 = match T {
+        _ => { 1.0 }
+        _ => { 2.0 }
+    };
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("a second default '_' arm in a match expression must reject");
+        assert!(
+            err.message
+                .contains("match cannot have more than one default '_' arm"),
+            "unexpected error message: {}",
+            err.message
+        );
+    }
+
+    // FA-02-005 / #1637: the statement-form match owns independent parsing
+    // logic (parse_match_stmt_after_kw_match) from the match expression
+    // above and must reject the identical duplicate-default-arm shape with
+    // the same diagnostic.
+
+    #[test]
+    fn rustlike_parser_accepts_match_statement_with_no_default_arm() {
+        let src = r#"
+fn main() {
+    match T {
+        T => { }
+    }
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("match statement with no default arm should parse");
+        let func = &program.functions[0];
+        let Stmt::Match { arms, default, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected leading match statement");
+        };
+        assert_eq!(arms.len(), 1);
+        assert!(default.is_empty());
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_match_statement_with_one_default_arm() {
+        // The default arm's block must be non-empty here: `Stmt::Match`
+        // stores `default` as a bare `Vec<StmtId>` (not `Option<...>`), so an
+        // empty default block is indistinguishable from "no default arm" by
+        // inspecting the stored AST alone. The parser's own transient
+        // `Option<Vec<StmtId>>` tracking (which this fix's duplicate check
+        // reads) does not share that ambiguity.
+        let src = r#"
+fn main() {
+    match T {
+        F => { }
+        _ => { return; }
+    }
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("match statement with exactly one default arm should parse");
+        let func = &program.functions[0];
+        let Stmt::Match { arms, default, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected leading match statement");
+        };
+        assert_eq!(arms.len(), 1);
+        assert!(!default.is_empty());
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_duplicate_default_match_statement_arm() {
+        let src = r#"
+fn main() {
+    match T {
+        _ => { }
+        _ => { }
+    }
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("a second default '_' arm in a match statement must reject");
+        assert!(
+            err.message
+                .contains("match cannot have more than one default '_' arm"),
+            "unexpected error message: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -792,6 +792,9 @@ Current `match` semantics:
 - enum `match` may omit `_` only when unguarded variant coverage is exhaustive
 - `_` currently means wildcard/default only in `match`, not a general rich
   pattern system
+- a `match` may contain at most one `_` default arm, in either the statement
+  or expression form; a second `_` arm is a deterministic frontend error, not
+  a replacement of the first
 - the first matching arm is selected deterministically
 
 Current `match` expression semantics:

--- a/examples/qualification/match_surface/negative_duplicate_default_expression_arm_rejected/src/main.sm
+++ b/examples/qualification/match_surface/negative_duplicate_default_expression_arm_rejected/src/main.sm
@@ -1,0 +1,12 @@
+fn classify(x: i32) -> quad {
+    let out: quad = match x {
+        5 => { T }
+        _ => { F }
+        _ => { N }
+    };
+    return out;
+}
+
+fn main() {
+    return;
+}

--- a/examples/qualification/match_surface/negative_duplicate_default_statement_arm_rejected/src/main.sm
+++ b/examples/qualification/match_surface/negative_duplicate_default_statement_arm_rejected/src/main.sm
@@ -1,0 +1,11 @@
+fn classify(x: i32) {
+    match x {
+        5 => { }
+        _ => { return; }
+        _ => { return; }
+    }
+}
+
+fn main() {
+    return;
+}

--- a/tests/match_surface_qualification.rs
+++ b/tests/match_surface_qualification.rs
@@ -201,6 +201,18 @@ fn match_surface_negative_fixtures_reject_deterministically() {
             "examples/qualification/match_surface/negative_result_or_pattern_with_wildcard_lowering_rejected/src/main.sm",
             "or-pattern match arms ('A | B') are not supported",
         ),
+        // FA-02-005 / FA-02-006 (#1637 / #1638): a second default '_' arm
+        // must reject deterministically at parse time in both the
+        // expression-producing and statement forms of match, rather than
+        // silently overwriting the first parsed default arm.
+        (
+            "examples/qualification/match_surface/negative_duplicate_default_expression_arm_rejected/src/main.sm",
+            "match cannot have more than one default '_' arm",
+        ),
+        (
+            "examples/qualification/match_surface/negative_duplicate_default_statement_arm_rejected/src/main.sm",
+            "match cannot have more than one default '_' arm",
+        ),
     ];
 
     for (rel, needle) in negative_cases {


### PR DESCRIPTION
SSF-07: #1578

Fixes #1637
Fixes #1638

Baseline SHA: 4ba2a89e96e587e24fecac4067990c1cf74f7ea1 (main, includes the #1722/#1665 and #1710 slices)

## Problem

Both the statement-form and expression-form `match` parsers in
`crates/sm-front/src/parser.rs` accept an unbounded number of `_` default
arms and silently keep only the last one:

- `parse_match_stmt_after_kw_match` (statement match, #1637 / FA-02-005):
  `default: Option<Vec<StmtId>>`, unconditionally does `default =
  Some(block);` for every `_` arm encountered.
- `parse_match_expr_after_kw_match` (expression match, #1638 / FA-02-006):
  `default: Option<BlockExpr>`, same unconditional overwrite.

Neither site checked whether `default` was already `Some(...)` before
overwriting it, so contradictory source (two `_` arms) silently resolved to
"keep the last one" instead of being rejected — a fail-open parsing gap on
directly conflicting syntax.

## Shared root cause

Both parsing functions are structurally identical for this concern: each
loop iteration that matches `_` unconditionally assigns into a local
`Option<...>` accumulator with no prior-state check. This is the same root
pattern in two independent (but nearly identical) functions — not one shared
helper's misuse — so this is one combined repair slice per the shared
invariant, not a coincidence.

## Reproduced pre-fix behavior

Verified directly against baseline `4ba2a89e` by temporarily reverting both
checks and rerunning the exact regression tests below (`cargo test -p
sm-front`), then restoring the fix. Concrete AST evidence:

**#1638 (expression match)** — `match T { _ => { 1.0 } _ => { 2.0 } }` inside
a `let value: f64 = ...;` parses successfully pre-fix. The panic output from
the reverted `rustlike_parser_rejects_duplicate_default_match_expression_arm`
test dumps the full parsed `Program`, showing:

```
Match(MatchExpr { scrutinee: ExprId(0), arms: [],
  default: Some(BlockExpr { statements: [], tail: ExprId(2) }) })
```

`ExprId(2)` is the *second* literal (`2.0`); `ExprId(1)` (the first
literal, `1.0`) never appears anywhere in `default` — it is fully discarded,
not merely shadowed.

**#1637 (statement match)** — using distinguishable arm bodies
(`_ => { continue; }` then `_ => { break; }`, verified with a temporary probe
test not included in this PR) parses successfully pre-fix, and the resulting
`Stmt::Match.default` is exactly `[Break(None)]` — the second arm's body.
The first arm's `continue;` is never reachable in the accepted AST.

Both confirm: **the parser successfully accepts duplicate default arms, and
the resulting AST contains only the second default body** — the two
strongest of the three acceptable proof forms named in the issues.

## Frozen invariant

A `match` construct (statement or expression form) may contain at most one
`_` wildcard/default arm. A second `_` arm is a deterministic
`FrontendError` at parse time. The first parsed default arm is authoritative
and is never overwritten, replaced, merged with, or silently discarded.

## Repair design

Added the identical check, with the identical diagnostic
(`"match cannot have more than one default '_' arm"`), at both parsing
sites, immediately before each site's own `default = Some(block)`
assignment:

```rust
if default.is_some() {
    return Err(FrontendError {
        pos: self.pos(),
        message: "match cannot have more than one default '_' arm".to_string(),
    });
}
```

Kept as two local checks rather than one shared helper: the check itself is
a two-line `if`, and the two call sites hold different `Option<T>` inner
types (`Vec<StmtId>` vs `BlockExpr`) with different surrounding control flow
(the `default.unwrap_or_default()` shape at the statement site vs. the
`Option<BlockExpr>` kept as-is at the expression site) — a generic helper
would add an abstraction layer to remove two lines of genuinely
straightforward, self-explanatory duplication. The shared, load-bearing
piece — the exact wording of the diagnostic — is kept textually identical by
construction, satisfying "statement and expression forms follow one rule"
without a forced shared function.

No other parser profile or syntax variant reaches this code:
`grep -rln "MatchArm\|MatchExprArm"` across `crates/sm-front/src` returns
only `parser.rs` (the implementation, now fixed), `types.rs` (AST
definitions), and `lib.rs` (re-exports) — `match` has no separate Logos-DSL
parsing path, so there is no sibling exposure to patch.

## Why this is fail-closed

- The only new behavior is rejection with a structured `FrontendError`;
  nothing is silently coerced, defaulted, or merged.
- Zero default arms and exactly one default arm are untouched — same parse
  result as before this change (proven by the positive-control tests below).
- The rejection happens at parse time, strictly before typecheck, lowering,
  emission, verification, or VM execution ever see the program.

## Fallback/bypass audit

Searched the changed neighborhood and the wider `parser.rs` for the same
"assign into `Option`/map with no prior-state check" shape
(`grep -n "= Some("`):

- `default = Some(block)` (both match-arm sites) — **SAME ROOT**, this PR.
- `self.self_type_scope = Some(self_ty)` — scope-stack push (paired with a
  restore later in the same function), not a duplicate-conflict pattern —
  **SAFE**.
- `out.system = Some(system)` (Logos `System` declaration parsing) — same
  root *pattern* (unconditional `Option` overwrite on a duplicate
  declaration) but a different construct entirely, and already tracked as
  its own finding, **FA-02-012 / #1644** ("duplicate Logos System
  declarations silently use last-write-wins semantics") — **NEW FINDING,
  already filed, intentionally left untouched**, per this PR's scope
  discipline.
- All other `= Some(...)`/`== Some(...)` occurrences in `parser.rs` are
  lookahead comparisons (`peek_next_kind() == Some(...)`), unrelated to
  overwrite/duplication concerns — **SAFE**.

One representational note surfaced while writing the positive-control tests,
not a defect: `Stmt::Match.default` is stored as a bare `Vec<StmtId>` (not
`Option<Vec<StmtId>>`), so an *explicitly present but empty* default block
(`_ => { }`) is indistinguishable from *no default arm at all* by inspecting
the stored AST alone. This has no observable behavioral consequence (both
mean "no default statements execute") and is unrelated to the duplicate-arm
defect this PR fixes, so it is not addressed here; documented as a comment
on the affected test (`rustlike_parser_accepts_match_statement_with_one_default_arm`)
for future readers.

## Tests added

`crates/sm-front/src/parser.rs` (parser-level, direct AST evidence):

- `rustlike_parser_accepts_match_expression_with_no_default_arm` (positive control)
- `rustlike_parser_rejects_duplicate_default_match_expression_arm`
- `rustlike_parser_accepts_match_statement_with_no_default_arm` (positive control)
- `rustlike_parser_accepts_match_statement_with_one_default_arm` (positive control)
- `rustlike_parser_rejects_duplicate_default_match_statement_arm`

(`rustlike_parser_accepts_match_expression` and
`rustlike_parser_accepts_adt_match_expression_surface`, already in the
suite, cover "exactly one default arm" for the expression form and continue
to pass unchanged.)

`tests/match_surface_qualification.rs` (higher-level regression, full
`smc check` pipeline) plus two new fixtures:

- `examples/qualification/match_surface/negative_duplicate_default_expression_arm_rejected/src/main.sm`
- `examples/qualification/match_surface/negative_duplicate_default_statement_arm_rejected/src/main.sm`

registered in `match_surface_negative_fixtures_reject_deterministically`,
asserting the CLI's `check` command surfaces the exact diagnostic.

## Pre-fix failure evidence

All five new parser-level tests were run against the pre-fix code
(production checks temporarily reverted in place, tests unchanged) and
confirmed to fail exactly as expected:

- Both `rustlike_parser_rejects_duplicate_default_match_*_arm` tests failed
  because parsing unexpectedly **succeeded** (`expect_err` panicked with the
  full parsed `Program` dumped — see the AST evidence quoted above).
- The two positive-control "no default arm" tests were unaffected (parsing
  behavior for zero defaults was never buggy).

Then the fix was restored and the full suite reconfirmed green.

## Post-fix qualification results (exact commands, this HEAD)

```
cargo check --workspace --all-targets                       -> clean
cargo test -p sm-front                                        -> 493 passed; 0 failed
cargo test --test match_surface_qualification                -> 3 passed; 0 failed
cargo test --test public_api_contracts                        -> 88 passed (no signature/snapshot drift; both fixed functions are private)
cargo test --test canonical_source_style --test ssf_language_contract_drift -> 21 passed
cargo fmt -p sm-front --check                                 -> clean
cargo clippy -p sm-front --all-targets -- -D warnings         -> clean
cargo clippy --workspace --all-targets -- -D warnings         -> clean
```

### Environment/pre-existing caveats (not fixed by this PR, by design)

`cargo fmt --check` (workspace-wide, no `-p`) still fails in this local
environment on the same unrelated Windows path-length OS error noted in the
prior two SSF-07 slices — confirmed unrelated (this PR touches no path
anywhere near whatever triggers it). Note that this run,
`cargo clippy --workspace --all-targets -- -D warnings` itself passed clean
(feature unification across the full workspace build graph apparently
enables whatever gates the previously-reported pre-existing
`VmProgramView.header` dead-code warning in `sm-vm`); running
`cargo clippy -p sm-vm --all-targets -- -D warnings` in isolation still
surfaces that same pre-existing, untouched-by-this-PR warning. This PR does
not touch `crates/sm-vm` at all.

Changed files: `crates/sm-front/src/parser.rs`,
`docs/spec/source_semantics.md`, `tests/match_surface_qualification.rs`,
`examples/qualification/match_surface/negative_duplicate_default_expression_arm_rejected/src/main.sm`
(new),
`examples/qualification/match_surface/negative_duplicate_default_statement_arm_rejected/src/main.sm`
(new).

CTF touched: none

## Out of scope

Per the assigned slice boundary — none of the following are touched:
#1636 (duplicate function parameters), #1652 (discard RHS typechecking),
#1654/#1721 (intrinsic namespace collisions), #1667 (trait `Self`), #1710
(CrystalFold — already merged in a prior slice), ownership fixes,
module/import fixes, verifier/runtime fixes, exhaustiveness redesign, new
pattern syntax/forms, async/macros, broad AST cleanup, or unrelated
warnings/refactors. Also explicitly out of scope: FA-02-012 / #1644 (the
same-root Logos `System` sibling identified in the fallback/bypass audit
above) and the `Stmt::Match.default` empty-vs-absent representational
ambiguity noted above — both are independent from this fix and are reported
rather than repaired here.

## Remaining SSF-07 work

This PR does **not** close #1578 and does not complete the wider SSF-07 /
Phase-B repair program. Do not begin SSF-08 work as a result of this PR.
