### PR TITLE
fix(front): reject generic traits outside first-wave contract (#1635)

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -581,12 +581,13 @@ pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError>
     let adt_table = build_adt_table(program)?;
     // The sole admitted type variable in a trait method signature is the
     // trait-side `Self` placeholder (Type::TypeVar, interned once per
-    // parsed trait). A trait's own declared type_params are deliberately
-    // NOT admitted here: generic traits are not part of the first-wave
-    // canonical contract (#1635), so a signature that references its own
-    // trait type parameter is rejected by the same "type variable is not
-    // in scope" path canonicalize_declared_type_generic already uses for
-    // any other out-of-scope type variable, rather than silently admitted.
+    // parsed trait). A trait's own declared type_params are never admitted
+    // here -- generic traits are rejected outright below, before any
+    // method signature is ever canonicalized (FA-02-003 / #1635), so this
+    // list existing only as a defensive default: it must never be widened
+    // to include a trait's own type_params, since that would make an
+    // in-scope reference to them the one path that could smuggle a generic
+    // trait past the declaration-level rejection below.
     let self_type_var = program.arena.symbol_to_id.get("Self").copied();
     let admitted_type_vars: Vec<SymbolId> = self_type_var.into_iter().collect();
     let mut out = BTreeMap::new();
@@ -596,6 +597,23 @@ pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError>
                 pos: 0,
                 message: format!(
                     "duplicate trait '{}'",
+                    resolve_symbol_name(&program.arena, t.name)?
+                ),
+            });
+        }
+        // FA-02-003 / #1635: TraitDecl.type_params is documented as "Empty
+        // in first-wave canonical form" (types.rs), but nothing previously
+        // enforced that -- a trait declaring type parameters, used or not,
+        // silently reached TraitTable. Reject before any method-signature
+        // work begins, independent of whether an impl exists or whether
+        // the parameters are referenced, mirroring the sibling impl-side
+        // enforcement in validate_trait_coherence (#1668) rather than
+        // erasing the parameters and treating the trait as non-generic.
+        if !t.type_params.is_empty() {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "trait '{}' declares type parameters; generic traits are not supported",
                     resolve_symbol_name(&program.arena, t.name)?
                 ),
             });
