### PR TITLE
fix(front): align single-function generic admission (#1649)

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -158,18 +158,18 @@ fn lift_literal_to_expected_type(
 /// Type-checks a `Program` containing exactly one function, using the same
 /// canonical `build_fn_table` FnSig-construction authority as
 /// `type_check_program` (FA-02-017 / #1649): generic `type_params` and
-/// `trait_bounds` are preserved and admitted under the identical rules the
-/// program-level path uses, never hardcoded to empty. A declaration this
-/// API rejects or admits therefore agrees with what `type_check_program`
-/// would decide for the same function embedded in a full program.
+/// `trait_bounds` are preserved under the same function-signature admission
+/// rules, never hardcoded to empty.
 ///
-/// `impl_list` is always empty here: this single-function API never builds
-/// or validates a `TraitTable`, so it has no coherence/conformance-checked
-/// impls available to satisfy a trait bound. A self-referential call inside
-/// the checked function's own body that requires bound satisfaction fails
-/// closed for that reason -- this API cannot honestly prove it, and does
-/// not pretend to. A bounded generic function's own declaration/signature
-/// is unaffected either way, since bounds are consulted only at call sites.
+/// This does not make the two public APIs semantically identical:
+/// `type_check_function` does not build or validate trait/impl coherence and
+/// intentionally checks the function with an empty validated impl context
+/// (`impl_list` is always `&[]` here). Therefore checks that require impl
+/// evidence -- such as a self-referential call inside the checked function's
+/// own body that needs trait-bound satisfaction -- may fail closed here even
+/// when a fully validated `type_check_program` context could prove them. A
+/// bounded generic function's own declaration/signature is unaffected either
+/// way, since bounds are consulted only at call sites.
 pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
     validate_executable_imports(program)?;
     if program.functions.len() != 1 {

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -155,6 +155,21 @@ fn lift_literal_to_expected_type(
     }
 }
 
+/// Type-checks a `Program` containing exactly one function, using the same
+/// canonical `build_fn_table` FnSig-construction authority as
+/// `type_check_program` (FA-02-017 / #1649): generic `type_params` and
+/// `trait_bounds` are preserved and admitted under the identical rules the
+/// program-level path uses, never hardcoded to empty. A declaration this
+/// API rejects or admits therefore agrees with what `type_check_program`
+/// would decide for the same function embedded in a full program.
+///
+/// `impl_list` is always empty here: this single-function API never builds
+/// or validates a `TraitTable`, so it has no coherence/conformance-checked
+/// impls available to satisfy a trait bound. A self-referential call inside
+/// the checked function's own body that requires bound satisfaction fails
+/// closed for that reason -- this API cannot honestly prove it, and does
+/// not pretend to. A bounded generic function's own declaration/signature
+/// is unaffected either way, since bounds are consulted only at call sites.
 pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
     validate_executable_imports(program)?;
     if program.functions.len() != 1 {
@@ -163,28 +178,32 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
             message: "type_check_function expects exactly one function in program".to_string(),
         });
     }
-    let mut table = BTreeMap::new();
+    // FA-02-017 / #1649: build the FnSig through the same canonical
+    // build_fn_table authority type_check_program uses, instead of
+    // reconstructing a second, hand-rolled FnSig here. The previous manual
+    // construction canonicalized params/ret through the non-generic
+    // canonicalize_declared_type (which unconditionally rejects TypeVar)
+    // and hardcoded type_params/trait_bounds to empty regardless of what
+    // the parsed Function actually declared -- so this API silently
+    // disagreed with the canonical program-level admission contract for
+    // every generic function, rejecting realistic generic declarations
+    // the canonical path admits (or, for the rare case a declaration did
+    // canonicalize, silently discarding metadata a self-referential call
+    // would have needed), rather than honestly preserving or explicitly
+    // rejecting generic metadata. impl_list stays empty deliberately below:
+    // this single-function API never builds or validates a TraitTable, so
+    // it has no coherence/conformance-checked impls to use for bound
+    // satisfaction -- reading program.impls unchecked here would let an
+    // unvalidated impl silently "prove" a bound the canonical path never
+    // confirmed. A generic function's own declaration/body is unaffected
+    // either way (bounds are consulted only at call sites); a
+    // self-referential call requiring bound satisfaction fails closed
+    // through the existing empty-impl_list path instead.
     let record_table = build_record_table(program)?;
     let adt_table = build_adt_table(program)?;
     let schema_table = build_schema_table(program)?;
