### PR TITLE
fix(front): resolve impl targets before Self conformance (#1667 #1651)

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -201,7 +201,7 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
     // M9.2 Wave 3: trait coherence and impl conformance.
     let trait_table = build_trait_table(p)?;
     validate_trait_coherence(&p.impls, &p.arena)?;
-    validate_impl_conformance(&p.impls, &trait_table, &p.arena)?;
+    validate_impl_conformance(&p.impls, &trait_table, &record_table, &adt_table, &p.arena)?;
     validate_top_level_name_collisions(p, &table, &record_table, &adt_table, &schema_table)?;
     validate_record_declarations(p, &record_table, &adt_table)?;
     validate_adt_declarations(p, &record_table, &adt_table)?;
@@ -7718,6 +7718,374 @@ mod tests {
         );
     }
 
+    // FA-02-035 / #1667 + FA-02-019 / #1651: impl target identity is proven
+    // once against the canonical RecordTable/AdtTable, and every meaning of
+    // `Self` derives from that one proven concrete Type. See
+    // `validate_impl_conformance` and `substitute_trait_self_type`.
+
+    /// Table-driven proof that `substitute_trait_self_type` substitutes both
+    /// parsed forms of `Self` (the trait-side `TypeVar` placeholder and the
+    /// impl-side uncanonicalized `Record(for_type)` form) identically,
+    /// recursively, through every currently admitted composite `Type`
+    /// position, for both a record and an ADT concrete target.
+    #[test]
+    fn substitute_trait_self_type_covers_nested_positions_for_both_nominal_families() {
+        let src = r#"
+            record R { n: i32 }
+            enum E { A, B }
+            fn main() {
+                return;
+            }
+        "#;
+        let mut program = parse_program(src).expect("parse");
+        let r_id = *program.arena.symbol_to_id.get("R").expect("R symbol");
+        let e_id = *program.arena.symbol_to_id.get("E").expect("E symbol");
+        let self_id = program.arena.intern_symbol("Self");
+        let arena = &program.arena;
+
+        for (for_type, concrete) in [(r_id, Type::Record(r_id)), (e_id, Type::Adt(e_id))] {
+            // direct Self, both parsed forms
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::TypeVar(self_id),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                concrete,
+                "direct Self (TypeVar form) must resolve to the concrete target type"
+            );
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Record(for_type),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                concrete,
+                "direct Self (impl-side Record form) must resolve to the concrete target type"
+            );
+
+            // tuple containing Self
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Tuple(vec![Type::I32, Type::TypeVar(self_id)]),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                Type::Tuple(vec![Type::I32, concrete.clone()])
+            );
+
+            // Sequence(Self)
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Sequence(SequenceType {
+                        family: SequenceCollectionFamily::OrderedSequence,
+                        item: Box::new(Type::TypeVar(self_id)),
+                    }),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                Type::Sequence(SequenceType {
+                    family: SequenceCollectionFamily::OrderedSequence,
+                    item: Box::new(concrete.clone()),
+                })
+            );
+
+            // Option(Self)
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Option(Box::new(Type::TypeVar(self_id))),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                Type::Option(Box::new(concrete.clone()))
+            );
+
+            // Result(Self, ...) and Result(..., Self)
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Result(Box::new(Type::TypeVar(self_id)), Box::new(Type::Bool)),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                Type::Result(Box::new(concrete.clone()), Box::new(Type::Bool))
+            );
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Result(Box::new(Type::Bool), Box::new(Type::TypeVar(self_id))),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                Type::Result(Box::new(Type::Bool), Box::new(concrete.clone()))
+            );
+
+            // closure parameter and return containing Self
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Closure(ClosureType {
+                        family: ClosureValueFamily::UnaryDirect,
+                        capture: ClosureCapturePolicy::Immutable,
+                        param: Box::new(Type::TypeVar(self_id)),
+                        ret: Box::new(Type::I32),
+                    }),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                Type::Closure(ClosureType {
+                    family: ClosureValueFamily::UnaryDirect,
+                    capture: ClosureCapturePolicy::Immutable,
+                    param: Box::new(concrete.clone()),
+                    ret: Box::new(Type::I32),
+                })
+            );
+            assert_eq!(
+                substitute_trait_self_type(
+                    &Type::Closure(ClosureType {
+                        family: ClosureValueFamily::UnaryDirect,
+                        capture: ClosureCapturePolicy::Immutable,
+                        param: Box::new(Type::I32),
+                        ret: Box::new(Type::TypeVar(self_id)),
+                    }),
+                    Some(self_id),
+                    for_type,
+                    &concrete
+                ),
+                Type::Closure(ClosureType {
+                    family: ClosureValueFamily::UnaryDirect,
+                    capture: ClosureCapturePolicy::Immutable,
+                    param: Box::new(Type::I32),
+                    ret: Box::new(concrete.clone()),
+                })
+            );
+
+            // an unrelated nominal name (not Self, not for_type) must never
+            // be substituted
+            let other = arena
+                .symbol_to_id
+                .get("R")
+                .copied()
+                .filter(|id| *id != for_type);
+            if let Some(other_id) = other {
+                assert_eq!(
+                    substitute_trait_self_type(
+                        &Type::Record(other_id),
+                        Some(self_id),
+                        for_type,
+                        &concrete
+                    ),
+                    Type::Record(other_id),
+                    "a nominal type reference that is not Self and not the impl target must be left untouched"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn impl_self_for_adt_target_typechecks_body_as_the_correct_adt_not_a_guessed_record() {
+        // FA-02-035 / #1667 core regression: a `Self`-typed impl method body
+        // for an enum/ADT target must be typechecked as the actual ADT, not
+        // as a guessed Record. Pattern-matching on `self` only typechecks if
+        // `self`'s resolved type is genuinely `Type::Adt(Color)`.
+        let src = r#"
+            trait Describe {
+                fn label(self: Self) -> i32;
+            }
+
+            enum Color {
+                Red,
+                Blue,
+            }
+
+            impl Describe for Color {
+                fn label(self: Self) -> i32 {
+                    match self {
+                        Color::Red => { return 1; }
+                        Color::Blue => { return 2; }
+                    }
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        typecheck_source(src).expect(
+            "enum-Self impl method body must typecheck against the correct ADT-shaped Self",
+        );
+    }
+
+    #[test]
+    fn impl_self_conformance_mismatch_reports_the_correct_adt_type_not_record() {
+        // FA-02-035 / #1667: this is the direct, historical-bug-exposing
+        // proof. Pre-fix, `substitute_trait_self_type` always reconstructed
+        // `Type::Record(concrete_self)` for `Self`, regardless of the impl
+        // target's real nominal family. A genuine conformance mismatch on a
+        // Self-typed position for an *enum* impl target must report the
+        // concrete type as `Adt(..)`, never `Record(..)`, in its diagnostic.
+        let src = r#"
+            trait Make {
+                fn make() -> Self;
+            }
+
+            enum Color {
+                Red,
+                Blue,
+            }
+
+            impl Make for Color {
+                fn make() -> i32 {
+                    return 0;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("impl method returning i32 instead of Self must fail conformance");
+        assert!(
+            err.message.contains("Adt("),
+            "expected the conformance diagnostic to report the resolved Adt(..) type for Self, got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("Record("),
+            "the conformance diagnostic must never guess Record(..) for an enum impl target, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn impl_target_that_does_not_exist_rejects_even_without_any_self_reference() {
+        // FA-02-019 / #1651 core regression: a trait whose methods never
+        // reference `Self` previously gave `validate_impl_conformance` no
+        // way to independently prove the impl target exists (it had no
+        // RecordTable/AdtTable input at all). An impl for a wholly
+        // undeclared name must reject deterministically regardless.
+        let src = r#"
+            trait Marker {
+                fn ping() -> i32;
+            }
+
+            impl Marker for MissingType {
+                fn ping() -> i32 {
+                    return 1;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("impl for an undeclared target must reject even with no Self reference");
+        assert!(
+            err.message.contains("unknown nominal type 'MissingType'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn impl_target_ambiguous_between_record_and_enum_rejects_deterministically() {
+        // The impl-target resolver must fail closed on ambiguity rather than
+        // arbitrarily preferring one nominal family, even though this
+        // program is also independently rejected later by
+        // validate_top_level_name_collisions — validate_impl_conformance
+        // runs first and must not silently pick Record.
+        let src = r#"
+            trait Marker {
+                fn ping() -> i32;
+            }
+
+            record Dup { n: i32 }
+            enum Dup { A, B }
+
+            impl Marker for Dup {
+                fn ping() -> i32 {
+                    return 1;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("impl target ambiguous between record and enum must reject");
+        assert!(
+            err.message
+                .contains("ambiguously declared as both record and enum"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn impl_target_that_exists_without_self_reference_still_typechecks() {
+        // Positive control paired with the #1651 regression above: a real,
+        // unambiguous target must still be admitted when the trait's
+        // methods never reference Self.
+        let src = r#"
+            trait Marker {
+                fn ping() -> i32;
+            }
+
+            record RealType { n: i32 }
+
+            impl Marker for RealType {
+                fn ping() -> i32 {
+                    return 1;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("impl for a real declared target must still typecheck with no Self reference");
+    }
+
+    #[test]
+    fn impl_self_nested_in_option_typechecks_end_to_end_for_enum_target() {
+        // At least one source-level conformance test for a nested Self
+        // position (Option(Self)) through the real pipeline, complementing
+        // the table-driven substitute_trait_self_type unit test above.
+        let src = r#"
+            trait MaybeSelf {
+                fn maybe(self: Self, flag: quad) -> Option(Self);
+            }
+
+            enum Color {
+                Red,
+                Blue,
+            }
+
+            impl MaybeSelf for Color {
+                fn maybe(self: Self, flag: quad) -> Option(Self) {
+                    if flag == T {
+                        return Option::Some(self);
+                    }
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("Option(Self) for an enum impl target must typecheck");
+    }
+
     #[test]
     fn generic_fn_with_bound_and_satisfying_impl_typechecks() {
         let src = r#"
@@ -10133,6 +10501,8 @@ fn validate_trait_coherence(impls: &[ImplDecl], arena: &AstArena) -> Result<(), 
 fn validate_impl_conformance(
     impls: &[ImplDecl],
     trait_table: &TraitTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
     arena: &AstArena,
 ) -> Result<(), FrontendError> {
     let self_type_var = arena.symbol_to_id.get("Self").copied();
@@ -10163,6 +10533,31 @@ fn validate_impl_conformance(
                 });
             }
         };
+        // FA-02-019 / #1651: prove the impl target itself is an admitted,
+        // unambiguous nominal type before anything else is checked. Reuses
+        // the same canonical resolver every other declared-type position in
+        // the frontend already goes through (Type::Record(name) is this
+        // codebase's uncanonicalized "unresolved nominal name" convention;
+        // canonicalize_declared_type_generic disambiguates it against
+        // RecordTable/AdtTable, or fails closed on unknown/ambiguous names).
+        // Without this, a trait whose methods never reference `Self` had no
+        // other admission check that the target type exists at all.
+        let trait_name_str = resolve_symbol_name(arena, imp.trait_name)?;
+        let for_type_str = resolve_symbol_name(arena, imp.for_type)?;
+        let resolved_self_ty = canonicalize_declared_type_generic(
+            &Type::Record(imp.for_type),
+            record_table,
+            adt_table,
+            arena,
+            &[],
+        )
+        .map_err(|err| FrontendError {
+            pos: 0,
+            message: format!(
+                "impl of trait '{}' for '{}': {}",
+                trait_name_str, for_type_str, err.message
+            ),
+        })?;
         for trait_method in &trait_decl.methods {
             match imp.methods.iter().find(|m| m.name == trait_method.name) {
                 None => {
@@ -10192,9 +10587,28 @@ fn validate_impl_conformance(
                     for ((_, actual_ty), (_, expected_ty)) in
                         m.params.iter().zip(trait_method.params.iter())
                     {
-                        let expected_ty =
-                            substitute_trait_self_type(expected_ty, self_type_var, imp.for_type);
-                        if actual_ty != &expected_ty {
+                        // FA-02-035 / #1667: substitute Self on *both* sides
+                        // through the same resolved concrete Type. The impl
+                        // side's own `Self` occurrences were parsed as the
+                        // uncanonicalized `Type::Record(imp.for_type)`
+                        // placeholder (identical to writing the target's
+                        // name directly instead of `Self`); the trait side's
+                        // were parsed as `Type::TypeVar("Self")`. Both must
+                        // resolve to the one proven concrete type before
+                        // comparison, never to a guessed `Record`.
+                        let actual_ty = substitute_trait_self_type(
+                            actual_ty,
+                            self_type_var,
+                            imp.for_type,
+                            &resolved_self_ty,
+                        );
+                        let expected_ty = substitute_trait_self_type(
+                            expected_ty,
+                            self_type_var,
+                            imp.for_type,
+                            &resolved_self_ty,
+                        );
+                        if actual_ty != expected_ty {
                             return Err(FrontendError {
                                 pos: 0,
                                 message: format!(
@@ -10207,15 +10621,25 @@ fn validate_impl_conformance(
                             });
                         }
                     }
-                    let expected_ret =
-                        substitute_trait_self_type(&trait_method.ret, self_type_var, imp.for_type);
-                    if m.ret != expected_ret {
+                    let actual_ret = substitute_trait_self_type(
+                        &m.ret,
+                        self_type_var,
+                        imp.for_type,
+                        &resolved_self_ty,
+                    );
+                    let expected_ret = substitute_trait_self_type(
+                        &trait_method.ret,
+                        self_type_var,
+                        imp.for_type,
+                        &resolved_self_ty,
+                    );
+                    if actual_ret != expected_ret {
                         return Err(FrontendError {
                             pos: 0,
                             message: format!(
                                 "impl method '{}' has return type {:?}, expected {:?} from trait '{}'",
                                 resolve_symbol_name(arena, trait_method.name)?,
-                                m.ret,
+                                actual_ret,
                                 expected_ret,
                                 resolve_symbol_name(arena, imp.trait_name)?,
                             ),
@@ -10241,17 +10665,38 @@ fn validate_impl_conformance(
     Ok(())
 }
 
+/// Replace every occurrence of `Self` with the one canonically resolved
+/// concrete impl-target `Type` (see FA-02-035 / #1667 and FA-02-019 /
+/// #1651). Two distinct parsed forms both denote `Self` and must both
+/// substitute to the identical concrete type:
+///
+/// - `Type::TypeVar(name)` where `name` is the interned "Self" symbol: how
+///   trait method signatures parse `Self` (a neutral placeholder, since no
+///   concrete impl target is known while parsing a trait body).
+/// - `Type::Record(name)` where `name == for_type`: how impl method
+///   signatures parse `Self` (this codebase's general "unresolved nominal
+///   name" convention — indistinguishable from writing the target type's
+///   name directly instead of `Self`, which is intentional: they denote the
+///   same type).
+///
+/// `concrete_self` must already be the canonically resolved `Type::Record`
+/// or `Type::Adt` for `for_type` (see `validate_impl_conformance`) — this
+/// function never itself guesses a nominal family.
 fn substitute_trait_self_type(
     ty: &Type,
     self_type_var: Option<SymbolId>,
-    concrete_self: SymbolId,
+    for_type: SymbolId,
+    concrete_self: &Type,
 ) -> Type {
     match ty {
-        Type::TypeVar(name) if Some(*name) == self_type_var => Type::Record(concrete_self),
+        Type::TypeVar(name) if Some(*name) == self_type_var => concrete_self.clone(),
+        Type::Record(name) if *name == for_type => concrete_self.clone(),
         Type::Tuple(items) => Type::Tuple(
             items
                 .iter()
-                .map(|item| substitute_trait_self_type(item, self_type_var, concrete_self))
+                .map(|item| {
+                    substitute_trait_self_type(item, self_type_var, for_type, concrete_self)
+                })
                 .collect(),
         ),
         Type::Sequence(sequence) => Type::Sequence(SequenceType {
@@ -10259,6 +10704,7 @@ fn substitute_trait_self_type(
             item: Box::new(substitute_trait_self_type(
                 sequence.item.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
         }),
@@ -10266,11 +10712,13 @@ fn substitute_trait_self_type(
             key: Box::new(substitute_trait_self_type(
                 map.key.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
             val: Box::new(substitute_trait_self_type(
                 map.val.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
         }),
@@ -10280,11 +10728,13 @@ fn substitute_trait_self_type(
             param: Box::new(substitute_trait_self_type(
                 closure.param.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
             ret: Box::new(substitute_trait_self_type(
                 closure.ret.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
         }),
@@ -10292,6 +10742,7 @@ fn substitute_trait_self_type(
             Box::new(substitute_trait_self_type(
                 base.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
             *unit,
@@ -10299,17 +10750,20 @@ fn substitute_trait_self_type(
         Type::Option(item) => Type::Option(Box::new(substitute_trait_self_type(
             item.as_ref(),
             self_type_var,
+            for_type,
             concrete_self,
         ))),
         Type::Result(ok_ty, err_ty) => Type::Result(
             Box::new(substitute_trait_self_type(
                 ok_ty.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
             Box::new(substitute_trait_self_type(
                 err_ty.as_ref(),
                 self_type_var,
+                for_type,
                 concrete_self,
             )),
         ),

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -266,6 +266,20 @@ outside the hardcoded
 Iterable `next()` for-loop desugaring, so general trait method dispatch and
 UFCS call resolution remain deferred and experimental.
 
+First-wave impl targets are direct declared nominal records or ADTs only.
+`validate_impl_conformance` proves the impl target identity exactly once,
+against the canonical `RecordTable`/`AdtTable` (the same resolver every other
+declared-type position in the frontend uses), before conformance succeeds —
+an impl for an undeclared target rejects deterministically even when the
+trait's own method signatures never reference `Self` and so would not
+otherwise force that resolution. `Self` in both trait and impl method
+signatures denotes exactly that one resolved concrete type and preserves its
+real nominal family: `Self` for a record-target impl resolves to
+`Type::Record`, `Self` for an enum/ADT-target impl resolves to `Type::Adt` —
+never a guessed `Record` regardless of the target's actual family. Broader
+generic/blanket/dynamic impl forms remain outside this closed surface, as
+described above.
+
 ## Deterministically unsupported forms
 
 Forms with no admitted current implementation must fail before execution with a


### PR DESCRIPTION
SSF-07: #1578

Fixes #1667
Fixes #1651

Baseline SHA: 9ddcf93e8e5ed2b349f3b3e129d836f0bcf19c63 (main, includes the #1722/#1665, #1710, and #1637/#1638 slices)

## Ground-truth reproduction

Both issues were reproduced directly against baseline before any code changed.

**#1651** (`impl_target_that_does_not_exist_rejects_even_without_any_self_reference`, and an earlier throwaway probe): a trait whose methods never reference `Self` at all —

```
trait Marker { fn ping() -> i32; }
impl Marker for MissingType { fn ping() -> i32 { return 1; } }
```

— **typechecked successfully** (`Ok(())`) on baseline `main`, even though `MissingType` is never declared anywhere as a record or enum. `validate_impl_conformance` had no `RecordTable`/`AdtTable` input at all, and nothing else in `type_check_program`'s pipeline independently checks that `imp.for_type` names a real declared type when no method signature forces that resolution.

**#1667** (`impl_self_conformance_mismatch_reports_the_correct_adt_type_not_record`, and an earlier throwaway direct-call probe): calling `substitute_trait_self_type(TypeVar(Self), Some(self_id), color_id)` where `Color` is declared as an `enum` returned `Record(SymbolId(N))` — the function unconditionally reconstructs `Type::Record(concrete_self)` for `Self`, regardless of the target's real nominal family. This surfaces as a wrong diagnostic: a genuine conformance mismatch on a `Self`-typed return for an enum impl reported `"...expected Record(SymbolId(3)) from trait 'Make'"` on baseline `main`, where the correct resolved type is `Adt(SymbolId(3))`.

Both reverts were done in place (production code only, tests unchanged) and confirmed via `cargo test -p sm-front`, then restored — see "Post-fix evidence" below for the exact commands and observed pre-fix failures.

## Why #1667 and #1651 are one repair slice

They compose through exactly one canonical impl-target-resolution boundary, with no second nominal-type authority, no parser change, and no trait/AST/generic-system redesign:

- #1651's fix *is* calling the resolver at all, unconditionally, before conformance succeeds.
- #1667's fix *is* using the resolver's actual output (a concrete `Type::Record`/`Type::Adt`) instead of blindly guessing `Record`, in the one place (`substitute_trait_self_type`) that reconstructs a concrete type for `Self`.

Investigation (see "Parser-phase decision for Self" below) showed **no parser change was needed** — impl-side `Self` already parsed through this codebase's general, pre-existing "unresolved nominal name" convention, and an already-canonical resolver (`canonicalize_declared_type_generic`) already existed and already handled the exact ambiguity/unknown-target failure modes both issues need. The entire repair is two functions in `crates/sm-front/src/typecheck.rs`.

## Root cause

One conflated assumption in two places:
1. `validate_impl_conformance` assumed the impl target's existence would always be incidentally proven by *something else* (a `Self`-typed method signature forcing canonicalization, or the separate `validate_top_level_name_collisions` pass) — untrue whenever no method signature mentions `Self`.
2. `substitute_trait_self_type` assumed "the impl target" and "a record" were the same concept, because in the frontend's original, blanket-impl-free surface, most/all impl targets in test coverage happened to be records.

## Canonical authority used

`canonicalize_declared_type_generic` (`crates/sm-front/src/lib.rs:726`), the same function every other declared-type position in the frontend (function params, return types, record fields, etc.) already goes through to disambiguate a parsed `Type::Record(name)` placeholder into the real `Type::Record`/`Type::Adt`, or reject it. Its existing behavior, reused verbatim (no new resolver written):

```rust
Type::Record(name) => match (record_table.contains_key(name), adt_table.contains_key(name)) {
    (true, false) => Ok(Type::Record(*name)),
    (false, true) => Ok(Type::Adt(*name)),
    (true, true)  => Err("top-level name '...' is ambiguously declared as both record and enum"),
    (false, false) => Err("unknown nominal type '...'"),
}
```

`validate_impl_conformance` now calls `canonicalize_declared_type_generic(&Type::Record(imp.for_type), record_table, adt_table, arena, &[])` once per impl, immediately after confirming the trait exists, propagating its error (wrapped with impl/trait context) via `?`. This single call is simultaneously the #1651 fix (fails closed on unknown/ambiguous target, unconditionally, before any method-level check) and the source of the one resolved concrete `Type` used for #1667's substitution.

**Validation-order note:** `validate_impl_conformance` still runs before `validate_top_level_name_collisions` in `type_check_program` (unchanged global ordering — no reordering was needed). A record/enum name collision can therefore still reach the resolver mid-audit; `canonicalize_declared_type_generic`'s existing `(true, true)` branch already fails closed on that ambiguity rather than guessing, so this is safe without touching global ordering. Confirmed via `impl_target_ambiguous_between_record_and_enum_rejects_deterministically`.

## Parser-phase decision for Self

No parser change. Investigated whether `parse_impl_decl`'s `with_self_type_scope(Type::Record(for_type), ...)` (line 402) needed to change to a neutral placeholder (mirroring the trait side's `Type::TypeVar(intern("Self"))`, line 336) — it does not: `Type::Record(name)` is this codebase's general, pre-existing convention for *any* not-yet-canonicalized nominal type reference (confirmed by reading `canonicalize_declared_type_generic`'s own handling of ordinary `Type::Record(name)` parameters, used for every other declared type in the language, not just impl `Self`). Writing `Self` in an impl method and writing the target type's name directly are — correctly — indistinguishable at the parsed-`Type` level; both denote the same concrete type for a given impl.

## Impl-target resolution invariant

```
Given impl.for_type: SymbolId,
resolve_impl_target = canonicalize_declared_type_generic(&Type::Record(for_type), record_table, adt_table, arena, &[])
  => Ok(Type::Record(id))   -- exactly one of Record/Adt admitted
  => Ok(Type::Adt(id))
  => Err(..)                -- ambiguous (both) or unknown (neither), always
```

Never `unknown target → assume Record → continue`. Never a second resolver competing with this one.

## Self substitution behavior

`substitute_trait_self_type(ty, self_type_var, for_type, concrete_self: &Type)` now recognizes **both** parsed forms of `Self` and substitutes both to the identical resolved `concrete_self`:

- `Type::TypeVar(name)` where `name == self_type_var` — the trait-side placeholder.
- `Type::Record(name)` where `name == for_type` — the impl-side "unresolved nominal name" form (see above).

It is applied to **both sides** of every conformance comparison (the trait's declared param/return type *and* the impl's own written param/return type), not only the trait side as before — necessary because the impl side's own `Self` occurrences are, by the point of comparison, still in their unresolved `Record(for_type)` form and must be resolved identically to compare correctly against an enum target. The existing recursive walk (tuple, `Sequence`, `Map`, `Closure` param/return, `Measured`, `Option`, `Result`) is unchanged in structure — only the base case and the threaded parameters changed; every pre-existing composite case still recurses correctly with no new gaps.

## Record-target behavior

Unchanged and reconfirmed: `trait_self_contract_allows_multiple_impl_targets`, `trait_self_contract_still_rejects_wrong_concrete_impl_parameter`, and the new `substitute_trait_self_type_covers_nested_positions_for_both_nominal_families` (record half of the table) all pass — `Self` for a record target resolves to `Type::Record`.

## ADT-target behavior

New: `Self` for an enum/ADT target resolves to `Type::Adt`, proven directly (unit-level, `substitute_trait_self_type_covers_nested_positions_for_both_nominal_families`) and end-to-end (`impl_self_for_adt_target_typechecks_body_as_the_correct_adt_not_a_guessed_record`, which pattern-matches on `self` inside the impl method body — this only typechecks if `self`'s resolved scope type is genuinely `Adt`, not a guessed `Record`).

## Unknown-target behavior

New: rejects deterministically even when no method signature references `Self` at all (`impl_target_that_does_not_exist_rejects_even_without_any_self_reference`), and even when the ambiguity is a record/enum name collision rather than an outright-missing name (`impl_target_ambiguous_between_record_and_enum_rejects_deterministically`). A real, unambiguous target with no `Self` reference still typechecks (`impl_target_that_exists_without_self_reference_still_typechecks`, positive control).

## Nested-Self substitution coverage

Table-driven unit test (`substitute_trait_self_type_covers_nested_positions_for_both_nominal_families`) exercises, for **both** a record and an ADT concrete target, and for **both** parsed `Self` forms: direct `Self`, tuple containing `Self`, `Sequence(Self)`, `Option(Self)`, `Result(Self, ..)`/`Result(.., Self)`, closure parameter containing `Self`, closure return containing `Self` — plus a check that an unrelated nominal type reference (not `Self`, not the impl target) is never substituted. Complemented by one source-level end-to-end test (`impl_self_nested_in_option_typechecks_end_to_end_for_enum_target`, `Option(Self)` through the real pipeline for an enum target).

## Validation-order implications

None beyond what's noted above under "Canonical authority used" — no reordering of `type_check_program`'s validator sequence.

## Pre-fix evidence

Verified by temporarily reverting `validate_impl_conformance`/`substitute_trait_self_type` to their exact baseline form in place (production code only; the one new unit test whose signature depends on the fix was disabled for that window via `#[cfg(any())]`, then re-enabled — no test logic was altered) and rerunning:

```
impl_target_that_does_not_exist_rejects_even_without_any_self_reference
  -> FAILED: typecheck_source returned Ok(()) instead of erroring (#1651, confirmed)

impl_target_ambiguous_between_record_and_enum_rejects_deterministically
  -> FAILED: got a DIFFERENT error ("top-level name 'Dup' cannot be used for
     both record and enum", from the later validate_top_level_name_collisions
     pass) instead of validate_impl_conformance's own ambiguity rejection --
     confirming the resolver itself did not yet fail closed on ambiguity and
     was relying on incidental coverage from an unrelated, later validator

impl_self_conformance_mismatch_reports_the_correct_adt_type_not_record
  -> FAILED: message was "...expected Record(SymbolId(3)) from trait 'Make'"
     (#1667, confirmed -- the exact historical wrong-value bug)
```

The other three new tests (`impl_self_for_adt_target_typechecks_body_as_the_correct_adt_not_a_guessed_record`, `impl_self_nested_in_option_typechecks_end_to_end_for_enum_target`, `impl_target_that_exists_without_self_reference_still_typechecks`) already passed pre-fix — expected, since they don't hit a comparison where the two independently-computed sides diverge; they remain in the suite as positive-control/characterization coverage for the fixed code path.

## Post-fix evidence

Fix restored (verified via clean `git diff main -- crates/sm-front/src/typecheck.rs`, no residual markers). Exact qualification below.

## Tests added

All in `crates/sm-front/src/typecheck.rs`:

- `substitute_trait_self_type_covers_nested_positions_for_both_nominal_families`
- `impl_self_for_adt_target_typechecks_body_as_the_correct_adt_not_a_guessed_record`
- `impl_self_conformance_mismatch_reports_the_correct_adt_type_not_record`
- `impl_target_that_does_not_exist_rejects_even_without_any_self_reference`
- `impl_target_ambiguous_between_record_and_enum_rejects_deterministically`
- `impl_target_that_exists_without_self_reference_still_typechecks`
- `impl_self_nested_in_option_typechecks_end_to_end_for_enum_target`

## Fallback/bypass audit

Reviewed the changed control-flow neighborhood in `validate_impl_conformance` and `substitute_trait_self_type`:

- `canonicalize_declared_type_generic(...).map_err(...)?` — **FAIL-CLOSED REPAIR**, this is the #1651 fix itself; propagates via `?`, no swallowed error.
- `_ => ty.clone()` catch-all in `substitute_trait_self_type` — **KEEP**, pre-existing and unchanged in spirit: the correct base case for a substitution walker (any type that is neither form of `Self` nor a composite containing it is legitimately left untouched).
- One self-review finding during drafting: I initially wrote `resolve_symbol_name(...).unwrap_or("<unknown>")` inside the new `map_err` closure (there is a pre-existing, unrelated precedent for this exact pattern elsewhere in the file at line ~2715, used only for a display string, not for admission logic). Rather than rely on that precedent, I refactored to resolve both symbol names via `?` *before* the closure, matching this file's dominant convention with zero `unwrap_or` in the new code. **FAIL-CLOSED REPAIR** (self-corrected before commit).
- No new `unwrap()`/`expect()`/`unwrap_or_default()`/`if let Ok(...)`/silent catch-all admission path anywhere in the diff.

## Sibling exposure audit

- **#1646** (`Self` outside trait/impl context silently reinterpreted as `Record`) — **UNAFFECTED**. Untouched code path (`parse_type`'s fallback when `self_type_scope` is `None`); `self_type_outside_trait_or_impl_positions_is_not_admitted` still passes unchanged.
- **#1668** (generic impl parameters admitted beyond first-wave contract) — **UNAFFECTED**. `validate_trait_coherence`'s rejection of non-empty `imp.type_params` is untouched; this PR passes `&[]` for `type_params` to `canonicalize_declared_type_generic` deliberately, matching that existing constraint, not loosening it.
- **#1669** (trait method signature types not independently canonicalized/validated) — **INTERSECTS BUT DOES NOT FIX**. Confirmed by construction: a trait parameter that is neither `Self` nor the impl's own `for_type` falls through `substitute_trait_self_type`'s unchanged `_ => ty.clone()` arm on both sides, so an unknown, non-`Self` type referenced only in a trait signature still passes conformance unvalidated. Genuinely the same class of gap as #1651 but a different surface (trait declarations, not impl targets) — left for its own issue rather than folded in here.
- **#1648** (recursive generic call inference/substitution) — **UNAFFECTED**. Entirely separate machinery (`subst_apply`, generic call-site substitution); not touched.
- **#1650** (applied generic nominal type model) — **UNAFFECTED**. No generic nominal type model exists yet for impls (type params on impls remain rejected); not touched.
- **#1717** (missing IR monomorphisation / completed-generics claim) — **UNAFFECTED**. This PR is entirely within `sm-front` frontend typecheck; impl methods still aren't registered in `FnTable` and remain uncallable from ordinary code, so no monomorphisation-adjacent claim is made or implied.

No sibling turned out to share the same root invariant such that it would remain independently broken after this repair — none were folded in.

## Qualification results (exact commands, this HEAD)

```
cargo check --workspace --all-targets                                       -> clean
cargo test -p sm-front                                                       -> 500 passed; 0 failed
cargo test --test public_api_contracts                                       -> 88 passed (no signature/snapshot drift; both changed functions are private)
cargo test --test ssf_language_contract_drift --test canonical_source_style  -> 21 passed
cargo test --test frontend_parser_qualification --test frontend_lexer_qualification -> 17 passed
cargo test -p sm-ir -p sm-vm                                                 -> unaffected, unchanged pass counts
cargo fmt -p sm-front --check                                                -> clean
cargo clippy -p sm-front --all-targets -- -D warnings                        -> clean
cargo clippy --workspace --all-targets -- -D warnings                        -> clean
```

### Environment/pre-existing caveats (not fixed by this PR, by design)

`cargo fmt --check` (workspace-wide, no `-p`) still fails in this local environment on the same unrelated Windows path-length OS error noted in every prior SSF-07 slice in this sequence — this PR touches nothing near whatever triggers it.

Changed files: `crates/sm-front/src/typecheck.rs`, `docs/spec/foundation_source_profile_v1.md`.

CTF touched: none

## Out of scope

Per the assigned slice boundary — none of the following are touched: generic traits, generic/blanket impls, specialization, trait objects/dynamic dispatch, monomorphisation, broader runtime trait dispatch, `Self` parser policy outside impl/trait (#1646), global `Type`-system redesign, #1636, #1652, #1654/#1721, #1729 (already merged separately), ownership fixes, module/import fixes, verifier/runtime fixes, exhaustiveness redesign, new pattern syntax/forms, async/macros, or unrelated warnings/refactors. Also explicitly out of scope and reported rather than repaired: #1669 (see sibling audit above).

## Remaining SSF-07 work

This PR does **not** close #1578 and does **not** authorize SSF-08. Candidate next slices from the earlier triage remain open (e.g. #1644 duplicate Logos `System` declarations, and the broader numeric/text/collection/closure/generic/pattern closure matrix).
