### PR TITLE
security(actions): declare least-privilege token permissions for CI workflows (#1865)

### DIFF
--- a/.github/workflows/7hell-full.yml
+++ b/.github/workflows/7hell-full.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   # Opt into the upcoming GitHub Actions Node 24 runtime now so CI is
   # validated before the platform-wide default switch.

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,58 +1,104 @@
 task:
-  id: SECURITY-MAINT-1865-ACTIONS-PERMISSIONS
-  title: "security(actions): declare least-privilege token permissions for CI workflows"
-  type: controlled_security_maintenance
+  id: SEMANTIC-STABLE-FOUNDATION-SSF-07
+  title: "language: close or bound numeric/text/collection/closure/generic/trait/pattern abstractions"
+  type: type_and_abstraction_closure_contract_qualification_and_bounded_implementation
   mode: active
+  supersedes: SEMANTIC-STABLE-FOUNDATION-SSF-06
   authorized_by: >-
-    Repository-owner checkpoint approval (chat, 2026-08-31) authorizing the
-    controlled out-of-band Issue #1865 security-maintenance transition.
+    Repository owner direct instruction (chat, 2026-08-08) to execute GitHub
+    umbrella #1569 continuously in strict SSF-00 through SSF-12 dependency
+    order. SSF-06 closed through PR #1597 at merge commit
+    92be6c0412140a3547cdd9627e0f9a8971965855, after an eleven-pass repair cycle
+    documented in issue #1598 (Decision Log DL-009 through DL-023); only
+    SSF-07 is now active.
 
 intent:
   summary: >-
-    Declare only the proven least-privilege GITHUB_TOKEN permissions in the
-    ordinary CI and 7hell qualification workflows, then restore the normal
-    SSF-07 development envelope byte-for-byte before PR submission.
+    Read SSF-00...06 outputs and build a gap table only for abstractions
+    already selected by the frozen Stable Foundation target; separate
+    contract gaps from implementation bugs. Freeze numeric overflow/
+    conversion policy, UTF-8 text semantics, collection equality/ordering/
+    mutability, first-wave closure capture semantics, generic/trait
+    monomorphisation and coherence, and pattern alignment across the
+    parser/typechecker/exhaustiveness/lowering/ownership/diagnostics
+    pipeline, each before implementing it. Add positive end-to-end tests and
+    deterministic negative cases for every included abstraction; give every
+    deferred form an explicit non-goal and a deterministic rejection
+    diagnostic instead of leaving it silently unsupported.
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .github/workflows/ci.yml
-    - .github/workflows/7hell-full.yml
+    - README.md
+    - CHANGELOG.md
+    - docs/LANGUAGE.md
+    - docs/examples_index.md
+    - docs/getting_started.md
+    - docs/spec/**
+    - docs/status/feature_maturity_matrix.md
+    - docs/roadmap/public_maturity_snapshot.md
+    - docs/roadmap/public_status_model.md
+    - docs/roadmap/v1_readiness.md
+    - docs/roadmap/stable_foundation/**
+    - examples/canonical/**
+    - examples/qualification/**
+    - tests/**
+    - crates/sm-format/**
+    - crates/sm-front/**
+    - crates/sm-sema/**
+    - crates/sm-ir/**
+    - crates/sm-emit/**
+    - crates/sm-verify/**
+    - crates/sm-vm/**
+    - crates/smc-cli/**
 
   forbidden_paths:
-    - AGENTS.md
-    - CONSTRAINTS.md
-    - .agents/**
-    - Cargo.toml
-    - Cargo.lock
-    - crates/**
-    - docs/**
-    - tests/**
-    - tools/**
+    - .github/**
+    - apps/**
+    - experiments/**
+    - src/**
+    - third_party/**
+    - ton618_legacy/**
 
 authorization:
-  rust_implementation: false
-  language_implementation: false
-  documentation_addition: false
-  documentation_correction: false
-  test_addition: false
-  workflow_changes: true
+  rust_implementation: true
+  language_implementation: true
+  documentation_addition: true
+  documentation_correction: true
+  test_addition: true
+  workflow_changes: false
   dependency_changes: false
   github_issue_lifecycle: true
   git_commit_push_pr: true
-  merge_after_review_and_checks: false
+  merge_after_review_and_checks: true
   stable_promotion: false
 
 constraints:
-  issue: 1865
+  one_active_ssf_phase: true
+  active_phase: SSF-07
+  issue: 1578
+  umbrella_issue: 1569
   base_branch: main
   one_logical_change_per_pr: true
   evidence_before_claims: true
-  out_of_band_security_maintenance: true
-  does_not_supersede_ssf_07: true
-  final_harness_diff_against_merge_base_must_be_zero: true
-  final_repository_diff_limited_to_ci_and_7hell_workflows: true
-  no_write_all: true
-  no_pat_or_new_secret: true
-  no_ci_gate_or_failure_semantics_weakening: true
-  no_fallback_or_bypass: true
+  current_main_is_not_stable: true
+  gap_table_scoped_to_already_selected_abstractions_only: true
+  contract_gaps_separated_from_implementation_bugs: true
+  no_new_abstraction_added_merely_because_convenient: true
+  numeric_overflow_and_conversion_policy_frozen_before_implementation: true
+  text_utf8_semantics_frozen_before_implementation: true
+  collections_equality_ordering_mutability_iteration_frozen_before_implementation: true
+  closures_first_wave_capture_and_invocation_semantics_frozen_before_implementation: true
+  generics_traits_deterministic_monomorphisation_and_coherence_required: true
+  patterns_aligned_across_parser_typechecker_exhaustiveness_lowering_ownership_diagnostics: true
+  positive_and_deterministic_negative_tests_required_per_included_abstraction: true
+  deferred_forms_have_explicit_non_goals_and_deterministic_rejection: true
+  no_global_refactor_unless_invariant_cannot_be_preserved_otherwise: true
+  no_stable_abstraction_depends_on_unstable_internal_crate_apis: true
+  no_async_await: true
+  no_broad_dynamic_dispatch_or_reflection: true
+  no_macro_system: true
+  no_gc_object_runtime: true
+  no_systems_language_claims_beyond_evidence: true
+  no_stable_release_claim: true
+  no_historical_document_rewrite: true

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,104 +1,58 @@
 task:
-  id: SEMANTIC-STABLE-FOUNDATION-SSF-07
-  title: "language: close or bound numeric/text/collection/closure/generic/trait/pattern abstractions"
-  type: type_and_abstraction_closure_contract_qualification_and_bounded_implementation
+  id: SECURITY-MAINT-1865-ACTIONS-PERMISSIONS
+  title: "security(actions): declare least-privilege token permissions for CI workflows"
+  type: controlled_security_maintenance
   mode: active
-  supersedes: SEMANTIC-STABLE-FOUNDATION-SSF-06
   authorized_by: >-
-    Repository owner direct instruction (chat, 2026-08-08) to execute GitHub
-    umbrella #1569 continuously in strict SSF-00 through SSF-12 dependency
-    order. SSF-06 closed through PR #1597 at merge commit
-    92be6c0412140a3547cdd9627e0f9a8971965855, after an eleven-pass repair cycle
-    documented in issue #1598 (Decision Log DL-009 through DL-023); only
-    SSF-07 is now active.
+    Repository-owner checkpoint approval (chat, 2026-08-31) authorizing the
+    controlled out-of-band Issue #1865 security-maintenance transition.
 
 intent:
   summary: >-
-    Read SSF-00...06 outputs and build a gap table only for abstractions
-    already selected by the frozen Stable Foundation target; separate
-    contract gaps from implementation bugs. Freeze numeric overflow/
-    conversion policy, UTF-8 text semantics, collection equality/ordering/
-    mutability, first-wave closure capture semantics, generic/trait
-    monomorphisation and coherence, and pattern alignment across the
-    parser/typechecker/exhaustiveness/lowering/ownership/diagnostics
-    pipeline, each before implementing it. Add positive end-to-end tests and
-    deterministic negative cases for every included abstraction; give every
-    deferred form an explicit non-goal and a deterministic rejection
-    diagnostic instead of leaving it silently unsupported.
+    Declare only the proven least-privilege GITHUB_TOKEN permissions in the
+    ordinary CI and 7hell qualification workflows, then restore the normal
+    SSF-07 development envelope byte-for-byte before PR submission.
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - README.md
-    - CHANGELOG.md
-    - docs/LANGUAGE.md
-    - docs/examples_index.md
-    - docs/getting_started.md
-    - docs/spec/**
-    - docs/status/feature_maturity_matrix.md
-    - docs/roadmap/public_maturity_snapshot.md
-    - docs/roadmap/public_status_model.md
-    - docs/roadmap/v1_readiness.md
-    - docs/roadmap/stable_foundation/**
-    - examples/canonical/**
-    - examples/qualification/**
-    - tests/**
-    - crates/sm-format/**
-    - crates/sm-front/**
-    - crates/sm-sema/**
-    - crates/sm-ir/**
-    - crates/sm-emit/**
-    - crates/sm-verify/**
-    - crates/sm-vm/**
-    - crates/smc-cli/**
+    - .github/workflows/ci.yml
+    - .github/workflows/7hell-full.yml
 
   forbidden_paths:
-    - .github/**
-    - apps/**
-    - experiments/**
-    - src/**
-    - third_party/**
-    - ton618_legacy/**
+    - AGENTS.md
+    - CONSTRAINTS.md
+    - .agents/**
+    - Cargo.toml
+    - Cargo.lock
+    - crates/**
+    - docs/**
+    - tests/**
+    - tools/**
 
 authorization:
-  rust_implementation: true
-  language_implementation: true
-  documentation_addition: true
-  documentation_correction: true
-  test_addition: true
-  workflow_changes: false
+  rust_implementation: false
+  language_implementation: false
+  documentation_addition: false
+  documentation_correction: false
+  test_addition: false
+  workflow_changes: true
   dependency_changes: false
   github_issue_lifecycle: true
   git_commit_push_pr: true
-  merge_after_review_and_checks: true
+  merge_after_review_and_checks: false
   stable_promotion: false
 
 constraints:
-  one_active_ssf_phase: true
-  active_phase: SSF-07
-  issue: 1578
-  umbrella_issue: 1569
+  issue: 1865
   base_branch: main
   one_logical_change_per_pr: true
   evidence_before_claims: true
-  current_main_is_not_stable: true
-  gap_table_scoped_to_already_selected_abstractions_only: true
-  contract_gaps_separated_from_implementation_bugs: true
-  no_new_abstraction_added_merely_because_convenient: true
-  numeric_overflow_and_conversion_policy_frozen_before_implementation: true
-  text_utf8_semantics_frozen_before_implementation: true
-  collections_equality_ordering_mutability_iteration_frozen_before_implementation: true
-  closures_first_wave_capture_and_invocation_semantics_frozen_before_implementation: true
-  generics_traits_deterministic_monomorphisation_and_coherence_required: true
-  patterns_aligned_across_parser_typechecker_exhaustiveness_lowering_ownership_diagnostics: true
-  positive_and_deterministic_negative_tests_required_per_included_abstraction: true
-  deferred_forms_have_explicit_non_goals_and_deterministic_rejection: true
-  no_global_refactor_unless_invariant_cannot_be_preserved_otherwise: true
-  no_stable_abstraction_depends_on_unstable_internal_crate_apis: true
-  no_async_await: true
-  no_broad_dynamic_dispatch_or_reflection: true
-  no_macro_system: true
-  no_gc_object_runtime: true
-  no_systems_language_claims_beyond_evidence: true
-  no_stable_release_claim: true
-  no_historical_document_rewrite: true
+  out_of_band_security_maintenance: true
+  does_not_supersede_ssf_07: true
+  final_harness_diff_against_merge_base_must_be_zero: true
+  final_repository_diff_limited_to_ci_and_7hell_workflows: true
+  no_write_all: true
+  no_pat_or_new_secret: true
+  no_ci_gate_or_failure_semantics_weakening: true
+  no_fallback_or_bypass: true


### PR DESCRIPTION
Closes #1865

## Summary
- Adds workflow-level `permissions: contents: read` to ordinary CI and the dedicated 7hell full qualification workflow.
- No jobs, steps, gates, tests, shell failure behavior, credentials, dependencies, or other workflows changed.

## Permission audit
Both target workflows only check out the repository and run local Rust/PowerShell qualification. Their invoked scripts contain no `GITHUB_TOKEN`, `github.token`, `gh`, GitHub API, release, SARIF upload, artifact upload/download, PAT, secret, or GitHub write operation. `contents: read` is therefore the sole permission granted. Intentionally privileged workflows remain unchanged: Clippy SARIF needs `security-events: write`; the release workflow needs `contents: write`.

## Controlled Harness transition
Owner authorization: https://github.com/skulmakov-oss/Semantic/issues/1865#issuecomment-5474637913
- Temporary authorized Harness: `d0389fa0`
- Workflow implementation: `c568067a`
- Exact SSF-07 restoration: `dcd98907`
- `pwsh -File scripts/harness-check.ps1` passed while the temporary Harness was active.
- Final Harness diff against `origin/main` is zero.

## Validation
- Python YAML parse: passed.
- `pwsh -File scripts/admission_guard.ps1 -PRReady`: passed.
- Final diff check: passed; only the two target workflow files remain.
- `actionlint` is not installed locally.

## Security assurances
No `write-all`, write permission, PAT, new secret, fallback credential path, CI bypass, test weakening, or unrelated workflow change was added. Existing CodeQL alerts #1-#9 were not dismissed and are expected to resolve only after merge and fresh analysis.