+    let table = build_fn_table(program)?;
     let func = &program.functions[0];
-    table.insert(
-        func.name,
-        FnSig {
-            type_params: Vec::new(),
-            trait_bounds: Vec::new(),
-            params: func
-                .params
-                .iter()
-                .map(|(_, t)| {
-                    canonicalize_declared_type(t, &record_table, &adt_table, &program.arena)
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-            param_names: Some(func.params.iter().map(|(name, _)| *name).collect()),
-            param_defaults: Some(func.param_defaults.clone()),
-            ret: canonicalize_declared_type(&func.ret, &record_table, &adt_table, &program.arena)?,
-        },
-    );
     validate_top_level_name_collisions(program, &table, &record_table, &adt_table, &schema_table)?;
     validate_record_declarations(program, &record_table, &adt_table)?;
     validate_adt_declarations(program, &record_table, &adt_table)?;
@@ -3451,6 +3470,148 @@ mod tests {
         let (_, caller) = callee_and_caller(&program);
         type_check_function_with_table(caller, &program.arena, &table)
             .expect("well-formed FnSig via the public FnTable API must still typecheck");
+    }
+
+    // FA-02-017 / #1649: type_check_function() previously reconstructed its
+    // own FnSig by hand, canonicalizing params/ret through the non-generic
+    // canonicalize_declared_type (which unconditionally rejects TypeVar)
+    // and hardcoding type_params/trait_bounds to empty regardless of what
+    // the parsed Function actually declared. It now builds its FnTable
+    // through the same canonical build_fn_table() authority
+    // type_check_program() uses, so this single-function API's admission
+    // verdict for generic declarations matches the canonical program path
+    // instead of silently disagreeing with it.
+
+    fn typecheck_single_function_source(src: &str) -> Result<(), FrontendError> {
+        let program = parse_program(src)?;
+        type_check_function(&program)
+    }
+
+    #[test]
+    fn type_check_function_admits_ordinary_non_generic_function() {
+        // (A) Positive control: unrelated to #1649, must remain unchanged.
+        let src = r#"
+            fn add(a: i32, b: i32) -> i32 {
+                return a + b;
+            }
+        "#;
+        typecheck_single_function_source(src)
+            .expect("ordinary non-generic function must typecheck");
+    }
+
+    #[test]
+    fn type_check_function_admits_generic_function_matching_canonical_admission() {
+        // (B) Central regression: a generic function whose parameter uses
+        // its own type parameter directly. Pre-fix, this rejected with
+        // "type variable 'T' is not admitted in the executable type-check
+        // path yet" even though the canonical program path admits it.
+        let src = r#"
+            fn id<T>(x: T) -> T {
+                return x;
+            }
+        "#;
+        typecheck_single_function_source(src).expect(
+            "a generic function admitted by the canonical program path must not be \
+             rejected by type_check_function",
+        );
+    }
+
+    #[test]
+    fn type_check_function_preserves_generic_trait_bounds_in_canonical_fn_table() {
+        // (C) Trait bounds must not be erased to an empty Vec. This tests
+        // metadata preservation, not bound satisfaction (satisfaction is a
+        // call-site concern this single-function API never performs --
+        // see generic_fn_with_bound_and_satisfying_impl_typechecks above
+        // for that separate contract).
+        let src = r#"
+            trait Zeroable {
+                fn zero(v: ZeroInt) -> i32;
+            }
+            record ZeroInt { n: i32 }
+            fn make_zero<T: Zeroable>(v: T) -> T {
+                return v;
+            }
+        "#;
+        let program = parse_program(src).expect("parse");
+        type_check_function(&program).expect(
+            "a bounded generic declaration must not be rejected merely for carrying a bound",
+        );
+        let table = build_fn_table(&program).expect("canonical table builds");
+        let fn_id = *program
+            .arena
+            .symbol_to_id
+            .get("make_zero")
+            .expect("make_zero interned");
+        let sig = table.get(&fn_id).expect("make_zero signature present");
+        assert!(
+            !sig.type_params.is_empty(),
+            "type_params must not be erased to empty"
+        );
+        assert_eq!(
+            sig.trait_bounds.len(),
+            1,
+            "trait_bounds must not be erased to empty"
+        );
+    }
+
+    #[test]
+    fn type_check_function_admits_generic_parameter_nested_in_compound_type() {
+        // (D) Catches a fake repair that only handles a direct top-level
+        // TypeVar param but still falls back to non-generic canonicalization
+        // for a type parameter nested inside a compound type.
+        let src = r#"
+            fn first<T>(x: Option(T)) -> i32 {
+                return 0;
+            }
+        "#;
+        typecheck_single_function_source(src)
+            .expect("a type parameter nested inside Option must not be erased or rejected");
+    }
+
+    #[test]
+    fn type_check_function_admits_record_parameter_via_canonical_identity() {
+        // (E) Existing non-generic behavior: nominal Record signatures must
+        // continue to canonicalize and typecheck exactly as before.
+        let src = r#"
+            record Point { x: i32, y: i32 }
+            fn make(x: i32, y: i32) -> Point {
+                return Point { x: x, y: y };
+            }
+        "#;
+        typecheck_single_function_source(src).expect("record-typed function must typecheck");
+    }
+
+    #[test]
+    fn type_check_function_agrees_with_canonical_program_path_for_generic_admission() {
+        // (F) Public API consistency regression: directly compares the
+        // single-function API's admission verdict against
+        // type_check_program's verdict for the identical generic
+        // declaration. Fails if type_check_function ever again hand-builds
+        // an FnSig with type_params/trait_bounds hardcoded to empty, since
+        // that reintroduces exactly the divergence this test detects.
+        let single_src = r#"
+            fn id<T>(x: T) -> T {
+                return x;
+            }
+        "#;
+        let program_src = r#"
+            fn id<T>(x: T) -> T {
+                return x;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let single = parse_program(single_src).expect("parse single-function program");
+        let full = parse_program(program_src).expect("parse full program");
+        let single_result = type_check_function(&single);
+        let full_result = type_check_program(&full);
+        assert_eq!(
+            single_result.is_ok(),
+            full_result.is_ok(),
+            "type_check_function must agree with type_check_program's admission verdict \
+             for the same generic declaration; single={single_result:?} full={full_result:?}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
SSF-07: #1578

Fixes #1649

## Baseline SHA

`4efc6ec6c198cb9e4acbdaba8d7585077def4efb` (matched the assignment's expected baseline exactly; confirmed via fresh `origin/main` fetch).

## Exact pre-fix reproduction

`type_check_function()` (`crates/sm-front/src/typecheck.rs`) hand-built its own `FnSig` for the single function it checks, canonicalizing `params`/`ret` through `canonicalize_declared_type` (the **non-generic** canonicalizer, which unconditionally rejects `Type::TypeVar` with `"policy violation: type variable '{}' is not admitted in the executable type-check path yet; generic monomorphisation is deferred to M9.1 Wave 2"`) and hardcoding `type_params: Vec::new(), trait_bounds: Vec::new()` regardless of what the parsed `Function` actually declared.

Reproduced with the smallest valid generic function:

```
fn id<T>(x: T) -> T {
    return x;
}
```

Pre-fix, `type_check_function()` returned `Err`, while `type_check_program()` on the same declaration embedded in a full program returned `Ok`. This is **inconsistent rejection**, not silent success as non-generic — the manual FnSig construction fails at signature-canonicalization time (before body-checking is ever reached) for essentially any generic function whose parameter/return type references its own type parameter, directly or nested (`canonicalize_declared_type` recurses into `Tuple`/`Sequence`/`Map`/`Measured`/`Option`/`Result` and hits the same unconditional `TypeVar` rejection in every position).

Bounded-generic reproduction (`fn make_zero<T: Zeroable>(v: T) -> T { return v; }`) hits the identical rejection at the same canonicalization step — the divergence is dominated by the `TypeVar` rejection, not specifically by the erased `trait_bounds` (see "Trait-bound handling" below for the one case where the erased `trait_bounds` field would matter on its own).

## `type_check_function` contract

Checks exactly one `Function` (`program.functions.len() == 1`), performing declaration validation (name collisions, record/ADT/schema declarations) and the same signature/body checking `type_check_program` performs per-function — but with no `main()` requirement and no trait/impl coherence machinery.

## `type_check_program` contract

Whole-program: builds `FnTable`/`RecordTable`/`AdtTable`/`SchemaTable`/`TraitTable`, runs trait coherence and impl conformance, requires `fn main()`, then checks every function and impl method through the identical per-function checking core (`type_check_function_with_tables`).

`type_check_function() == type_check_program() minus main` does **not** hold pre-fix: the two paths used genuinely different `FnSig`-construction logic. Post-fix, FnSig construction and generic-metadata admission are identical (`build_fn_table`). Whole-program *semantic* admission is intentionally **not** identical: `type_check_function` has no validated trait/impl context (`impl_list = &[]`), so a check that requires impl evidence can fail closed here even where a fully validated `type_check_program` context could prove it — see "Impl-context decision" below.

## Chosen contract: Model A

Generic-aware single-function checker. `type_check_function()` now preserves and admits `type_params`/`trait_bounds` under the exact same rules the canonical program path uses.

## Why this contract is correct

`build_fn_table()` (audited per the task's Section 4 checklist):
1. Works correctly on a one-function `Program` without `main` — it only iterates `program.functions`, no `main` dependency.
2. Introduces no unrelated whole-program requirements — no trait/impl/schema table dependency.
3. Validates metadata `type_check_function()` was **not** previously validating: the reserved-application-boundary-name check (`APPLICATION_BUILTIN_NAMES`) that `build_fn_table` already performs was silently skipped by the old manual construction. This PR closes that incidental gap as a direct consequence of adopting one canonical authority — flagged explicitly here since it is a small, real behavior change beyond the generic-metadata fix itself, not scope creep (there were zero existing callers/tests depending on the old permissive behavior; see "Public call-site audit").
4. Requires no trait/impl state unavailable to the single-function checker.
5. Reuse removes a duplicated semantic authority — exactly the "one `Function` → `FnSig` authority" architecture this slice's task description asks for.

Model B (explicit rejection) was rejected because nothing about the single-function contract makes generic *declaration* admission dishonest to provide — declaration-time canonicalization needs only `record_table`/`adt_table`/`func.type_params`, all of which this API already has. Only bound *satisfaction* (a call-site concern) genuinely needs impl context this API doesn't build; that narrower case is handled below without inventing a new rejection mode.

## Canonical FnSig authority

`build_fn_table(program)` — the same function `type_check_program` calls. `type_check_function()` no longer constructs a second `FnSig`.

## Generic metadata handling

`type_params` is preserved verbatim from `build_fn_table`'s output (`f.type_params.clone()`), never hardcoded empty.

## Trait-bound handling

`trait_bounds` is preserved verbatim from `build_fn_table`'s output, never hardcoded empty. Metadata preservation is **not** the same as bound satisfaction: bounds are consulted only at call sites (`typecheck.rs` generic call-site substitution, ~line 2917), never at declaration-admission time. A bounded generic function's own declaration/body is therefore unaffected by whether `trait_bounds` is correct or erased, *unless* the function calls itself recursively and that call needs bound satisfaction — see "Impl-context decision."

## Impl-context decision

`impl_list` stays `&[]`, unchanged from before. This single-function API never builds or validates a `TraitTable` (no `build_trait_table`, no `validate_trait_coherence`, no `validate_impl_conformance`). Reading `program.impls` unchecked here would let an **unvalidated** impl silently "prove" a bound the canonical path never confirmed — worse than the status quo, and well outside this slice's narrow scope (adopting the full trait/impl validation stack into a "single function" API contradicts its own contract). Consequence: a self-referential call inside the checked function's own body that requires bound satisfaction fails closed (`impl_list.iter().any(...)` over an empty list is always `false`) — an honest "cannot prove under this API's contract" outcome using the pre-existing call-site machinery, not a new bypass.

## Generic-body-checking decision

Unchanged, and this PR does not touch it. `type_check_function_with_tables`'s body-checking loop (`for stmt in &func.body { check_stmt(...) }`) runs unconditionally for every function regardless of `is_generic`; the `is_generic` flag only gates whether a top-level `TypeVar` parameter/return type skips the *executable-type* check (substitution happens per call-site). `is_generic` was always computed from `func.type_params` (the real, parsed AST field), never from the table — so this control flow was never affected by the erased-metadata bug in the first place. The comment "body type-check deferred until Wave 3 monomorphisation" refers to IR-level monomorphisation (see #1717, unaffected by this PR), not frontend structural body-checking, which already runs for generic function bodies both pre- and post-fix.

## Non-generic behavior

Unchanged. Positive-control regression added.

## Nested generic-type behavior

`fn first<T>(x: Option(T)) -> i32` now admits (pre-fix: rejected identically to the direct-`TypeVar` case, since `canonicalize_declared_type` recurses into `Option` and hits the same unconditional rejection).

## `type_check_function_with_table` classification

**UNAFFECTED.** Takes a caller-supplied `FnTable` and never builds its own — its only production caller (`sm-ir::legacy_lowering::lower_function_to_ir`) builds that table via `build_fn_table` in both real call sites (`tests/arena_stage_guards.rs:153`, `tests/frontend_boundaries.rs:9`), so it was never exposed to #1649's manual-FnSig defect. A caller *could* theoretically pass a hand-built, mismatched `FnSig`, which the function trusts as-is (documented as the caller's contract responsibility, not validated here) — a caller-contract question, not a #1649-owned defect. Not modified by this PR.

## Public call-site audit

Workspace-wide grep for `type_check_function(` and `type_check_function_with_table(`:
- `type_check_function(` — **zero** callers anywhere in the workspace outside its own definition. No production or test caller depended on the old broken behavior.
- `type_check_function_with_table(` — one production caller (`sm-ir::legacy_lowering::lower_function_to_ir`), both real invocations build the table via `build_fn_table` already (see above); five existing tests in `typecheck.rs` (`malformed_fn_sig_*`, `canonical_fn_sig_continues_to_typecheck_via_public_table_api`), all reran green, unaffected.

## Pre-fix → post-fix evidence

Temporarily reverted `type_check_function()` to the exact old hand-built-`FnSig` form (final regression tests kept unchanged, marked `TEMP-DISABLED-FOR-PREFIX-PROOF`):

- `type_check_function_admits_generic_function_matching_canonical_admission` — panicked: `Err(FrontendError { message: "policy violation: type variable 'T' is not admitted in the executable type-check path yet; generic monomorphisation is deferred to M9.1 Wave 2" })`
- `type_check_function_preserves_generic_trait_bounds_in_canonical_fn_table` — panicked, same message.
- `type_check_function_admits_generic_parameter_nested_in_compound_type` — panicked, same message (nested `Option(T)` position).
- `type_check_function_agrees_with_canonical_program_path_for_generic_admission` — assertion failed directly showing the divergence: `single=Err(...) full=Ok(())`.
- `type_check_function_admits_ordinary_non_generic_function` and `type_check_function_admits_record_parameter_via_canonical_identity` (positive controls) — passed unchanged, confirming they are true controls.

Restored verbatim afterward; diff confirmed byte-identical to the intended fix before re-running. All 6 tests pass post-fix; full `sm-front` suite: 523 passed (517 baseline + 6 new).

## Tests

- `type_check_function_admits_ordinary_non_generic_function` (A)
- `type_check_function_admits_generic_function_matching_canonical_admission` (B, central regression)
- `type_check_function_preserves_generic_trait_bounds_in_canonical_fn_table` (C, directly inspects the stored `FnSig`)
- `type_check_function_admits_generic_parameter_nested_in_compound_type` (D)
- `type_check_function_admits_record_parameter_via_canonical_identity` (E)
- `type_check_function_agrees_with_canonical_program_path_for_generic_admission` (F, public API consistency — fails if a hand-rolled empty-metadata `FnSig` is ever reintroduced)

## Sibling audit

- **#1648** (generic call inference doesn't recurse through compound types) — UNAFFECTED. Call-site inference logic is untouched; the same pre-existing limitation, if triggered, now behaves identically under both public APIs (the correct equivalence property), not newly introduced or fixed here.
- **#1650** (generic record/ADT applied nominal representation) — UNAFFECTED, not touched.
- **#1634** (parser admits multiple type parameters beyond the one-parameter first-wave contract) — INTERSECTS BUT DOES NOT FIX. Empirically confirmed pre-existing on the canonical path: `fn pair<T, U>(x: T, y: U) -> T { return x; }` already admits via `type_check_program` on current `main`. Since `type_check_function()` now shares the same `build_fn_table` authority, it inherits this same pre-existing, separately-tracked gap rather than being newly exposed to or fixing it.
- **#1633** (non-function trait bounds parsed and silently discarded) — UNAFFECTED. Function bounds were never part of the bound-discarding `parse_type_params()` path #1633 describes (functions use `parse_type_params_with_bounds` directly and always retained bounds); #1649 was purely about `type_check_function()` erasing already-correctly-parsed bounds afterward, not a parser defect.
- **#1635** (generic traits admitted beyond first-wave contract) — already fixed, merged PR #1863. Re-ran `build_trait_table_rejects_generic_trait_*`/`build_trait_table_admits_non_generic_first_wave_trait` as regression evidence: green, unmodified.
- **#1668** (generic impl parameters) — already closed as completed/already-enforced. Re-ran `blanket_impl_with_type_params_is_rejected`: green, unmodified. Not touched.
- **#1717** (completed generics track claims IR monomorphisation but sm-ir has none) — **critical, explicitly addressed.** This PR does not implement monomorphisation and does not touch `sm-ir`/lowering/VM at all (diff confined to `typecheck.rs`). Generic function bodies were already structurally type-checked by the frontend before this PR (the "deferred to Wave 3 monomorphisation" comment governs the executable-type check on a bare top-level `TypeVar`, not whether the body loop runs at all — it always ran). This PR only makes `type_check_function()`'s *admission* verdict agree with `type_check_program()`'s; it does **not** make generic functions any more executable end-to-end than they already were. #1717's gap is unchanged and remains open.

## Fallback/bypass audit

Grepped the full diff for `unwrap_or*`, `or_else`, `if let Ok/Some`, `let Ok/Some ... else`, catch-all `match _ =>`, `Default::default()`, `.unwrap()`, `.expect()`. Zero matches in production code (the new `type_check_function` body is `?`-propagation only, calling `build_fn_table` exactly once). All `.expect(...)` matches are in test setup, the established repo convention.

## Docs

Added a doc comment on `type_check_function` in `typecheck.rs` documenting the Model A contract, the canonical-authority rationale, and the deliberate empty-`impl_list` decision. `docs/spec/foundation_source_profile_v1.md` was not touched: it documents the *source-language* admission contract, which is unchanged by this PR (generic functions were always part of the "still-experimental broad generics" surface via `type_check_program`; #1649 was purely an internal Rust-API-level inconsistency between two entry points into the same frontend, not a change to what source the language admits).

**Corrective commit `207d7eb7`** (doc-comment-only, zero production logic changed): the original doc comment overclaimed general verdict equivalence — "a declaration this API rejects or admits therefore agrees with what `type_check_program` would decide" — when the very next paragraph already documented a counterexample (empty `impl_list` can make a bound-satisfaction check fail closed here where a validated program context could prove it). Narrowed to the claim actually proven: identical FnSig construction / generic-metadata admission, not identical whole-program semantic admission. Caught in review before merge.

## Qualification

- `cargo check --workspace --all-targets` — clean
- `cargo test -p sm-front` — 523 passed, 0 failed (up from 517)
- `cargo test --test public_api_contracts` — 88 passed, no drift (signature of `type_check_function` unchanged)
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed
- `cargo fmt -p sm-front --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Targeted: `malformed_fn_sig_*`/`build_trait_table_*`/`generic_fn_with_bound_*`/`blanket_impl_with_type_params_is_rejected`/`impl_self_*` (#1665/#1722, #1635/#1669, #1667/#1651, #1668, #1647) — 24 passed, all rerun green
- Workspace-wide `cargo fmt --check` — same pre-existing unrelated Windows path-length OS error, confirmed unchanged

## Changed files

- `crates/sm-front/src/typecheck.rs` (`type_check_function` body + doc comment; 6 new tests)

## Out of scope

This PR does not implement recursive generic inference (#1648).
This PR does not implement applied generic nominal types (#1650).
This PR does not implement IR monomorphisation (#1717).
This PR does not close #1578.
This PR does not authorize SSF-08.

## Remaining SSF-07 work

#1648, #1650, #1634, #1717 remain open, all classified above. #1578 remains open.

