### PR TITLE
fix(front): enforce first-wave generic arity (#1634)

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -496,6 +496,27 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
                 message: format!("duplicate function '{name}'"),
             });
         }
+        // FA-02-002 / #1634: the first-wave generic contract admits at most
+        // one type parameter per definition site. The parser deliberately
+        // has no arity limit -- `parse_type_params_with_bounds` may
+        // represent `<T, U, ...>` as raw AST (see
+        // generic_function_two_type_params_are_parsed /
+        // function_with_multiple_type_params_mixed_bounds_is_parsed in
+        // parser.rs, which pin that parsing fidelity) -- so admission is
+        // enforced here, at the same table-construction boundary that
+        // already owns the reserved-name and duplicate-name checks above,
+        // rather than truncating to the first parameter or silently
+        // admitting the extras.
+        if f.type_params.len() > 1 {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "function '{name}' declares {} type parameters; first-wave generic \
+                     definitions admit at most one",
+                    f.type_params.len()
+                ),
+            });
+        }
         out.insert(
             f.name,
             FnSig {
@@ -542,6 +563,21 @@ pub fn build_record_table(program: &Program) -> Result<RecordTable, FrontendErro
                 ),
             });
         }
+        // FA-02-002 / #1634: first-wave generic definitions admit at most
+        // one type parameter (see build_fn_table above for the identical
+        // rule and its rationale). The parser has no arity limit, so
+        // admission is enforced here at table-construction time.
+        if record.type_params.len() > 1 {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "record '{}' declares {} type parameters; first-wave generic \
+                     definitions admit at most one",
+                    resolve_symbol_name(&program.arena, record.name)?,
+                    record.type_params.len()
+                ),
+            });
+        }
         out.insert(record.name, record.clone());
     }
     Ok(out)
@@ -557,6 +593,21 @@ pub fn build_adt_table(program: &Program) -> Result<AdtTable, FrontendError> {
                 message: format!(
                     "duplicate enum '{}'",
                     resolve_symbol_name(&program.arena, adt.name)?
+                ),
+            });
+        }
+        // FA-02-002 / #1634: first-wave generic definitions admit at most
+        // one type parameter (see build_fn_table above for the identical
+        // rule and its rationale). The parser has no arity limit, so
+        // admission is enforced here at table-construction time.
+        if adt.type_params.len() > 1 {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "enum '{}' declares {} type parameters; first-wave generic \
+                     definitions admit at most one",
+                    resolve_symbol_name(&program.arena, adt.name)?,
+                    adt.type_params.len()
                 ),
             });
         }
