### PR TITLE
fix(front): validate trait signatures and executable type admission (#1669 #1647)

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -608,16 +608,28 @@ pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError>
                     .params
                     .iter()
                     .map(|(name, ty)| {
-                        Ok((
-                            *name,
-                            canonicalize_declared_type_generic(
-                                ty,
-                                &record_table,
-                                &adt_table,
-                                &program.arena,
-                                &admitted_type_vars,
-                            )?,
-                        ))
+                        let canonical = canonicalize_declared_type_generic(
+                            ty,
+                            &record_table,
+                            &adt_table,
+                            &program.arena,
+                            &admitted_type_vars,
+                        )?;
+                        // FA-02-015 / #1647: TraitTable admission proves both
+                        // canonical nominal identity AND that the canonical
+                        // type is on the current executable-admitted
+                        // surface -- never store first and validate later.
+                        typecheck::ensure_executable_type_supported(
+                            &canonical,
+                            &program.arena,
+                            &admitted_type_vars,
+                            format!(
+                                "parameter '{}' of trait method '{}'",
+                                resolve_symbol_name(&program.arena, *name)?,
+                                resolve_symbol_name(&program.arena, m.name)?
+                            ),
+                        )?;
+                        Ok((*name, canonical))
                     })
                     .collect::<Result<Vec<_>, FrontendError>>()?;
                 let ret = canonicalize_declared_type_generic(
@@ -626,6 +638,15 @@ pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError>
                     &adt_table,
                     &program.arena,
                     &admitted_type_vars,
+                )?;
+                typecheck::ensure_executable_type_supported(
+                    &ret,
+                    &program.arena,
+                    &admitted_type_vars,
+                    format!(
+                        "return type of trait method '{}'",
+                        resolve_symbol_name(&program.arena, m.name)?
+                    ),
                 )?;
                 Ok(TraitMethodSig {
                     name: m.name,
@@ -1718,16 +1739,14 @@ fn main() {
     }
 
     #[test]
-    fn build_trait_table_admits_qvec_signatures_independent_of_1647() {
-        // Sibling-exposure note for #1647 (QVec falls through executable
-        // type validation as supported): this repair calls only
-        // canonicalize_declared_type_generic, never
-        // ensure_executable_type_supported (the separate, already-tracked
-        // function #1647 is about), so #1669's closure is independent of
-        // #1647's status either way. QVec is not a Record/Adt nominal
-        // reference, so canonicalize's unrelated catch-all arm returns it
-        // unchanged -- proving this repair neither depends on nor
-        // absorbs #1647's defect.
+    fn build_trait_table_rejects_direct_qvec_signature() {
+        // FA-02-015 / #1647, corrected: a post-review contract audit found
+        // that #1669's "unsupported type must reject" requirement depends
+        // on ensure_executable_type_supported actually being exhaustive.
+        // build_trait_table now consumes that authoritative check after
+        // canonicalizing, so a reserved, not-yet-promoted-to-executable
+        // QVec signature must reject at trait admission, exactly like an
+        // unknown nominal type does -- never silently stored.
         let src = r#"
             trait Marker {
                 fn f(x: qvec[8]) -> i32;
@@ -1737,7 +1756,35 @@ fn main() {
             }
         "#;
         let program = parse_program(src).expect("parse");
-        build_trait_table(&program).expect("qvec trait signature must admit, independent of #1647");
+        let err = build_trait_table(&program)
+            .expect_err("a reserved qvec trait signature must reject at admission");
+        assert!(
+            err.message.contains("qvec is a reserved type"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_rejects_nested_qvec_signature() {
+        // Recursive enforcement: an unsupported family nested inside an
+        // otherwise-admitted composite must also reject.
+        let src = r#"
+            trait Marker {
+                fn f(x: Option(qvec[8])) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("qvec nested inside Option must reject at admission");
+        assert!(
+            err.message.contains("qvec is a reserved type"),
+            "unexpected error: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -567,6 +567,28 @@ pub fn build_adt_table(program: &Program) -> Result<AdtTable, FrontendError> {
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError> {
+    // FA-02-037 / #1669: TraitTable is the owner-layer canonical trait
+    // contract (the same architectural role FnSig/FnTable plays for
+    // functions), not an unchecked cache of raw parsed declarations. Every
+    // non-Self method-signature type must resolve against the same
+    // canonical nominal authority every other declared-type position in the
+    // frontend uses (see build_fn_table above), before this trait is
+    // admitted -- independent of whether any impl ever exists. Built
+    // locally (mirroring build_fn_table) rather than accepting
+    // caller-supplied tables, so this invariant holds for every public
+    // caller of build_trait_table, not only type_check_program's.
+    let record_table = build_record_table(program)?;
+    let adt_table = build_adt_table(program)?;
+    // The sole admitted type variable in a trait method signature is the
+    // trait-side `Self` placeholder (Type::TypeVar, interned once per
+    // parsed trait). A trait's own declared type_params are deliberately
+    // NOT admitted here: generic traits are not part of the first-wave
+    // canonical contract (#1635), so a signature that references its own
+    // trait type parameter is rejected by the same "type variable is not
+    // in scope" path canonicalize_declared_type_generic already uses for
+    // any other out-of-scope type variable, rather than silently admitted.
+    let self_type_var = program.arena.symbol_to_id.get("Self").copied();
+    let admitted_type_vars: Vec<SymbolId> = self_type_var.into_iter().collect();
     let mut out = BTreeMap::new();
     for t in &program.traits {
         if out.contains_key(&t.name) {
@@ -578,7 +600,48 @@ pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError>
                 ),
             });
         }
-        out.insert(t.name, t.clone());
+        let methods = t
+            .methods
+            .iter()
+            .map(|m| {
+                let params = m
+                    .params
+                    .iter()
+                    .map(|(name, ty)| {
+                        Ok((
+                            *name,
+                            canonicalize_declared_type_generic(
+                                ty,
+                                &record_table,
+                                &adt_table,
+                                &program.arena,
+                                &admitted_type_vars,
+                            )?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, FrontendError>>()?;
+                let ret = canonicalize_declared_type_generic(
+                    &m.ret,
+                    &record_table,
+                    &adt_table,
+                    &program.arena,
+                    &admitted_type_vars,
+                )?;
+                Ok(TraitMethodSig {
+                    name: m.name,
+                    params,
+                    ret,
+                })
+            })
+            .collect::<Result<Vec<_>, FrontendError>>()?;
+        out.insert(
+            t.name,
+            TraitDecl {
+                name: t.name,
+                type_params: t.type_params.clone(),
+                methods,
+            },
+        );
     }
     Ok(out)
 }
@@ -1351,6 +1414,330 @@ fn main() {
             "unexpected error: {}",
             err.message
         );
+    }
+
+    // FA-02-037 / #1669: TraitTable is the owner-layer canonical trait
+    // contract, not an unchecked cache of raw parsed declarations. Every
+    // non-Self method-signature type must resolve against the same
+    // canonical RecordTable/AdtTable authority build_fn_table already uses,
+    // independent of whether any impl exists. See build_trait_table.
+
+    #[test]
+    fn build_trait_table_rejects_unknown_parameter_type() {
+        // (A) No impl anywhere -- the trait contract must prove itself.
+        let src = r#"
+            trait Broken {
+                fn f(x: MissingType) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("unknown parameter type must reject with no impl present");
+        assert!(
+            err.message.contains("unknown nominal type 'MissingType'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_rejects_unknown_return_type() {
+        // (B)
+        let src = r#"
+            trait Broken {
+                fn f() -> MissingType;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("unknown return type must reject with no impl present");
+        assert!(
+            err.message.contains("unknown nominal type 'MissingType'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_rejects_nested_unknown_type() {
+        // (C) At least one compound position containing the unknown name.
+        let src = r#"
+            trait Broken {
+                fn f(x: Option(MissingType)) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("unknown type nested inside Option must reject with no impl present");
+        assert!(
+            err.message.contains("unknown nominal type 'MissingType'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_canonicalizes_record_signature_to_record_type() {
+        // (D) The stored contract must be canonical, not the raw parsed
+        // placeholder -- inspected directly, per #1669's requirement.
+        let src = r#"
+            record R { n: i32 }
+            trait Contract {
+                fn a(x: R) -> R;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let r_id = *program.arena.symbol_to_id.get("R").expect("R symbol");
+        let table = build_trait_table(&program).expect("record signature should admit");
+        let t_id = *program
+            .arena
+            .symbol_to_id
+            .get("Contract")
+            .expect("Contract symbol");
+        let decl = &table[&t_id];
+        assert_eq!(decl.methods[0].params[0].1, Type::Record(r_id));
+        assert_eq!(decl.methods[0].ret, Type::Record(r_id));
+    }
+
+    #[test]
+    fn build_trait_table_canonicalizes_adt_signature_to_adt_type() {
+        // (E) Record-vs-Adt identity must be uniform with the merged
+        // #1667/#1651 impl-side repair: an enum target must never be
+        // stored as an unresolved/guessed Record.
+        let src = r#"
+            enum E { A, B }
+            trait Contract {
+                fn a(x: E) -> E;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let e_id = *program.arena.symbol_to_id.get("E").expect("E symbol");
+        let table = build_trait_table(&program).expect("enum signature should admit");
+        let t_id = *program
+            .arena
+            .symbol_to_id
+            .get("Contract")
+            .expect("Contract symbol");
+        let decl = &table[&t_id];
+        assert_eq!(decl.methods[0].params[0].1, Type::Adt(e_id));
+        assert_eq!(decl.methods[0].ret, Type::Adt(e_id));
+    }
+
+    #[test]
+    fn build_trait_table_admits_reserved_self_in_direct_and_nested_source_positions() {
+        // (F) direct Self, tuple, Sequence, Option, Result(Self, ..),
+        // Result(.., Self) -- all writable as explicit source type syntax.
+        // Closure param/return positions are covered separately below via a
+        // direct canonicalize_declared_type_generic call: this first-wave
+        // surface has no source syntax for writing an explicit closure
+        // type annotation.
+        let cases = [
+            "fn a(x: Self) -> Self;",
+            "fn a(x: (Self, i32)) -> i32;",
+            "fn a(x: Sequence(Self)) -> i32;",
+            "fn a(x: Option(Self)) -> i32;",
+            "fn a(x: Result(Self, i32)) -> i32;",
+            "fn a(x: Result(i32, Self)) -> i32;",
+        ];
+        for method_sig in cases {
+            let src = format!(
+                r#"
+                    trait Contract {{
+                        {method_sig}
+                    }}
+                    fn main() {{
+                        return;
+                    }}
+                "#
+            );
+            let program = parse_program(&src).expect("parse");
+            build_trait_table(&program)
+                .unwrap_or_else(|err| panic!("'{method_sig}' must admit Self: {err:?}"));
+        }
+    }
+
+    #[test]
+    fn canonicalize_declared_type_generic_admits_self_in_closure_positions() {
+        // (F) closure parameter/return continuation of the above, using
+        // build_trait_table's exact admission mechanism directly (no
+        // source syntax exists for an explicit closure type annotation).
+        let src = r#"
+            trait Contract {
+                fn a(x: Self) -> Self;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let self_id = *program
+            .arena
+            .symbol_to_id
+            .get("Self")
+            .expect("Self interned");
+        let record_table = build_record_table(&program).expect("record table");
+        let adt_table = build_adt_table(&program).expect("adt table");
+        let admitted = [self_id];
+
+        let closure_param_self = Type::Closure(ClosureType {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: Box::new(Type::TypeVar(self_id)),
+            ret: Box::new(Type::I32),
+        });
+        let resolved = canonicalize_declared_type_generic(
+            &closure_param_self,
+            &record_table,
+            &adt_table,
+            &program.arena,
+            &admitted,
+        )
+        .expect("closure parameter containing Self must admit");
+        assert_eq!(resolved, closure_param_self);
+
+        let closure_ret_self = Type::Closure(ClosureType {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: Box::new(Type::I32),
+            ret: Box::new(Type::TypeVar(self_id)),
+        });
+        let resolved = canonicalize_declared_type_generic(
+            &closure_ret_self,
+            &record_table,
+            &adt_table,
+            &program.arena,
+            &admitted,
+        )
+        .expect("closure return containing Self must admit");
+        assert_eq!(resolved, closure_ret_self);
+    }
+
+    #[test]
+    fn build_trait_table_does_not_treat_unrelated_nominal_type_as_self() {
+        // (G) A record parameter that is not Self must canonicalize to its
+        // own identity, never be conflated with the reserved placeholder.
+        let src = r#"
+            record R { n: i32 }
+            trait Contract {
+                fn a(x: R, y: Self) -> Self;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let r_id = *program.arena.symbol_to_id.get("R").expect("R symbol");
+        let self_id = *program
+            .arena
+            .symbol_to_id
+            .get("Self")
+            .expect("Self interned");
+        let table = build_trait_table(&program).expect("mixed signature should admit");
+        let t_id = *program
+            .arena
+            .symbol_to_id
+            .get("Contract")
+            .expect("Contract symbol");
+        let decl = &table[&t_id];
+        assert_eq!(decl.methods[0].params[0].1, Type::Record(r_id));
+        assert_eq!(decl.methods[0].params[1].1, Type::TypeVar(self_id));
+        assert_ne!(r_id, self_id);
+    }
+
+    #[test]
+    fn build_trait_table_rejects_ambiguous_nominal_identity_with_no_impl() {
+        // (H) The resolver must fail closed on ambiguity itself, not rely
+        // on validate_top_level_name_collisions (a later, unrelated pass)
+        // to incidentally catch it -- and this must hold with zero impls,
+        // proving trait admission is the independent authority.
+        let src = r#"
+            record Dup { n: i32 }
+            enum Dup { A, B }
+            trait Contract {
+                fn a(x: Dup) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("ambiguous record/enum identity in a trait signature must reject");
+        assert!(
+            err.message
+                .contains("ambiguously declared as both record and enum"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_does_not_admit_a_trait_own_type_parameter_as_a_signature_type() {
+        // Sibling-exposure note for #1635 (generic trait declarations
+        // admitted beyond the first-wave contract): this repair
+        // deliberately admits only the reserved Self placeholder as a
+        // TypeVar, never a trait's own declared type_params (see the
+        // comment in build_trait_table). A side effect -- not a fix of
+        // #1635 itself, whose parser-admission surface is untouched -- is
+        // that a method signature actually using the trait's own type
+        // parameter is now incidentally rejected at trait-admission time by
+        // the same "type variable is not in scope" path any other
+        // out-of-scope TypeVar hits, where previously build_trait_table
+        // performed no signature validation at all.
+        let src = r#"
+            trait Foo<TP> {
+                fn bar(x: TP) -> TP;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("a trait's own type parameter is not an admitted signature TypeVar");
+        assert!(
+            err.message.contains("type variable 'TP' is not in scope"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_admits_qvec_signatures_independent_of_1647() {
+        // Sibling-exposure note for #1647 (QVec falls through executable
+        // type validation as supported): this repair calls only
+        // canonicalize_declared_type_generic, never
+        // ensure_executable_type_supported (the separate, already-tracked
+        // function #1647 is about), so #1669's closure is independent of
+        // #1647's status either way. QVec is not a Record/Adt nominal
+        // reference, so canonicalize's unrelated catch-all arm returns it
+        // unchanged -- proving this repair neither depends on nor
+        // absorbs #1647's defect.
+        let src = r#"
+            trait Marker {
+                fn f(x: qvec[8]) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        build_trait_table(&program).expect("qvec trait signature must admit, independent of #1647");
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -372,6 +372,7 @@ fn type_check_function_with_tables(
         ensure_executable_type_supported(
             ty,
             arena,
+            &func.type_params,
             format!("parameter '{}'", resolve_symbol_name(arena, *name)?),
         )?;
     }
@@ -390,6 +391,7 @@ fn type_check_function_with_tables(
         ensure_executable_type_supported(
             &canonical_ret,
             arena,
+            &func.type_params,
             format!(
                 "return type of '{}'",
                 resolve_symbol_name(arena, func.name)?
@@ -8086,6 +8088,83 @@ mod tests {
         typecheck_source(src).expect("Option(Self) for an enum impl target must typecheck");
     }
 
+    // FA-02-015 / #1647: ensure_executable_type_supported must be exhaustive
+    // (no `_ => Ok(())` catch-all) over every current Type variant, so a
+    // reserved/not-yet-promoted family like QVec rejects deterministically
+    // -- directly, and nested inside every currently admitted composite
+    // position.
+
+    #[test]
+    fn ensure_executable_type_supported_rejects_qvec_directly_and_when_nested() {
+        let qvec = Type::QVec(8);
+        let cases: Vec<(&str, Type)> = vec![
+            ("direct", qvec.clone()),
+            ("Option(qvec)", Type::Option(Box::new(qvec.clone()))),
+            (
+                "Sequence(qvec)",
+                Type::Sequence(SequenceType {
+                    family: SequenceCollectionFamily::OrderedSequence,
+                    item: Box::new(qvec.clone()),
+                }),
+            ),
+            (
+                "Result(qvec, i32)",
+                Type::Result(Box::new(qvec.clone()), Box::new(Type::I32)),
+            ),
+            (
+                "Result(i32, qvec)",
+                Type::Result(Box::new(Type::I32), Box::new(qvec.clone())),
+            ),
+            ("tuple containing qvec", Type::Tuple(vec![Type::I32, qvec])),
+        ];
+        let program = parse_program("fn main() { return; }").expect("parse");
+        for (label, ty) in cases {
+            let err =
+                ensure_executable_type_supported(&ty, &program.arena, &[], "test".to_string())
+                    .expect_err(&format!("{label} must reject as not executable-admitted"));
+            assert!(
+                err.message.contains("qvec is a reserved type"),
+                "{label}: unexpected error: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn ensure_executable_type_supported_admits_ordinary_families() {
+        // Positive control: every already-qualified executable family must
+        // continue to pass through the now-exhaustive match unchanged.
+        let program = parse_program(
+            r#"
+            record R { n: i32 }
+            enum E { A, B }
+            fn main() { return; }
+        "#,
+        )
+        .expect("parse");
+        let r_id = *program.arena.symbol_to_id.get("R").expect("R symbol");
+        let e_id = *program.arena.symbol_to_id.get("E").expect("E symbol");
+        for ty in [
+            Type::Quad,
+            Type::Bool,
+            Type::Text,
+            Type::I32,
+            Type::U32,
+            Type::Fx,
+            Type::F64,
+            Type::Unit,
+            Type::RangeI32,
+            Type::Record(r_id),
+            Type::Adt(e_id),
+            Type::Tuple(vec![Type::I32, Type::Bool]),
+            Type::Option(Box::new(Type::I32)),
+            Type::Result(Box::new(Type::I32), Box::new(Type::Bool)),
+        ] {
+            ensure_executable_type_supported(&ty, &program.arena, &[], "test".to_string())
+                .unwrap_or_else(|err| panic!("{ty:?} must remain executable-admitted: {err:?}"));
+        }
+    }
+
     #[test]
     fn generic_fn_with_bound_and_satisfying_impl_typechecks() {
         let src = r#"
@@ -11389,42 +11468,108 @@ fn ensure_type_resolved(
     }
 }
 
-fn ensure_executable_type_supported(
+/// FA-02-015 / #1647: exhaustive (no catch-all) executable-type admission.
+///
+/// Every `Type` variant is matched explicitly, so adding a new variant to
+/// the `Type` enum without updating this function is a compile error rather
+/// than a silent "falls through to `Ok(())`" admission. `admitted_type_vars`
+/// is the same narrow, caller-scoped admission list
+/// `canonicalize_declared_type_generic` already uses for the same type (a
+/// function's own `type_params`, or — for a trait method signature — just
+/// the reserved `Self` symbol): a `Type::TypeVar` is executable-admitted
+/// only when its name is in that list, never unconditionally. `Type::QVec`
+/// is a reserved, not-yet-promoted-to-executable type family and rejects
+/// deterministically until it is explicitly qualified by its own repair.
+pub(crate) fn ensure_executable_type_supported(
     ty: &Type,
     arena: &AstArena,
+    admitted_type_vars: &[SymbolId],
     context: String,
 ) -> Result<(), FrontendError> {
     match ty {
+        Type::Quad
+        | Type::Bool
+        | Type::Text
+        | Type::I32
+        | Type::U32
+        | Type::Fx
+        | Type::F64
+        | Type::Unit
+        | Type::RangeI32 => Ok(()),
         Type::Tuple(items) => {
             for item in items {
-                ensure_executable_type_supported(item, arena, context.clone())?;
+                ensure_executable_type_supported(item, arena, admitted_type_vars, context.clone())?;
             }
             Ok(())
         }
-        Type::Sequence(sequence) => {
-            ensure_executable_type_supported(sequence.item.as_ref(), arena, context)
-        }
+        Type::Sequence(sequence) => ensure_executable_type_supported(
+            sequence.item.as_ref(),
+            arena,
+            admitted_type_vars,
+            context,
+        ),
         Type::Map(map) => {
-            ensure_executable_type_supported(map.key.as_ref(), arena, context.clone())?;
-            ensure_executable_type_supported(map.val.as_ref(), arena, context)
+            ensure_executable_type_supported(
+                map.key.as_ref(),
+                arena,
+                admitted_type_vars,
+                context.clone(),
+            )?;
+            ensure_executable_type_supported(map.val.as_ref(), arena, admitted_type_vars, context)
         }
-        Type::Measured(base, _) => ensure_executable_type_supported(base, arena, context),
-        Type::Option(item) => ensure_executable_type_supported(item, arena, context),
+        Type::Closure(closure) => {
+            ensure_executable_type_supported(
+                closure.param.as_ref(),
+                arena,
+                admitted_type_vars,
+                context.clone(),
+            )?;
+            ensure_executable_type_supported(
+                closure.ret.as_ref(),
+                arena,
+                admitted_type_vars,
+                context,
+            )
+        }
+        Type::Measured(base, _) => {
+            ensure_executable_type_supported(base, arena, admitted_type_vars, context)
+        }
+        Type::Option(item) => {
+            ensure_executable_type_supported(item, arena, admitted_type_vars, context)
+        }
         Type::Result(ok_ty, err_ty) => {
-            ensure_executable_type_supported(ok_ty, arena, context.clone())?;
-            ensure_executable_type_supported(err_ty, arena, context)
+            ensure_executable_type_supported(ok_ty, arena, admitted_type_vars, context.clone())?;
+            ensure_executable_type_supported(err_ty, arena, admitted_type_vars, context)
         }
         Type::Record(name) => {
             let _ = resolve_symbol_name(arena, *name)?;
-            let _ = context;
             Ok(())
         }
         Type::Adt(name) => {
             let _ = resolve_symbol_name(arena, *name)?;
-            let _ = context;
             Ok(())
         }
-        _ => Ok(()),
+        Type::TypeVar(name) => {
+            if admitted_type_vars.contains(name) {
+                Ok(())
+            } else {
+                Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "type variable '{}' is not admitted as an executable type in {}",
+                        resolve_symbol_name(arena, *name)?,
+                        context
+                    ),
+                })
+            }
+        }
+        Type::QVec(_) => Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "qvec is a reserved type and is not yet admitted as an executable type in {}",
+                context
+            ),
+        }),
     }
 }
 

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -295,6 +295,18 @@ signature that references its own generic parameter is rejected here as an
 out-of-scope type variable, since generic traits are not part of this closed
 surface.
 
+A canonical identity alone is not sufficient for trait admission: the
+canonical type must also be on the current executable-admitted type surface.
+`build_trait_table` consumes `ensure_executable_type_supported` — an
+exhaustive match over every `Type` variant, with no catch-all arm, so adding
+a new `Type` variant without updating this function is a compile error
+rather than a silent new admission — after canonicalizing each signature
+type. `QVec` is a reserved, not-yet-promoted-to-executable type family and
+rejects deterministically wherever it appears in a trait method signature,
+directly or nested, exactly like an unknown nominal type. `TraitTable`
+success therefore means both canonical identity is proven *and* the current
+executable/admitted type surface is proven — never identity alone.
+
 ## Deterministically unsupported forms
 
 Forms with no admitted current implementation must fail before execution with a

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -280,6 +280,21 @@ never a guessed `Record` regardless of the target's actual family. Broader
 generic/blanket/dynamic impl forms remain outside this closed surface, as
 described above.
 
+`TraitTable` (`build_trait_table`) is itself the admitted owner-layer trait
+contract, not an unchecked cache of raw parsed declarations: every non-`Self`
+parameter and return type in every trait method signature is canonicalized
+against the same `RecordTable`/`AdtTable` authority before a trait is
+admitted — independent of whether any impl for it exists. A declared record
+name canonicalizes to `Type::Record`, a declared enum/ADT name canonicalizes
+to `Type::Adt`, and an unknown or ambiguous nominal signature type rejects
+deterministically, in nested positions (tuples, `Sequence`, `Option`,
+`Result`, closure parameter/return) as well as directly. `Self` remains the
+one reserved trait placeholder admitted through this same canonicalizer; a
+trait's own declared type parameters are not — a first-wave trait method
+signature that references its own generic parameter is rejected here as an
+out-of-scope type variable, since generic traits are not part of this closed
+surface.
+
 ## Deterministically unsupported forms
 
 Forms with no admitted current implementation must fail before execution with a


### PR DESCRIPTION
SSF-07: #1578

Fixes #1669
Fixes #1647

Baseline SHA: 30b5fa7e0f0472db50141a5a57b670047258ddf0 (main, includes the #1722/#1665, #1710, #1637/#1638, and #1667/#1651 slices)

> **Post-review correction:** a contract audit after the first review round
> (reviewed commit `a7887ef9dec7bc622e3a64fc425c935753c81c0f`) found that this
> PR's original claim — "#1669 is fully covered and independent of #1647" —
> was incorrect. #1669 requires that *unknown OR unsupported* trait
> method-signature types reject; the original commit only closed the nominal
> (Record/Adt/unknown-name) half. Its own regression,
> `build_trait_table_admits_qvec_signatures_independent_of_1647`, actually
> *proved* the remaining gap: a `qvec` trait signature was admitted into
> `TraitTable`. The slice was therefore extended narrowly, on a new commit
> (`34c3a4a1978f6d006fb20d7ad07a33cd752d09ba`), to repair #1647 at its owning
> boundary (`ensure_executable_type_supported`) and consume that
> authoritative check from `TraitTable` construction. The original Codex
> review of `a7887ef9...` is historical evidence only; a fresh review was
> requested on the corrective HEAD.

## Ground-truth reproduction

### #1669 (nominal half, first commit `a7887ef9de`)

```
build_trait_table_rejects_unknown_parameter_type:
  trait Broken { fn f(x: MissingType) -> i32; }
  -> Ok, stored TraitMethodSig { params: [(_, Record(SymbolId(4)))], ret: I32 }

build_trait_table_rejects_unknown_return_type:
  trait Broken { fn f() -> MissingType; }
  -> Ok, stored TraitMethodSig { params: [], ret: Record(SymbolId(3)) }

build_trait_table_rejects_nested_unknown_type:
  trait Broken { fn f(x: Option(MissingType)) -> i32; }
  -> Ok, stored params: [(_, Option(Record(SymbolId(4))))]

build_trait_table_rejects_ambiguous_nominal_identity_with_no_impl:
  record Dup { n: i32 }  enum Dup { A, B }  trait T { fn a(x: Dup) -> i32; }
  -> Ok, stored params: [(_, Record(SymbolId(0)))] -- picked Record silently

build_trait_table_canonicalizes_adt_signature_to_adt_type:
  enum E { A, B }  trait T { fn a(x: E) -> E; }
  -> assertion failed: left: Record(SymbolId(0)), right: Adt(SymbolId(0))
```

### #1647 (executable-admission half, corrective commit `34c3a4a197`)

```
build_trait_table_rejects_direct_qvec_signature (pre-fix, executable check
neutralized in place):
  trait Marker { fn f(x: qvec[8]) -> i32; }
  -> panicked: "a reserved qvec trait signature must reject at admission:
     {SymbolId(0): TraitDecl { .. methods: [TraitMethodSig { ..
     params: [(SymbolId(3), QVec(8))], ret: I32 }] }}"

build_trait_table_rejects_nested_qvec_signature (same neutralization):
  trait Marker { fn f(x: Option(qvec[8])) -> i32; }
  -> panicked: "qvec nested inside Option must reject at admission:
     {.. params: [(SymbolId(3), Option(QVec(8)))] .. }"
```

Both proofs were obtained by temporarily reverting the relevant production
behavior in place (new tests unchanged), rerunning, capturing the failure,
then restoring — see "Pre-fix / post-fix evidence" below for the exact
technique used for each commit.

## Root cause

Two distinct, independently-reachable gaps:

1. **#1669's original gap** (nominal): `build_trait_table` stored the raw
   parsed `TraitDecl` verbatim, with method signature types never
   canonicalized or existence-checked against `RecordTable`/`AdtTable`.
2. **#1647's gap** (executable admission, exposed by closing #1669's first
   half): `ensure_executable_type_supported` — the function that decides
   whether a *canonical* type is on the current executable-admitted
   surface — ended in `_ => Ok(())`. Every `Type` variant it didn't
   explicitly enumerate (`QVec`, `TypeVar`, `Closure`, `RangeI32`, every
   scalar) silently passed. `build_trait_table`'s first commit correctly
   canonicalized signature types but never called this function at all, so
   a *canonically resolved but not executable* type (`QVec`) sailed through
   both checks.

## TraitTable architectural role

Unchanged from the first commit: `TraitTable` is the owner-layer canonical
trait contract (confirmed **(B)** — `validate_impl_conformance` trusts its
entries directly). This corrective commit strengthens what "canonical" means
for admission purposes: canonical identity is necessary but not sufficient.

## Canonical authority reused

No new authority introduced. `ensure_executable_type_supported` already
existed and was already the sole function this concern is owned by (used by
`type_check_function_with_tables` for ordinary function signatures);
`build_trait_table` now consumes it, mirroring exactly how it already
consumes `canonicalize_declared_type_generic`. No trait-only QVec check and
no second executable-type whitelist were added.

## Self exception model

Unchanged in spirit, extended to the executable check: `ensure_executable_
type_supported` now takes an `admitted_type_vars: &[SymbolId]` parameter —
the same narrow, caller-scoped admission list `canonicalize_declared_type_
generic` already uses for the identical type. A `Type::TypeVar` is
executable-admitted only when its name is in that list. `build_trait_table`
passes only the reserved `Self` symbol; the two existing function-signature
call sites (`type_check_function_with_tables`) pass `&func.type_params`,
preserving their exact existing behavior for both top-level and (previously
unchecked-here, now correctly checked) nested generic type-parameter
positions. TypeVar admission was **not** globalized — it remains as narrowly
scoped as before, just explicit instead of falling through a catch-all.

## Stored TraitTable representation

Unchanged from the first commit for the nominal half. Now additionally:
a successful `TraitTable` entry's stored types are guaranteed to be both
canonical *and* executable-admitted — `qvec` (or any future reserved family)
can never reach storage.

## Validation ordering

No change. `build_trait_table` still fails closed entirely on its own,
before `type_check_program` reaches `validate_trait_coherence`/
`validate_impl_conformance`.

## Pre-fix / post-fix evidence

**#1647 / `ensure_executable_type_supported`:** temporarily replaced the new
`Type::TypeVar`/`Type::QVec` match arms with the exact pre-fix `Ok(())`
behavior (function signature and every other arm left untouched), reran:

- `build_trait_table_rejects_direct_qvec_signature` → FAILED (`Ok`
  returned, exact stored value quoted above)
- `build_trait_table_rejects_nested_qvec_signature` → FAILED (same)

Restored the fix (verified via `git diff` against the exact reverted
region), reran both → pass. The two new direct unit tests on
`ensure_executable_type_supported` itself
(`ensure_executable_type_supported_rejects_qvec_directly_and_when_nested`,
`ensure_executable_type_supported_admits_ordinary_families`) needed their
new 4-argument call signature to exist to compile at all, so they were
temporarily disabled via `#[cfg(any())]` for the revert window only (not
logic-altered) and re-enabled immediately after restoring the fix — no
disabled test remains in the final commit (verified: `grep -n
"TEMP-DISABLED"` returns nothing).

**#1669 (nominal half):** unchanged from the first commit's evidence — see
above.

## Tests added (this corrective commit)

`crates/sm-front/src/lib.rs`:

- `build_trait_table_rejects_direct_qvec_signature` (replaces the
  incorrect `..._admits_qvec_signatures_independent_of_1647`)
- `build_trait_table_rejects_nested_qvec_signature`

`crates/sm-front/src/typecheck.rs`:

- `ensure_executable_type_supported_rejects_qvec_directly_and_when_nested`
  (table-driven: direct, `Option`, `Sequence`, `Result(qvec,i32)`,
  `Result(i32,qvec)`, tuple)
- `ensure_executable_type_supported_admits_ordinary_families` (positive
  control: every scalar, `RangeI32`, `Unit`, `Record`, `Adt`, `Tuple`,
  `Option`, `Result` still admits)

## Full `Type`-variant executable-admission classification

All 20 `Type` variants, exhaustively matched (compiler-enforced — no `_`
arm compiles):

| Variant | Classification | Handling |
|---|---|---|
| `Quad`, `Bool`, `Text`, `I32`, `U32`, `Fx`, `F64`, `Unit`, `RangeI32` | ADMITTED EXECUTABLE (leaf) | `Ok(())` directly |
| `Tuple`, `Sequence`, `Map`, `Option`, `Result`, `Measured` | ADMITTED EXECUTABLE (composite) | recurse into every nested `Type` (unchanged from before, `Closure` newly added — see below) |
| `Closure` | ADMITTED EXECUTABLE (composite) | **newly** recurses into `param`/`ret`; previously fell through the catch-all and was never recursed into at all |
| `Record`, `Adt` | ADMITTED EXECUTABLE (nominal) | unchanged — resolves the symbol name for diagnostics |
| `TypeVar` | STRUCTURAL / PLACEHOLDER WITH SPECIAL CONTEXT | admitted only if the name is in the caller-scoped `admitted_type_vars` list; otherwise rejects |
| `QVec` | RESERVED / NON-EXECUTABLE | rejects deterministically (`#1647`'s fix) |

`Closure` and `RangeI32` were **not** explicitly matched before this commit
(both fell through `_ => Ok(())`); `RangeI32` is a leaf so this had no
practical effect, but `Closure`'s param/return were previously never
recursively checked at all by this function (unlike
`canonicalize_declared_type_generic`, which already recursed into it) — this
commit closes that latent gap too, since making the match exhaustive
required deciding every variant explicitly.

## Exact change to `ensure_executable_type_supported`

- Added `admitted_type_vars: &[SymbolId]` parameter.
- Removed the `_ => Ok(())` catch-all entirely — replaced with 20 explicit
  arms (grouped where behavior is identical).
- `Type::TypeVar(name)`: admits iff `admitted_type_vars.contains(name)`,
  else `Err`.
- `Type::QVec(_)`: unconditional `Err` ("qvec is a reserved type and is not
  yet admitted as an executable type in {context}").
- `Type::Closure`: new explicit arm, recurses into `param`/`ret`.
- Both existing call sites (`type_check_function_with_tables`, ordinary
  function param/return checks) updated to pass `&func.type_params` —
  their pre-existing top-level `TypeVar`-skip-when-generic guards are
  unchanged and still correct; the new parameter only affects *nested*
  generic-`TypeVar` positions, which were previously unchecked by this
  function (though already checked earlier by `canonicalize_declared_type_
  generic`) and are now explicitly, correctly admitted via the same list.
- `ensure_executable_type_supported` changed from module-private to
  `pub(crate)` so `build_trait_table` (in `lib.rs`) can call it — a
  crate-internal visibility change only; the crate's *external* public API
  is unaffected (confirmed: `public_api_contracts` golden snapshot test
  unchanged).

## Was the broad `_ => Ok(())` removed?

Yes, entirely, from `ensure_executable_type_supported`. `ensure_storage_
type_supported` — a separate function with the identical catch-all pattern,
but for record/ADT *field storage* types, not executable *signature*
types — was **not** touched; reported as a sibling finding below, not
folded into this repair.

## Direct QVec post-fix behavior

`ensure_executable_type_supported(&Type::QVec(8), ..)` → `Err("qvec is a
reserved type and is not yet admitted as an executable type in ..")`,
proven directly (`ensure_executable_type_supported_rejects_qvec_directly_
and_when_nested`).

## Nested QVec post-fix behavior

Same error, proven for `Option(qvec)`, `Sequence(qvec)`, `Result(qvec,i32)`,
`Result(i32,qvec)`, and a tuple containing `qvec` — all in the same test.

## TraitTable QVec post-fix behavior

`build_trait_table` rejects both a direct and an `Option`-nested `qvec`
trait method signature parameter, proven end-to-end through the real
canonicalize → executable-check → store pipeline
(`build_trait_table_rejects_direct_qvec_signature`,
`..._rejects_nested_qvec_signature`).

## Self behavior

Unaffected and reconfirmed: `build_trait_table_admits_reserved_self_in_
direct_and_nested_source_positions` and `canonicalize_declared_type_
generic_admits_self_in_closure_positions` still pass — `Self` now also
passes the new executable-admission check (via the same `admitted_type_
vars = [self_symbol]` list threaded through).

## Record/ADT canonicalization behavior

Unaffected and reconfirmed: `build_trait_table_canonicalizes_record_
signature_to_record_type` / `..._canonicalizes_adt_signature_to_adt_type`
still pass unchanged.

## Existing #1669 regressions

All reconfirmed green in the full suite run on this HEAD: unknown parameter/
return/nested-nominal rejection, ambiguous-nominal rejection, Record/Adt
canonicalization, Self admission (direct + nested source positions), no
accidental Self substitution, trait's-own-type-parameter rejection.

## Existing #1667/#1651 regressions

All reconfirmed green: `impl_self_*` (3), `impl_target_*` (4, incl. the
parser-level anchoring test), `substitute_trait_self_type_covers_nested_
positions_for_both_nominal_families`.

## Sibling issues deliberately left open

- **`ensure_storage_type_supported`** (not a filed issue number, discovered
  during this corrective pass) — structurally identical catch-all pattern,
  but a separate function owning record/ADT *field* storage-type admission,
  not executable *signature* types. Left untouched; worth its own finding
  if not already tracked.
- **#1635, #1646, #1668, #1648, #1650, #1717** — unaffected, unchanged from
  the first commit's sibling audit (see below).

### Full sibling-exposure classification (carried forward + updated)

- **#1635** (generic trait declarations admitted beyond first-wave
  contract) — **INCIDENTALLY BLOCKED AT OWNER ADMISSION** (unchanged).
- **#1646** (`Self` outside trait/impl context reinterpreted as `Record`) —
  **UNAFFECTED**.
- **#1647** — **FIXED BY THIS ROOT** (this corrective commit).
- **#1668** (generic impl parameters beyond first-wave contract) —
  **UNAFFECTED**.
- **#1667 / #1651** — previously fixed (prior merged slice); reconfirmed
  unaffected and still green.
- **#1648** (recursive generic call inference) — **UNAFFECTED**.
- **#1650** (applied generic nominal type representation) — **UNAFFECTED**.
- **#1717** (missing IR monomorphisation) — **UNAFFECTED**.

## Qualification results (exact commands, this HEAD)

```
cargo check --workspace --all-targets                                       -> clean
cargo test -p sm-front                                                       -> 514 passed; 0 failed
cargo test --test public_api_contracts                                       -> 88 passed (no signature/snapshot drift)
cargo test --test ssf_language_contract_drift --test canonical_source_style  -> 21 passed
cargo fmt -p sm-front --check                                                -> clean
cargo clippy -p sm-front --all-targets -- -D warnings                        -> clean
cargo clippy --workspace --all-targets -- -D warnings                        -> clean
```

### Environment/pre-existing caveats (not fixed by this PR, by design)

`cargo fmt --check` (workspace-wide, no `-p`) still fails in this local
environment on the same unrelated Windows path-length OS error noted in
every prior SSF-07 slice in this sequence — unchanged, confirmed unrelated
to this diff.

Changed files (this corrective commit): `crates/sm-front/src/lib.rs`,
`crates/sm-front/src/typecheck.rs`, `docs/spec/foundation_source_profile_v1.md`.

Changed files (cumulative, both commits): same three files.

CTF touched: none

## Out of scope

Per the assigned slice boundary — none of the following are touched:
`ensure_storage_type_supported`'s identical catch-all (reported above, not
fixed), QVec parser syntax (#1640/#1641/#1642/#1643), generic traits
(#1635), generic impls (#1668), `Self` outside trait/impl context (#1646),
IR monomorphisation (#1717), runtime trait dispatch, or any unrelated
warnings/refactors. Fixing executable admission of QVec is explicitly not
the same as fixing QVec parser syntax — those remain separate findings.

## Remaining SSF-07 work

This PR does **not** close #1578 and does **not** authorize SSF-08. Open
candidates from prior triage remain: #1644 (duplicate Logos `System`
declarations), #1635, #1646, #1668, `ensure_storage_type_supported`'s
catch-all (new, unfiled), and the broader numeric/text/collection/closure/
generic/pattern closure matrix.