@@ -1709,17 +1727,17 @@ fn main() {
 
     #[test]
     fn build_trait_table_does_not_admit_a_trait_own_type_parameter_as_a_signature_type() {
-        // Sibling-exposure note for #1635 (generic trait declarations
-        // admitted beyond the first-wave contract): this repair
-        // deliberately admits only the reserved Self placeholder as a
-        // TypeVar, never a trait's own declared type_params (see the
-        // comment in build_trait_table). A side effect -- not a fix of
-        // #1635 itself, whose parser-admission surface is untouched -- is
-        // that a method signature actually using the trait's own type
-        // parameter is now incidentally rejected at trait-admission time by
-        // the same "type variable is not in scope" path any other
-        // out-of-scope TypeVar hits, where previously build_trait_table
-        // performed no signature validation at all.
+        // Updated for FA-02-003 / #1635: this case -- a trait method
+        // signature actually referencing the trait's own declared type
+        // parameter -- is necessarily a non-empty-type_params trait, so it
+        // is now rejected by the deliberate declaration-level generic-trait
+        // check before method-signature canonicalization ever runs, not by
+        // the incidental "type variable is not in scope" path this test
+        // originally observed under #1858 (when build_trait_table did not
+        // yet reject generic traits at all). The admitted_type_vars
+        // TypeVar-scope path documented in build_trait_table remains a
+        // defensive default for this same reason, not the active owner of
+        // this rejection.
         let src = r#"
             trait Foo<TP> {
                 fn bar(x: TP) -> TP;
@@ -1730,9 +1748,9 @@ fn main() {
         "#;
         let program = parse_program(src).expect("parse");
         let err = build_trait_table(&program)
-            .expect_err("a trait's own type parameter is not an admitted signature TypeVar");
+            .expect_err("a trait declaring a type parameter must reject as a generic trait");
         assert!(
-            err.message.contains("type variable 'TP' is not in scope"),
+            err.message.contains("Foo") && err.message.contains("generic traits are not supported"),
             "unexpected error: {}",
             err.message
         );
@@ -1784,6 +1802,91 @@ fn main() {
             err.message.contains("qvec is a reserved type"),
             "unexpected error: {}",
             err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_rejects_generic_trait_with_unused_type_parameter() {
+        // FA-02-003 / #1635: the central regression. `T` is never
+        // referenced by any method signature, so this proves rejection is
+        // driven by TraitDecl declaration admission itself (non-empty
+        // type_params), not by incidental method-signature TypeVar-scope
+        // validation -- and with zero impls anywhere, proving trait
+        // declaration validity does not depend on an implementation
+        // existing.
+        let src = r#"
+            trait GenericTrait<T> {
+                fn value(self: Self) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("a generic trait with an unused type parameter must reject");
+        assert!(
+            err.message.contains("GenericTrait")
+                && err.message.contains("generic traits are not supported"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_rejects_generic_trait_naming_the_offending_trait() {
+        // (E) Stored-state invariant, proven at the whole-program level: a
+        // successful TraitTable can never contain an entry whose
+        // type_params is non-empty, because build_trait_table rejects the
+        // owning trait before any entry is inserted -- even alongside an
+        // otherwise-admitted non-generic trait declared first.
+        let src = r#"
+            trait Contract {
+                fn a(x: Self) -> Self;
+            }
+            trait GenericTrait<T> {
+                fn value(self: Self) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("a generic trait anywhere in the program must reject the whole table");
+        assert!(
+            err.message.contains("GenericTrait")
+                && err.message.contains("generic traits are not supported"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_admits_non_generic_first_wave_trait() {
+        // (C) Positive control: an ordinary first-wave trait with an empty
+        // type_params list must continue to admit successfully.
+        let src = r#"
+            trait Contract {
+                fn value(self: Self) -> i32;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        let table = build_trait_table(&program).expect("non-generic first-wave trait must admit");
+        let contract_id = *program
+            .arena
+            .symbol_to_id
+            .get("Contract")
+            .expect("Contract interned");
+        let decl = table
+            .get(&contract_id)
+            .expect("Contract must be present in TraitTable");
+        assert!(
+            decl.type_params.is_empty(),
+            "non-generic trait must be stored with empty type_params"
         );
     }
 

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -290,10 +290,22 @@ to `Type::Adt`, and an unknown or ambiguous nominal signature type rejects
 deterministically, in nested positions (tuples, `Sequence`, `Option`,
 `Result`, closure parameter/return) as well as directly. `Self` remains the
 one reserved trait placeholder admitted through this same canonicalizer; a
-trait's own declared type parameters are not — a first-wave trait method
-signature that references its own generic parameter is rejected here as an
-out-of-scope type variable, since generic traits are not part of this closed
-surface.
+trait's own declared type parameters are never admitted here, but a
+signature referencing one is no longer what rejects a generic trait — see
+below.
+
+First-wave traits are non-generic: `build_trait_table` requires
+`TraitDecl.type_params.is_empty()` before any method-signature work begins,
+independent of whether the parameters are referenced by any method and
+independent of whether an impl exists. Generic trait syntax
+(`trait Foo<T> { ... }`) may still parse — the raw AST is not required to
+reject it — but a non-empty `type_params` list is never erased or treated
+as though the trait were non-generic; it rejects deterministically instead,
+mirroring the sibling `ImplDecl.type_params` enforcement in
+`validate_trait_coherence`. Generic trait syntax is future/out-of-scope
+work, not a defect to paper over: no successful `TraitTable` entry can have
+a non-empty `type_params`, and `Self` remains supported exactly as
+described above regardless.
 
 A canonical identity alone is not sufficient for trait admission: the
 canonical type must also be on the current executable-admitted type surface.


### PR DESCRIPTION
SSF-07: #1578

Fixes #1635

## Baseline SHA

`3d0adf1bb791a84622fde4c3f1a172f6cbdda044` (matched the assignment's expected baseline exactly; confirmed via fresh `origin/main` fetch before branching).

## Ground-truth reproduction

`build_trait_table()` (`crates/sm-front/src/lib.rs`) validated duplicate trait names and canonicalized/admitted each method signature, but never inspected `TraitDecl.type_params` itself. A trait declaring type parameters — used or unused, with or without an impl — was cloned straight into the canonical `TraitTable`:

```rust
out.insert(t.name, TraitDecl { name: t.name, type_params: t.type_params.clone(), methods });
```

Reproduced with the central regression (`T` unused, zero impls anywhere):

```
trait GenericTrait<T> {
    fn value(self: Self) -> i32;
}
fn main() { return; }
```

Pre-fix, `build_trait_table` returned `Ok` and stored:

```
TraitDecl { name: SymbolId(0), type_params: [SymbolId(1)], methods: [TraitMethodSig { name: SymbolId(3), params: [(SymbolId(4), TypeVar(SymbolId(2)))], ret: I32 }] }
```

confirming `type_params: [T]` reached the canonical table.

## Owner-boundary decision

`build_trait_table` is confirmed (post-#1858) as the canonical trait admission authority — every public entry point that produces a `TraitTable` goes through it, and it already independently builds its own `RecordTable`/`AdtTable` rather than trusting a caller. The repair is enforced there, before any method-signature work begins, mirroring the existing sibling enforcement for impls in `validate_trait_coherence` (#1668).

## Raw AST vs canonical admission decision

```
RAW AST representation allowed? YES
CANONICAL TraitTable admission allowed? NO
```

`parser.rs::parse_trait_decl` / `parse_type_params` are unchanged. `TraitDecl.type_params` is documented in `types.rs` as "Empty in first-wave canonical form" using the same Wave-1/Wave-2 owner-layer-admission convention already used for `RecordDecl`, `AdtDecl`, `Function`, and `ImplDecl` — i.e. Model A (parser may represent future syntax; the owner layer decides canonical admission) is the repo's established architecture, not something introduced here. No parser changes were made or needed.

## Root cause

`build_trait_table` cloned `t.type_params` into the stored `TraitDecl` unconditionally, with no check that it was empty — the only owner-layer admission function in the trait/impl family that didn't enforce its own documented `type_params` invariant (`validate_trait_coherence` already enforced it for `ImplDecl.type_params`; `build_trait_table` never enforced it for `TraitDecl.type_params`).

## Repair

Added an explicit fail-closed check in `build_trait_table`, right after the duplicate-trait-name check and before any method-signature canonicalization:

```rust
if !t.type_params.is_empty() {
    return Err(FrontendError {
        pos: 0,
        message: format!(
            "trait '{}' declares type parameters; generic traits are not supported",
            resolve_symbol_name(&program.arena, t.name)?
        ),
    });
}
```

## Why metadata is rejected rather than erased

`type_params` is never cleared/zeroed to make a generic trait masquerade as non-generic. The whole trait declaration is rejected via `FrontendError`, deterministically, independent of whether any method references the parameter and independent of whether any impl exists. No substitution, inference, or generic-trait semantics were implemented.

## Pre-fix evidence

With the new check temporarily neutralized (`if false && !t.type_params.is_empty()`, tests untouched):

- `build_trait_table_rejects_generic_trait_with_unused_type_parameter` — panicked, `Ok` returned, stored `TraitDecl { type_params: [SymbolId(1)], ... }`.
- `build_trait_table_rejects_generic_trait_naming_the_offending_trait` — panicked, `Ok` returned, table contained both the non-generic `Contract` (`type_params: []`) and the generic `GenericTrait` (`type_params: [SymbolId(5)]`) side by side.
- `build_trait_table_does_not_admit_a_trait_own_type_parameter_as_a_signature_type` — still failed, but via the old incidental `"type variable 'TP' is not in scope"` path (proving this test's new assertion is exercising the *new* declaration-level owner, not the old incidental one).

Restored verbatim afterward; diff confirmed byte-identical to the intended fix before re-running.

## Post-fix evidence

All three tests pass; full `sm-front` suite: 517 passed, 0 failed (514 baseline + 3 new).

## Tests

- `build_trait_table_rejects_generic_trait_with_unused_type_parameter` (central regression — A/F: unused param, zero impls)
- `build_trait_table_rejects_generic_trait_naming_the_offending_trait` (E: stored-state invariant across a mixed generic/non-generic program)
- `build_trait_table_admits_non_generic_first_wave_trait` (C: positive control, also directly asserts `type_params.is_empty()` on the stored entry)
- `build_trait_table_does_not_admit_a_trait_own_type_parameter_as_a_signature_type` (B, updated: same source, diagnostic owner changed from the incidental TypeVar-scope path to the new deliberate declaration-level check)

## Self regression evidence

`build_trait_table_admits_reserved_self_in_direct_and_nested_source_positions` (D) reran green, unmodified — Self in direct/tuple/Sequence/Option/Result positions remains admitted.

## Public-entry-point audit

- `build_trait_table` — same admission authority; now fail-closed on `TraitDecl.type_params`.
- `type_check_program` — calls `build_trait_table` internally; inherits the fix automatically.
- `type_check_function` / `type_check_function_with_table` — not applicable by contract: neither builds or consumes a `TraitTable` at all (single-function checkers; see #1649, unrelated pre-existing finding, out of scope here).

No public function signature changed; `sm_front_lib.txt` golden snapshot (`public_api_contracts`) passed unchanged.

## Downstream `TraitDecl.type_params` consumer audit

Workspace-wide grep for `TraitDecl`/`TraitTable`/`trait_table` found references only inside `sm-front` (`lib.rs`, `types.rs`, `typecheck.rs`, `parser.rs`) — zero references in `sm-ir`, `sm-sema`, `sm-emit`, `sm-verify`, `sm-vm`, or `smc-cli`. Within `sm-front`, the only reader of a stored `TraitDecl`'s fields is `validate_impl_conformance`, which reads `trait_decl.methods` only (`typecheck.rs:10640,10731`) — never `.type_params`. No generic-trait substitution is implemented anywhere; impl conformance does not use trait type parameters; lowering does not encode them; no downstream stage "ignores" them because no downstream stage ever sees a `TraitTable`. This strengthens the reject-now decision: there is no existing semantics this change could be seen as removing.

## Sibling audit

- **#1633** (non-function trait bounds parsed and silently discarded) — INTERSECTS BUT DOES NOT FIX. Any non-empty `type_params` on a trait now rejects regardless of whether a bound was attached, which makes the specific "bound silently discarded on an *admitted* trait" scenario unreachable for the trait declaration form. But #1633 also covers record/ADT/impl declaration forms (all still route bounds through the same bound-discarding `parse_type_params()` helper), which this PR does not touch. Not closing #1633.
- **#1634** (parser admits multiple type parameters beyond the one-parameter first-wave contract) — INTERSECTS BUT DOES NOT FIX. `trait Foo<T, U>` now naturally rejects (any non-empty list rejects, arity irrelevant), but #1634 covers every generic definition site; function/record/ADT generic arity is completely untouched by this PR. Not closing #1634.
- **#1668** (generic impl parameters admitted despite concrete-target contract) — ALREADY ENFORCED ON CURRENT MAIN. `validate_trait_coherence` (`typecheck.rs:10549-10562`) already rejects non-empty `ImplDecl.type_params` unconditionally; test `blanket_impl_with_type_params_is_rejected` (`typecheck.rs:7371`) passes unmodified on the baseline. Not touched by this PR; issue-status cleanup left as a separate action.
- **#1649** (`type_check_function()` strips function generic metadata) — UNAFFECTED. Concerns `Function.type_params` on the single-function public API, not `TraitDecl.type_params`; that API never builds a `TraitTable`.
- **#1648** (generic call inference doesn't recurse through compound types) — UNAFFECTED. Concerns function call-site inference/substitution, an entirely different generic mechanism from trait declaration admission.
- **#1650** (generic record/ADT declarations lack an applied nominal type path) — UNAFFECTED. Concerns `RecordDecl`/`AdtDecl` generic instantiation, not traits.

## Fallback/bypass audit

Grepped the full diff for `unwrap_or*`, `or_else`, `if let Ok/Some`, `let Ok/Some ... else`, catch-all `match _ =>`, `Default::default()`, `.unwrap()`, `.expect()`. Zero matches in production code. All `.expect(...)` matches are in test setup (`parse_program(src).expect("parse")` and table-lookup assertions), the established convention used throughout this test module. The new check is a direct `if !... { return Err(...) }` — no silent-success path exists for a non-empty `type_params`.

## Docs

`docs/spec/foundation_source_profile_v1.md`: corrected the sentence describing the (now superseded) incidental TypeVar-scope rejection, and added a paragraph stating the explicit first-wave invariant: `TraitDecl.type_params.is_empty()` is required for admission, generic trait syntax may still parse but is never erased or treated as non-generic, and rejection is independent of impl existence or parameter use. No version bump — consistent with how #1667/#1651 and #1669/#1647 extended this same section.

## Qualification

- `cargo check --workspace --all-targets` — clean
- `cargo test -p sm-front` — 517 passed, 0 failed (up from 514)
- `cargo test --test public_api_contracts` — passed, no drift
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — passed
- `cargo fmt -p sm-front --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Targeted: all `TraitTable`/trait/Self/impl-conformance/#1667/#1651/#1669/#1647 regressions rerun green
- `cargo fmt --check` (workspace-wide, no `-p`) — same pre-existing unrelated Windows path-length OS error, confirmed unchanged

## Changed files

- `crates/sm-front/src/lib.rs` (`build_trait_table` + 3 new tests + 1 updated test)
- `docs/spec/foundation_source_profile_v1.md`

## Out of scope

- No generic trait implementation, substitution, or inference.
- No parser changes.
- No changes to #1633, #1634, #1648, #1649, #1650 (classified above, not fixed).
- No changes to #1668 (already enforced; confirmed, not modified).
- No `Type` redesign.

This PR does not implement generic traits.
This PR does not close #1578.
This PR does not authorize SSF-08.

## Remaining SSF-07 work

#1633, #1634, #1648, #1649, #1650, #1668-issue-cleanup remain open, all classified above. #1578 remains open.