@@ -1450,6 +1501,241 @@ fn main() {
             .expect_err("user function named stdout_write must be rejected");
         assert!(
             err.message.contains("stdout_write") && err.message.contains("reserved"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    // FA-02-002 / #1634: first-wave generic-capable definitions admit at
+    // most one type parameter. The parser deliberately keeps no arity limit
+    // (see generic_function_two_type_params_are_parsed and
+    // function_with_multiple_type_params_mixed_bounds_is_parsed in
+    // parser.rs, both of which must remain green -- raw AST fidelity is
+    // unaffected), so the boundary lives at the same table-construction
+    // authority already used for the reserved/duplicate-name checks above.
+
+    #[test]
+    fn build_fn_table_admits_single_type_param_function() {
+        // Positive control: unaffected by this slice's change.
+        let program = parse_program(
+            r#"
+                fn id<T>(x: T) -> T {
+                    return x;
+                }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        build_fn_table(&program).expect("single type parameter must remain admitted");
+    }
+
+    #[test]
+    fn build_fn_table_preserves_bound_on_single_type_param_function() {
+        let program = parse_program(
+            r#"
+                trait Zeroable {
+                    fn zero(v: ZeroInt) -> i32;
+                }
+                record ZeroInt { n: i32 }
+                fn make_zero<T: Zeroable>(v: T) -> T {
+                    return v;
+                }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let table = build_fn_table(&program).expect("bounded single-param function must admit");
+        let fn_id = *program
+            .arena
+            .symbol_to_id
+            .get("make_zero")
+            .expect("make_zero interned");
+        let sig = table.get(&fn_id).expect("signature present");
+        assert_eq!(sig.type_params.len(), 1);
+        assert_eq!(sig.trait_bounds.len(), 1);
+    }
+
+    #[test]
+    fn build_fn_table_rejects_function_with_two_type_params() {
+        // Central regression, per #1634's own reproducer.
+        let program = parse_program(
+            r#"
+                fn pair<T, U>(x: T, y: U) -> T {
+                    return x;
+                }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let err = build_fn_table(&program)
+            .expect_err("a function declaring two type parameters must reject");
+        assert!(
+            err.message.contains("pair")
+                && err.message.contains("2 type parameters")
+                && err.message.contains("at most one"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_fn_table_rejects_bound_on_first_of_two_type_params() {
+        // Mirrors function_with_multiple_type_params_mixed_bounds_is_parsed
+        // in parser.rs (`<T: Eq, U>`) -- the parser still represents this
+        // faithfully; canonical admission must still reject it, and must
+        // not partially preserve the bounded parameter while discarding U.
+        let program = parse_program(
+            r#"
+                trait Eq2 {
+                    fn eq2(v: Self) -> i32;
+                }
+                fn apply<T: Eq2, U>(x: T, y: U) -> i32 {
+                    return 0;
+                }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let err = build_fn_table(&program).expect_err(
+            "a function declaring two type parameters must reject even when only one is bounded",
+        );
+        assert!(
+            err.message.contains("apply") && err.message.contains("at most one"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_fn_table_rejects_bound_on_second_of_two_type_params() {
+        // `<T, U: Bound>` -- the opposite ordering.
+        let program = parse_program(
+            r#"
+                trait Eq2 {
+                    fn eq2(v: Self) -> i32;
+                }
+                fn apply<T, U: Eq2>(x: T, y: U) -> i32 {
+                    return 0;
+                }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let err = build_fn_table(&program)
+            .expect_err("a function declaring two type parameters must reject regardless of which one is bounded");
+        assert!(
+            err.message.contains("apply") && err.message.contains("at most one"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_fn_table_rejects_duplicate_type_param_name_via_arity() {
+        // (Duplicate-name classification, #1634 section 14): `<T, T>` is
+        // arity 2 regardless of the repeated name, so it is rejected by
+        // this same check. This is incidental arity coverage, not a
+        // dedicated duplicate-name repair -- no separate uniqueness check
+        // is added here.
+        let program = parse_program(
+            r#"
+                fn f<T, T>(x: T) -> T {
+                    return x;
+                }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let err = build_fn_table(&program).expect_err("<T, T> must reject as a two-parameter list");
+        assert!(
+            err.message.contains("at most one"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_record_table_admits_single_type_param() {
+        let program = parse_program(
+            r#"
+                record Box<T> { value: T }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        build_record_table(&program).expect("single type parameter record must remain admitted");
+    }
+
+    #[test]
+    fn build_record_table_rejects_two_type_params() {
+        let program = parse_program(
+            r#"
+                record Pair<T, U> { a: T, b: U }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let err = build_record_table(&program)
+            .expect_err("a record declaring two type parameters must reject");
+        assert!(
+            err.message.contains("Pair")
+                && err.message.contains("2 type parameters")
+                && err.message.contains("at most one"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_adt_table_admits_single_type_param() {
+        let program = parse_program(
+            r#"
+                enum Maybe<T> { Some(T), None }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        build_adt_table(&program).expect("single type parameter enum must remain admitted");
+    }
+
+    #[test]
+    fn build_adt_table_rejects_two_type_params() {
+        let program = parse_program(
+            r#"
+                enum Either<T, U> { Left(T), Right(U) }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let err = build_adt_table(&program)
+            .expect_err("an enum declaring two type parameters must reject");
+        assert!(
+            err.message.contains("Either")
+                && err.message.contains("2 type parameters")
+                && err.message.contains("at most one"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_trait_table_rejects_trait_with_two_type_params() {
+        // #1634 classification evidence: already rejected by #1635's
+        // stricter zero-arity trait contract, independent of this slice's
+        // new max-one check -- not a #1634 repair target for traits.
+        let program = parse_program(
+            r#"
+                trait Foo<X, Y> {
+                    fn a(v: Self) -> i32;
+                }
+                fn main() { return; }
+            "#,
+        )
+        .expect("parse");
+        let err = build_trait_table(&program)
+            .expect_err("a two-parameter generic trait must still reject via #1635's contract");
+        assert!(
+            err.message.contains("Foo") && err.message.contains("generic traits are not supported"),
             "unexpected error: {}",
             err.message
         );

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -3615,6 +3615,37 @@ mod tests {
     }
 
     #[test]
+    fn type_check_function_and_type_check_program_agree_on_multi_param_generic_rejection() {
+        // FA-02-002 / #1634, extending the #1649 consistency guard above to
+        // the out-of-contract-arity case specifically: since #1649,
+        // type_check_function shares build_fn_table with type_check_program,
+        // so both must reject a two-parameter generic function identically
+        // rather than diverging again.
+        let single_src = r#"
+            fn pair<T, U>(x: T, y: U) -> T {
+                return x;
+            }
+        "#;
+        let program_src = r#"
+            fn pair<T, U>(x: T, y: U) -> T {
+                return x;
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let single = parse_program(single_src).expect("parse single-function program");
+        let full = parse_program(program_src).expect("parse full program");
+        let single_result = type_check_function(&single);
+        let full_result = type_check_program(&full);
+        assert!(
+            single_result.is_err() && full_result.is_err(),
+            "both APIs must reject an out-of-contract two-parameter generic function; \
+             single={single_result:?} full={full_result:?}",
+        );
+    }
+
+    #[test]
     fn fx_identity_surface_typechecks() {
         let src = r#"
             fn id(x: fx) -> fx {
@@ -7549,6 +7580,38 @@ mod tests {
         "#;
         let err = typecheck_source(src)
             .expect_err("blanket/generic impl with type_params must be rejected");
+        assert!(
+            err.message.contains("generic") || err.message.contains("type param"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    // FA-02-002 / #1634 classification evidence: a two-parameter impl is
+    // already rejected by #1668's stricter zero-arity impl contract,
+    // independent of #1634's new max-one check elsewhere -- not a #1634
+    // repair target for impls.
+    #[test]
+    fn two_type_param_impl_is_rejected_by_existing_zero_arity_contract() {
+        let src = r#"
+            trait Show {
+                fn show(self: MyType) -> i32;
+            }
+
+            record MyType { x: i32 }
+
+            impl<X, Y> Show for MyType {
+                fn show(self: MyType) -> i32 {
+                    return 0;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("a two-parameter generic impl must still reject via #1668's contract");
         assert!(
             err.message.contains("generic") || err.message.contains("type param"),
             "unexpected error: {}",

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -319,6 +319,23 @@ directly or nested, exactly like an unknown nominal type. `TraitTable`
 success therefore means both canonical identity is proven *and* the current
 executable/admitted type surface is proven — never identity alone.
 
+First-wave generic-capable definitions — functions, records, and ADTs —
+admit at most one type parameter per definition site; zero is non-generic
+and one is the contracted generic surface. The parser has no arity limit of
+its own (`parse_type_params_with_bounds` may represent `<T, U, ...>` and
+mixed bound combinations like `<T: Bound, U>` as raw AST, and does so
+deliberately, exactly as it does for the generic trait/impl syntax `build_trait_table`/`validate_trait_coherence`
+reject above); admission is enforced at each family's own canonical
+table-construction authority instead (`build_fn_table`, `build_record_table`,
+`build_adt_table`), never by truncating to the first parameter or silently
+admitting the extras. Traits and impls already require zero type parameters
+under the stricter contracts described above, so an out-of-contract arity
+there was already rejected before this boundary existed; it is not a new
+restriction for those two families. Admission of the contracted one-parameter
+form for records/ADTs is a declaration-time fact only — it does not imply a
+faithful applied nominal instantiation path for generic source use, which
+remains a separate, open gap.
+
 ## Deterministically unsupported forms
 
 Forms with no admitted current implementation must fail before execution with a


### PR DESCRIPTION
SSF-07: #1578

Fixes #1634

## Baseline

`26e894d4b7fb1c4cfffdc4b5a25a7a509847f030` — matched the assignment's expected baseline exactly; confirmed via fresh `origin/main` fetch, isolated worktree from the start.

## Pre-fix reproduction

Empirically verified on baseline, before any code change:

| Case | Result |
|---|---|
| `fn pair<T, U>(x: T, y: U) -> T { return x; }` | `build_fn_table` → `Ok(FnSig{type_params:[T,U], ...})`; `type_check_program` → `Ok(())` |
| `record Pair<T, U> { a: T, b: U }` | `type_check_program` → `Ok(())` (field types `TypeVar` fall through `ensure_type_resolved`'s pre-existing, out-of-scope `_ => Ok(())` catch-all, and nothing else checks `record.type_params`) |
| `enum Either<T, U> { Left(T), Right(U) }` | `type_check_program` → `Ok(())`, same mechanism |
| `trait Foo<X, Y> { fn a(v: Self) -> i32; }` | `build_trait_table` → `Err("trait 'Foo' declares type parameters; generic traits are not supported")` — **already rejected by #1635** |
| `impl<X, Y> Foo for R { ... }` | `type_check_program` → `Err("impl of trait 'Foo' for type 'R' declares type parameters; generic/blanket impls are not supported")` — **already rejected by #1668** |

Out-of-contract arity reached canonical semantic admission for all three non-trait/impl families. Confirmed with `RECORD TWO PARAM RESULT: Ok(())` / `ADT TWO PARAM RESULT: Ok(())` / `FN TWO PARAM type_check_program: Ok(())` panics during reproduction, removed before the final commit.

## Declaration-surface matrix

| Family | Raw parser may represent generics? | Canonical first-wave arity | Owner-layer admission (pre-fix) | Owner-layer admission (post-fix) |
|---|---|---|---|---|
| `Function` | yes, unbounded arity (`parse_type_params_with_bounds`) | ≤ 1 | none (any arity admitted) | `build_fn_table` rejects > 1 |
| `RecordDecl` | yes, unbounded arity (`parse_type_params`) | ≤ 1 | none (any arity admitted) | `build_record_table` rejects > 1 |
| `AdtDecl` | yes, unbounded arity (`parse_type_params`) | ≤ 1 | none (any arity admitted) | `build_adt_table` rejects > 1 |
| `TraitDecl` | yes, unbounded arity (`parse_type_params`) | 0 | `build_trait_table` rejects any non-empty (#1635) | unchanged |
| `ImplDecl` | yes, unbounded arity (`parse_type_params`) | 0 | `validate_trait_coherence` rejects any non-empty (#1668) | unchanged |

## Parser-vs-owner decision: Model B

Raw parser can represent arbitrary arity; each canonical owner enforces its own contracted arity. The parser (`parse_type_params_with_bounds`) is **untouched**.

## Why this boundary is correct

Two independent, existing test files already document that arbitrary-arity parsing is *intentional*, not a defect:

- `generic_function_two_type_params_are_parsed` (parser.rs) — `fn pair<A, B>(a: A, b: B) -> A` parses and asserts `f.type_params.len() == 2`.
- `function_with_multiple_type_params_mixed_bounds_is_parsed` (parser.rs) — `fn apply<T: Eq, U>(x: T, y: U) -> i32` parses and asserts `func.type_params.len() == 2, func.trait_bounds.len() == 1`.

Both are titled under the "M9.1 Wave 2: generic syntax admission tests" block — a deliberate milestone proving raw-AST parsing fidelity independent of semantic admission. Choosing Model A (parser-level rejection) would require deleting or inverting this existing, intentional test coverage — exactly the "smaller diff, wrong boundary" trap the task warned against. Model B also mirrors the architecture #1635 already established for traits (raw AST may represent `trait Foo<T>`; `build_trait_table` is the admission authority) and the `RecordDecl`/`TraitDecl`/`ImplDecl` doc comments in `types.rs` ("Admitted at the owner layer (Wave 1). Parser admission is deferred to Wave 2"), which use this exact convention for every declaration family, not just traits.

Both parser tests above reran green, unmodified, confirming raw AST fidelity is fully preserved.

## Exact arity invariant per declaration family

```
type_params.len() <= 1   for Function, RecordDecl, AdtDecl
type_params.len() == 0   for TraitDecl (#1635), ImplDecl (#1668)
```

## Function result

`fn f<T,U>(...)` → `build_fn_table` rejects: `"function '{name}' declares 2 type parameters; first-wave generic definitions admit at most one"`. `fn f<T>(...)` and `fn f<T: Bound>(...)` unaffected — new positive-control tests confirm admission and bound preservation.

## Record result

`record R<T,U>{...}` → `build_record_table` rejects with the record-specific equivalent message. `record R<T>{...}` unaffected.

## ADT result

`enum E<T,U>{...}` → `build_adt_table` rejects with the enum-specific equivalent message. `enum E<T>{...}` unaffected.

## Trait classification

Already rejected by #1635's stricter zero-arity contract — not a #1634 repair target. New test `build_trait_table_rejects_trait_with_two_type_params` documents this explicitly (2-param case, distinct from #1635's existing 1-param tests) so the classification is pinned, not just asserted in prose.

## Impl classification

Already rejected by #1668's stricter zero-arity contract — not a #1634 repair target. New test `two_type_param_impl_is_rejected_by_existing_zero_arity_contract` documents this explicitly (2-param case).

## Bound handling

`<T: Trait, U>` and `<T, U: Trait>` both rejected deterministically (`build_fn_table_rejects_bound_on_first_of_two_type_params`, `build_fn_table_rejects_bound_on_second_of_two_type_params`) — neither partially preserves the bounded parameter while discarding the other; the whole declaration is rejected before any `FnSig` is constructed. `<T: Bound>` (contracted single-parameter form) continues to preserve its bound (`build_fn_table_preserves_bound_on_single_type_param_function`, directly inspecting the stored `FnSig`).

## `type_param_scope` audit

No parser change was made, so no audit finding applies to scope push/pop mechanics themselves — `pop_type_param_scope(type_params.len())` continues to run symmetrically for any arity, exactly as before. More importantly: rejection now happens entirely in a *separate, later pass* (`build_fn_table`/`build_record_table`/`build_adt_table`, called after the whole `Program` has already finished parsing), never mid-parse. There is no interleaving between owner-layer rejection and `type_param_scope` state, so no partial-scope-state risk exists by construction.

## #1649 regression evidence

New test `type_check_function_and_type_check_program_agree_on_multi_param_generic_rejection` proves `type_check_function` and `type_check_program` reject `fn pair<T, U>(...)` identically (both `Err`) post-fix — extending the existing #1649 consistency guard (`type_check_function_agrees_with_canonical_program_path_for_generic_admission`) to the rejection case specifically. Pre-fix, both paths agreed on *admitting* it (`single=Ok(()) full=Ok(())`) — itself part of the bug this PR closes; post-fix they agree on rejecting it, through the same shared `build_fn_table` authority #1649 unified. No special-cased check was hand-built in either API.

## #1648 classification

`#1648 — UNAFFECTED SEMANTICS, NARROWER INPUT CONTRACT`. Call-site inference/substitution logic is untouched; #1648's future repair now only needs to reason about one generic parameter with nested occurrences, not an unbounded list.

## #1650 classification

Unaffected; not implemented here. The contracted one-parameter form for records/ADTs remains admitted at the *declaration* level only — no `Record(SymbolId, Vec<Type>)`/`Adt(SymbolId, Vec<Type>)` applied-nominal representation, no source instantiation syntax, no monomorphisation. #1650's gap (no faithful applied nominal type path for generic record/ADT use) remains exactly as open as before this PR; stated explicitly in the new spec-doc paragraph.

## #1717 classification

`UNAFFECTED; IR monomorphisation gap remains open.` Zero changes to `sm-ir`, `passes/`, SemCode lowering, or the VM. This PR only freezes frontend declaration arity.

## #1633 classification

Unaffected; not conflated. #1633 concerns non-function declaration bounds parsed and discarded through `parse_type_params()` (records/ADTs/traits/impls). This PR does not touch bound parsing or discarding at all — it adds an arity check after parsing completes, at each family's existing table-construction authority.

## Duplicate-param classification

`<T, T>` is arity 2 regardless of the repeated name, so it is rejected by this same check (`build_fn_table_rejects_duplicate_type_param_name_via_arity`). This is **incidental arity coverage**, not a dedicated duplicate-name repair — no separate uniqueness check was added, per the task's explicit instruction not to opportunistically repair this without a tracked root/issue.

## Fallback/bypass audit

Grepped the full diff for `unwrap_or*`, `or_else`, `if let Ok/Some`, `let Ok/Some ... else`, `Default::default()`, `.unwrap()`, `.expect()`, `truncate`, `first()`, `skip()`, `take(1)`, catch-all `match _ =>`. Zero matches in production code — the three new checks are plain `if type_params.len() > 1 { return Err(...) }`, no truncation, no partial admission. All `.expect(...)` matches are in test setup, the established repo convention.

## Docs

`docs/spec/foundation_source_profile_v1.md`: added one paragraph to the existing "Experimental but currently accepted extensions" block (the same block #1635/#1668's trait/impl closures are already documented in), stating the frozen `type_params.len() <= 1` / `== 0` invariant per family, that the parser deliberately retains no arity limit, and that admission of the contracted record/ADT form does not imply a faithful applied-nominal instantiation path (#1650 remains open). No version bump, consistent with how prior SSF-07 slices extended this same section.

## Qualification

- `cargo check --workspace --all-targets` — clean
- `cargo test -p sm-front` — 536 passed, 0 failed (up from 523)
- `cargo test --test public_api_contracts` — 88 passed, no drift
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed (rerun after the spec-doc edit)
- `cargo fmt -p sm-front --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Targeted (37 tests): generic functions/records/ADTs (parser fidelity + owner admission), `build_fn_table`, `type_check_function` (#1649), trait admission (#1635), impl generic rejection (#1668), generic bounds, malformed-`FnSig` regressions (#1665/#1722) — all rerun green
- Workspace-wide `cargo fmt --check` — same pre-existing unrelated Windows path-length OS error, confirmed unchanged

## Changed files

- `crates/sm-front/src/lib.rs` (`build_fn_table`, `build_record_table`, `build_adt_table` + 11 new tests)
- `crates/sm-front/src/typecheck.rs` (2 new tests: impl classification evidence, #1649 rejection-consistency evidence)
- `docs/spec/foundation_source_profile_v1.md` (one paragraph)

## Out of scope

This PR does not implement multi-parameter generics.
This PR does not implement recursive generic inference (#1648).
This PR does not implement applied generic nominal types (#1650).
This PR does not implement IR monomorphisation (#1717).
This PR does not close #1578.
This PR does not authorize SSF-08.

## Remaining SSF-07 work

#1648, #1650, #1717 remain open, all classified above. #1578 remains open.
