### PR TITLE
fix(front): recurse generic call inference through compound types (#1648)

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1854,14 +1854,207 @@ fn check_stmt(
     }
 }
 
-/// Apply a type-variable substitution map to `ty` (M9.1 Wave 3).
-/// Only direct `TypeVar` occurrences are substituted; compound types
-/// that could theoretically contain a TypeVar (e.g. `Sequence<T>`) are
-/// not handled here — those are deferred to the monomorphisation pass.
+/// Apply a type-variable substitution map to `ty` (FA-02-016 / #1648),
+/// recursively, through every currently admitted structural type family. A
+/// `TypeVar` occurrence is substituted wherever it appears -- directly, or
+/// nested inside `Tuple`/`Sequence`/`Map`/`Option`/`Result`/`Closure`/
+/// `Measured` -- not only at the top level. This is frontend call-site type
+/// substitution, distinct from IR monomorphisation (#1717, unaffected):
+/// `Record`/`Adt` are nominal leaves with no applied type arguments (#1650)
+/// and are never recursed into. Exhaustive over every `Type` variant, no
+/// catch-all arm, so a future variant forces an explicit decision here
+/// rather than silently passing through unsubstituted (mirrors the
+/// exhaustiveness discipline `ensure_executable_type_supported` established
+/// for #1647).
 fn subst_apply(ty: &Type, subst: &BTreeMap<SymbolId, Type>) -> Type {
     match ty {
         Type::TypeVar(id) => subst.get(id).cloned().unwrap_or_else(|| ty.clone()),
-        _ => ty.clone(),
+        Type::Tuple(items) => Type::Tuple(items.iter().map(|t| subst_apply(t, subst)).collect()),
+        Type::Sequence(sequence) => Type::Sequence(SequenceType {
+            family: sequence.family,
+            item: Box::new(subst_apply(sequence.item.as_ref(), subst)),
+        }),
+        Type::Map(map) => Type::Map(MapType {
+            key: Box::new(subst_apply(map.key.as_ref(), subst)),
+            val: Box::new(subst_apply(map.val.as_ref(), subst)),
+        }),
+        Type::Closure(closure) => Type::Closure(ClosureType {
+            family: closure.family,
+            capture: closure.capture,
+            param: Box::new(subst_apply(closure.param.as_ref(), subst)),
+            ret: Box::new(subst_apply(closure.ret.as_ref(), subst)),
+        }),
+        Type::Measured(base, unit) => Type::Measured(Box::new(subst_apply(base, subst)), *unit),
+        Type::Option(item) => Type::Option(Box::new(subst_apply(item, subst))),
+        Type::Result(ok_ty, err_ty) => Type::Result(
+            Box::new(subst_apply(ok_ty, subst)),
+            Box::new(subst_apply(err_ty, subst)),
+        ),
+        Type::Quad
+        | Type::QVec(_)
+        | Type::Bool
+        | Type::Text
+        | Type::I32
+        | Type::U32
+        | Type::Fx
+        | Type::F64
+        | Type::RangeI32
+        | Type::Record(_)
+        | Type::Adt(_)
+        | Type::Unit => ty.clone(),
+    }
+}
+
+/// Recursively derives `TypeVar` constraints for a generic call argument
+/// (FA-02-016 / #1648): given the declared, canonicalized `expected` shape
+/// (which may contain the callee's own declared type parameter, directly or
+/// nested inside any currently admitted structural family) and the `actual`
+/// inferred type of the argument expression, walks both in lockstep and
+/// binds or checks each `TypeVar` encountered in `expected`.
+///
+/// Responsibility split: this function only collects/checks constraints
+/// (inference); `subst_apply` performs the corresponding recursive
+/// substitution afterward. Neither is a substitute for the other.
+///
+/// A structural shape mismatch (e.g. expected `Option(T)`, actual
+/// `Sequence(i32)`) yields no constraint here rather than an error -- the
+/// existing canonical second-pass parameter-compatibility check remains the
+/// final authority and rejects the call deterministically once the
+/// (unsubstituted, still-generic) expected shape provably cannot equal the
+/// concrete argument type. This avoids two independent, potentially
+/// disagreeing diagnostics for the same defect.
+///
+/// `actual` binding a declared type parameter to a bare `TypeVar` (its own,
+/// or -- since symbol names are interned program-wide -- another unrelated
+/// declaration's of the same spelling) is not an error case to special-case
+/// here: it is exactly how a generic function's body-check honestly types a
+/// call to another generic function using its own still-opaque parameter
+/// (e.g. `fn outer<T>(x: T) -> T { return id(x); }` calling
+/// `fn id<T>(y: T) -> T`), independent of and unaffected by whatever
+/// concrete type `outer` itself is later called with. `subst_apply` performs
+/// one structural substitution pass with no fixpoint re-application, so this
+/// carries no cyclic/infinite-recursion risk either way.
+fn collect_generic_constraints(
+    expected: &Type,
+    actual: &Type,
+    arena: &AstArena,
+    subst: &mut BTreeMap<SymbolId, Type>,
+) -> Result<(), FrontendError> {
+    match expected {
+        Type::TypeVar(tid) => match subst.get(tid) {
+            None => {
+                subst.insert(*tid, actual.clone());
+                Ok(())
+            }
+            Some(existing) if existing == actual => Ok(()),
+            Some(existing) => Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "conflicting generic constraints for type parameter '{}': {:?} vs {:?}",
+                    resolve_symbol_name(arena, *tid)?,
+                    existing,
+                    actual
+                ),
+            }),
+        },
+        Type::Tuple(expected_items) => {
+            if let Type::Tuple(actual_items) = actual {
+                if expected_items.len() == actual_items.len() {
+                    for (e, a) in expected_items.iter().zip(actual_items.iter()) {
+                        collect_generic_constraints(e, a, arena, subst)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+        Type::Sequence(expected_seq) => {
+            if let Type::Sequence(actual_seq) = actual {
+                collect_generic_constraints(
+                    expected_seq.item.as_ref(),
+                    actual_seq.item.as_ref(),
+                    arena,
+                    subst,
+                )?;
+            }
+            Ok(())
+        }
+        Type::Map(expected_map) => {
+            if let Type::Map(actual_map) = actual {
+                collect_generic_constraints(
+                    expected_map.key.as_ref(),
+                    actual_map.key.as_ref(),
+                    arena,
+                    subst,
+                )?;
+                collect_generic_constraints(
+                    expected_map.val.as_ref(),
+                    actual_map.val.as_ref(),
+                    arena,
+                    subst,
+                )?;
+            }
+            Ok(())
+        }
+        Type::Closure(expected_closure) => {
+            if let Type::Closure(actual_closure) = actual {
+                if expected_closure.family == actual_closure.family
+                    && expected_closure.capture == actual_closure.capture
+                {
+                    collect_generic_constraints(
+                        expected_closure.param.as_ref(),
+                        actual_closure.param.as_ref(),
+                        arena,
+                        subst,
+                    )?;
+                    collect_generic_constraints(
+                        expected_closure.ret.as_ref(),
+                        actual_closure.ret.as_ref(),
+                        arena,
+                        subst,
+                    )?;
+                }
+            }
+            Ok(())
+        }
+        Type::Measured(expected_base, expected_unit) => {
+            if let Type::Measured(actual_base, actual_unit) = actual {
+                if expected_unit == actual_unit {
+                    collect_generic_constraints(expected_base, actual_base, arena, subst)?;
+                }
+            }
+            Ok(())
+        }
+        Type::Option(expected_item) => {
+            if let Type::Option(actual_item) = actual {
+                collect_generic_constraints(expected_item, actual_item, arena, subst)?;
+            }
+            Ok(())
+        }
+        Type::Result(expected_ok, expected_err) => {
+            if let Type::Result(actual_ok, actual_err) = actual {
+                collect_generic_constraints(expected_ok, actual_ok, arena, subst)?;
+                collect_generic_constraints(expected_err, actual_err, arena, subst)?;
+            }
+            Ok(())
+        }
+        // Leaves for generic-constraint purposes: no TypeVar can occur
+        // inside them, so there is nothing to bind. Record/Adt are nominal
+        // leaves specifically because they carry no applied type arguments
+        // (#1650 remains the separate, unimplemented gap for that). Final
+        // shape/value compatibility for every leaf family remains the
+        // existing canonical second-pass checker's responsibility.
+        Type::Quad
+        | Type::QVec(_)
+        | Type::Bool
+        | Type::Text
+        | Type::I32
+        | Type::U32
+        | Type::Fx
+        | Type::F64
+        | Type::RangeI32
+        | Type::Record(_)
+        | Type::Adt(_)
+        | Type::Unit => Ok(()),
     }
 }
 
@@ -2888,36 +3081,40 @@ fn infer_expr_type(
                 });
             };
             let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
-            // M9.1 Wave 3: generic call-site substitution.
+            // FA-02-016 / #1648: generic call-site substitution.
             // When the function is generic (sig.type_params non-empty), infer a
             // substitution map TypeVar(T) → concrete_type from the argument
-            // expressions and apply it before checking argument/return types.
+            // expressions -- recursively through every currently admitted
+            // structural family, not only a directly TypeVar-shaped parameter
+            // -- and apply it before checking argument/return types.
             if !sig.type_params.is_empty() {
                 let fn_name = resolve_symbol_name(arena, *name)?;
-                // First pass: build substitution map from arguments whose
-                // expected param type is a TypeVar.
+                // First pass: recursively collect TypeVar constraints from
+                // every argument's declared (expected) shape against its
+                // actual inferred type. Operates on the final bound
+                // parameter slot (ordered_args.slots), never source
+                // position, so named/default-argument reordering (#1722)
+                // cannot desync inference from the ABI-bound parameter it
+                // actually corresponds to.
                 let mut subst: BTreeMap<SymbolId, Type> = BTreeMap::new();
                 for (i, arg) in ordered_args.slots.iter().enumerate() {
-                    if let Type::TypeVar(tid) = &sig.params[i] {
-                        if subst.contains_key(tid) {
-                            // Already bound — verify consistency below.
-                            continue;
-                        }
-                        let at = infer_expr_type(
-                            *arg,
-                            arena,
-                            env,
-                            table,
-                            record_table,
-                            adt_table,
-                            ret_ty.clone(),
-                            loop_stack,
-                            impl_list,
-                        )?;
-                        subst.insert(*tid, at);
-                    }
+                    let at = infer_expr_type(
+                        *arg,
+                        arena,
+                        env,
+                        table,
+                        record_table,
+                        adt_table,
+                        ret_ty.clone(),
+                        loop_stack,
+                        impl_list,
+                    )?;
+                    collect_generic_constraints(&sig.params[i], &at, arena, &mut subst)?;
                 }
-                // Every declared type parameter must have been bound.
+                // Every declared type parameter must have been bound by at
+                // least one argument -- the formal exit invariant: a
+                // successful generic call never leaves a declared type
+                // parameter with no constraint at all.
                 for tp in &sig.type_params {
                     if !subst.contains_key(tp) {
                         return Err(FrontendError {
@@ -3284,6 +3481,533 @@ mod tests {
     fn typecheck_source(src: &str) -> Result<(), FrontendError> {
         let program = parse_program(src)?;
         type_check_program(&program)
+    }
+
+    // FA-02-016 / #1648: generic call-site inference and substitution now
+    // recurse through every currently admitted structural type family
+    // (Tuple, Sequence, Map, Option, Result, Closure, Measured), not only a
+    // directly TypeVar-shaped parameter. `Record`/`Adt` remain nominal
+    // leaves (#1650 is the separate, unimplemented applied-nominal gap);
+    // IR monomorphisation (#1717) is a different layer and is untouched.
+
+    #[test]
+    fn generic_call_direct_typevar_still_works() {
+        // (Control) The pre-existing, already-working case must remain
+        // unaffected by recursing constraint collection.
+        let src = r#"
+            fn id<T>(x: T) -> T {
+                return x;
+            }
+            fn main() {
+                let y: i32 = id(1);
+                let _ = y;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("direct TypeVar inference must still work");
+    }
+
+    #[test]
+    fn generic_call_direct_typevar_conflicting_constraints_reject() {
+        // fn same<T>(a: T, b: T) -> T; same(1, "x") must reject -- the
+        // exact reproducer named in #1648's conflict-semantics section.
+        let src = r#"
+            fn same<T>(a: T, b: T) -> T {
+                return a;
+            }
+            fn main() {
+                let y = same(1, "x");
+                let _ = y;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("conflicting direct TypeVar constraints for the same T must reject");
+        assert!(
+            err.message.contains("conflicting generic constraints") && err.message.contains('T'),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn generic_call_infers_and_substitutes_through_option() {
+        // Also proves nested return substitution: the call's inferred type
+        // must be the concrete `Option(i32)`, never `Option(TypeVar(T))` --
+        // otherwise the `let r: Option(i32) = ...` binding could not
+        // type-check.
+        let src = r#"
+            fn identity_via_option<T>(x: Option(T)) -> Option(T) {
+                return x;
+            }
+            fn main() {
+                let v: Option(i32) = Option::Some(1);
+                let r: Option(i32) = identity_via_option(v);
+                let _ = r;
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("Option(T) must infer T and substitute a concrete return type");
+    }
+
+    #[test]
+    fn generic_call_infers_and_substitutes_through_sequence() {
+        // Also proves nested return substitution via the returned element.
+        let src = r#"
+            fn first<T>(xs: Sequence(T)) -> T {
+                return xs[0];
+            }
+            fn main() {
+                let items: Sequence(i32) = [1, 2, 3];
+                let y: i32 = first(items);
+                let _ = y;
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("Sequence(T) must infer T and substitute a concrete return type");
+    }
+
+    #[test]
+    fn generic_call_infers_and_substitutes_through_tuple() {
+        let src = r#"
+            fn tuple_first<T>(pair: (T, i32)) -> T {
+                let (first, _) = pair;
+                return first;
+            }
+            fn main() {
+                let p: (i32, i32) = (7, 2);
+                let y: i32 = tuple_first(p);
+                let _ = y;
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("(T, concrete) must infer T and substitute a concrete return type");
+    }
+
+    #[test]
+    fn generic_call_tuple_repeated_consistent_constraint_succeeds() {
+        // (T, T) + (i32, i32) -> T = i32; the same T constrained twice
+        // consistently must not be treated as a conflict.
+        let src = r#"
+            fn same_pair<T>(pair: (T, T)) -> T {
+                let (first, _) = pair;
+                return first;
+            }
+            fn main() {
+                let ok: (i32, i32) = (1, 2);
+                let y: i32 = same_pair(ok);
+                let _ = y;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("repeated consistent nested constraints must succeed");
+    }
+
+    #[test]
+    fn generic_call_tuple_repeated_conflicting_constraint_rejects() {
+        // (T, T) + (i32, text) -> conflicting constraints -> deterministic
+        // reject. No "last binding wins", no first-binding silent ignore.
+        let src = r#"
+            fn same_pair<T>(pair: (T, T)) -> T {
+                let (first, _) = pair;
+                return first;
+            }
+            fn main() {
+                let bad: (i32, text) = (1, "x");
+                let y = same_pair(bad);
+                let _ = y;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("conflicting nested tuple constraints for the same T must reject");
+        assert!(
+            err.message.contains("conflicting generic constraints") && err.message.contains('T'),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn generic_call_infers_through_result() {
+        // Result(T, concrete) is the only source-constructible Result shape
+        // under the one-parameter first-wave contract (#1634) -- a shape
+        // requiring two independent function type parameters (Result(T, E))
+        // is not fabricated here.
+        let src = r#"
+            fn result_marker<T>(r: Result(T, text)) -> i32 {
+                return 0;
+            }
+            fn main() {
+                let r: Result(i32, text) = Result::Ok(1);
+                let y: i32 = result_marker(r);
+                let _ = y;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("Result(T, concrete) must infer T");
+    }
+
+    #[test]
+    fn generic_call_cross_parameter_conflicting_constraints_reject() {
+        // fn cross_constrain<T>(a: Option(T), b: Sequence(T)); arguments
+        // constrain T differently across two different structural families
+        // -> deterministic reject.
+        let src = r#"
+            fn cross_constrain<T>(a: Option(T), b: Sequence(T)) -> i32 {
+                return 0;
+            }
+            fn main() {
+                let opt: Option(i32) = Option::Some(1);
+                let seq: Sequence(text) = ["x"];
+                let y = cross_constrain(opt, seq);
+                let _ = y;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("constraints on T from two different structural families must be checked against each other");
+        assert!(
+            err.message.contains("conflicting generic constraints") && err.message.contains('T'),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn generic_call_unused_type_param_cannot_infer() {
+        // fn unused<T>(x: i32) -> i32; T never appears in params/return, so
+        // no argument can ever constrain it -- deterministic reject at the
+        // call site. Pre-existing behavior (the "every declared type
+        // parameter must be bound" check predates this slice); confirmed
+        // unaffected by the recursive-collection change.
+        let src = r#"
+            fn unused<T>(x: i32) -> i32 {
+                return x;
+            }
+            fn main() {
+                let y: i32 = unused(5);
+                let _ = y;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("a type parameter no argument constrains must reject deterministically");
+        assert!(
+            err.message.contains("cannot infer") && err.message.contains('T'),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn generic_call_structural_mismatch_rejects_via_second_pass() {
+        // Expected Option(T), actual Sequence(i32): a structural shape
+        // mismatch yields no constraint from collect_generic_constraints
+        // (T is separately bound by the first, direct-TypeVar argument
+        // here, so this is not merely "cannot infer"); the existing
+        // canonical second-pass parameter-compatibility check is proven to
+        // be the one that actually rejects the call.
+        let src = r#"
+            fn wrap<T>(a: T, b: Option(T)) -> i32 {
+                return 0;
+            }
+            fn main() {
+                let items: Sequence(i32) = [1, 2, 3];
+                let y = wrap(1, items);
+                let _ = y;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src).expect_err(
+            "a structurally mismatched argument shape must still reject deterministically",
+        );
+        assert!(
+            err.message.contains("has type") && err.message.contains("expected"),
+            "expected the canonical second-pass type-mismatch diagnostic, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn generic_call_bound_satisfied_through_nested_option() {
+        // Nested generic parameter shape (Option(T)) + bound on T +
+        // satisfying impl -> passes. type_check_function cannot exercise
+        // this positively (empty validated impl context by design, #1649);
+        // this whole-program test is the required positive-satisfaction
+        // evidence.
+        let src = r#"
+            trait Zeroable {
+                fn zero(v: ZeroInt) -> i32;
+            }
+            record ZeroInt { n: i32 }
+            impl Zeroable for ZeroInt {
+                fn zero(v: ZeroInt) -> i32 { return 0; }
+            }
+            fn wrap<T: Zeroable>(x: Option(T)) -> i32 {
+                return 0;
+            }
+            fn main() {
+                let v: Option(ZeroInt) = Option::Some(ZeroInt { n: 0 });
+                let y: i32 = wrap(v);
+                let _ = y;
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("a bound on T satisfied by an impl through a nested Option(T) must pass");
+    }
+
+    #[test]
+    fn generic_call_bound_missing_through_nested_option_fails_closed() {
+        // Same nested shape, no satisfying impl -> fails closed.
+        let src = r#"
+            trait Printable {
+                fn show(v: NoPrint) -> i32;
+            }
+            record NoPrint { x: i32 }
+            record Unprinted { y: i32 }
+            fn wrap2<T: Printable>(x: Option(T)) -> i32 {
+                return 0;
+            }
+            fn main() {
+                let v: Option(Unprinted) = Option::Some(Unprinted { y: 1 });
+                let r = wrap2(v);
+                let _ = r;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src).expect_err(
+            "a bound on T with no satisfying impl through a nested Option(T) must fail closed",
+        );
+        assert!(
+            err.message.contains("Printable"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn type_check_function_and_type_check_program_agree_on_sequence_generic_declaration() {
+        // #1649 regression, extended to a compound family: both public
+        // entry points share the identical call-inference code path this
+        // slice changed, so their admission verdict for a Sequence(T)
+        // declaration must still agree.
+        let single_src = r#"
+            fn first<T>(xs: Sequence(T)) -> T {
+                return xs[0];
+            }
+        "#;
+        let program_src = r#"
+            fn first<T>(xs: Sequence(T)) -> T {
+                return xs[0];
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        let single = parse_program(single_src).expect("parse single-function program");
+        let full = parse_program(program_src).expect("parse full program");
+        let single_result = type_check_function(&single);
+        let full_result = type_check_program(&full);
+        assert_eq!(
+            single_result.is_ok(),
+            full_result.is_ok(),
+            "type_check_function must agree with type_check_program for a Sequence(T) declaration; \
+             single={single_result:?} full={full_result:?}",
+        );
+    }
+
+    #[test]
+    fn generic_call_inference_uses_bound_parameter_slot_not_source_position() {
+        // FA-02-033 / #1722: source evaluation order != parameter binding
+        // order. `pick`'s declared order is (a: T, b: i32); this call names
+        // both arguments in the reverse source order. If inference ever
+        // read `sig.params[i]` against the source-position argument instead
+        // of `ordered_args.slots[i]` (the canonically bound slot), it would
+        // bind T from `b`'s i32 value instead of `a`'s text value, and
+        // either infer the wrong T or reject with a spurious type mismatch.
+        let src = r#"
+            fn pick<T>(a: T, b: i32) -> T {
+                return a;
+            }
+            fn main() {
+                let y: text = pick(b = 2, a = "hello");
+                let _ = y;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect(
+            "generic inference must use the bound parameter slot, not source argument position",
+        );
+    }
+
+    // Focused structural unit tests for `collect_generic_constraints` and
+    // `subst_apply` directly: Map has no literal construction syntax in
+    // source (only `map_empty()` + `map_set(...)`), and constructing a
+    // function signature exercising both Closure positions and a Measured
+    // base independently has no simple corresponding call-site source form.
+    // Per #1648's own guidance, these are tested as structural Type
+    // recursion directly rather than through invented sugar.
+
+    #[test]
+    fn collect_generic_constraints_and_subst_apply_recurse_through_map_both_positions() {
+        let program =
+            parse_program("fn f<T>(x: T) -> T { return x; } fn main() { return; }").expect("parse");
+        let t = *program.arena.symbol_to_id.get("T").expect("T interned");
+
+        // Map(text, T) + Map(text, i32) -> T = i32 (value position).
+        let expected_val = Type::Map(MapType {
+            key: Box::new(Type::Text),
+            val: Box::new(Type::TypeVar(t)),
+        });
+        let actual_val = Type::Map(MapType {
+            key: Box::new(Type::Text),
+            val: Box::new(Type::I32),
+        });
+        let mut subst = BTreeMap::new();
+        collect_generic_constraints(&expected_val, &actual_val, &program.arena, &mut subst)
+            .expect("Map value position must infer T");
+        assert_eq!(subst.get(&t), Some(&Type::I32));
+        assert_eq!(subst_apply(&expected_val, &subst), actual_val);
+
+        // Map(T, i32) + Map(text, i32) -> T = text (key position,
+        // independent generic parameter usage -- not two type variables).
+        let expected_key = Type::Map(MapType {
+            key: Box::new(Type::TypeVar(t)),
+            val: Box::new(Type::I32),
+        });
+        let actual_key = Type::Map(MapType {
+            key: Box::new(Type::Text),
+            val: Box::new(Type::I32),
+        });
+        let mut subst2 = BTreeMap::new();
+        collect_generic_constraints(&expected_key, &actual_key, &program.arena, &mut subst2)
+            .expect("Map key position must infer T");
+        assert_eq!(subst2.get(&t), Some(&Type::Text));
+        assert_eq!(subst_apply(&expected_key, &subst2), actual_key);
+    }
+
+    #[test]
+    fn collect_generic_constraints_and_subst_apply_recurse_through_closure_both_positions() {
+        let program =
+            parse_program("fn f<T>(x: T) -> T { return x; } fn main() { return; }").expect("parse");
+        let t = *program.arena.symbol_to_id.get("T").expect("T interned");
+
+        // Closure(T -> i32) + Closure(text -> i32) -> T = text (param).
+        let expected_param = Type::Closure(ClosureType {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: Box::new(Type::TypeVar(t)),
+            ret: Box::new(Type::I32),
+        });
+        let actual_param = Type::Closure(ClosureType {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: Box::new(Type::Text),
+            ret: Box::new(Type::I32),
+        });
+        let mut subst = BTreeMap::new();
+        collect_generic_constraints(&expected_param, &actual_param, &program.arena, &mut subst)
+            .expect("Closure param position must infer T");
+        assert_eq!(subst.get(&t), Some(&Type::Text));
+        assert_eq!(subst_apply(&expected_param, &subst), actual_param);
+
+        // Closure(i32 -> T) + Closure(i32 -> bool) -> T = bool (ret).
+        let expected_ret = Type::Closure(ClosureType {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: Box::new(Type::I32),
+            ret: Box::new(Type::TypeVar(t)),
+        });
+        let actual_ret = Type::Closure(ClosureType {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: Box::new(Type::I32),
+            ret: Box::new(Type::Bool),
+        });
+        let mut subst2 = BTreeMap::new();
+        collect_generic_constraints(&expected_ret, &actual_ret, &program.arena, &mut subst2)
+            .expect("Closure return position must infer T");
+        assert_eq!(subst2.get(&t), Some(&Type::Bool));
+        assert_eq!(subst_apply(&expected_ret, &subst2), actual_ret);
+    }
+
+    #[test]
+    fn collect_generic_constraints_and_subst_apply_recurse_through_measured_preserving_unit() {
+        let mut program =
+            parse_program("fn f<T>(x: T) -> T { return x; } fn main() { return; }").expect("parse");
+        let t = *program.arena.symbol_to_id.get("T").expect("T interned");
+        let ms = program.arena.intern_symbol("ms");
+
+        // Measured(T, ms) + Measured(i32, ms) -> T = i32, unit preserved.
+        let expected = Type::Measured(Box::new(Type::TypeVar(t)), ms);
+        let actual = Type::Measured(Box::new(Type::I32), ms);
+        let mut subst = BTreeMap::new();
+        collect_generic_constraints(&expected, &actual, &program.arena, &mut subst)
+            .expect("Measured base must infer T");
+        assert_eq!(subst.get(&t), Some(&Type::I32));
+        assert_eq!(subst_apply(&expected, &subst), actual);
+
+        // A different unit must not be absorbed by T: no unit erasure, no
+        // coercive magic -- yields no constraint, left to final
+        // compatibility.
+        let kg = program.arena.intern_symbol("kg");
+        let actual_wrong_unit = Type::Measured(Box::new(Type::I32), kg);
+        let mut subst2 = BTreeMap::new();
+        collect_generic_constraints(&expected, &actual_wrong_unit, &program.arena, &mut subst2)
+            .expect("a differing unit yields no constraint rather than an error here");
+        assert!(
+            subst2.is_empty(),
+            "a mismatched unit must never bind T to the other unit's base type"
+        );
+    }
+
+    #[test]
+    fn collect_generic_constraints_treats_record_and_adt_as_nominal_leaves() {
+        // #1650 boundary: Record/Adt carry no applied type arguments and
+        // are never recursed into for generic-constraint purposes.
+        let program = parse_program(
+            "record R { n: i32 } enum E { A } fn f<T>(x: T) -> T { return x; } fn main() { return; }",
+        )
+        .expect("parse");
+        let t = *program.arena.symbol_to_id.get("T").expect("T interned");
+        let r_id = program.records[0].name;
+        let e_id = program.adts[0].name;
+
+        let mut subst = BTreeMap::new();
+        collect_generic_constraints(
+            &Type::Record(r_id),
+            &Type::Record(r_id),
+            &program.arena,
+            &mut subst,
+        )
+        .expect("nominal Record leaf yields no constraint");
+        assert!(subst.is_empty());
+        collect_generic_constraints(
+            &Type::Adt(e_id),
+            &Type::Adt(e_id),
+            &program.arena,
+            &mut subst,
+        )
+        .expect("nominal Adt leaf yields no constraint");
+        assert!(subst.is_empty());
+
+        // T itself can still bind to a nominal type as an opaque leaf value
+        // from a direct TypeVar position -- this is ordinary inference, not
+        // recursion through the nominal type's (nonexistent) arguments.
+        let mut subst2 = BTreeMap::new();
+        collect_generic_constraints(
+            &Type::TypeVar(t),
+            &Type::Record(r_id),
+            &program.arena,
+            &mut subst2,
+        )
+        .expect("T binds to a nominal type as an opaque value");
+        assert_eq!(subst2.get(&t), Some(&Type::Record(r_id)));
     }
 
     fn derive_validation_plans_from_source(

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1905,6 +1905,86 @@ fn subst_apply(ty: &Type, subst: &BTreeMap<SymbolId, Type>) -> Type {
     }
 }
 
+/// FA-02-016 / #1648 corrective: proves every `TypeVar` occurring in `ty`,
+/// directly or nested inside any currently admitted structural family,
+/// belongs to `declared` -- before `collect_generic_constraints` is ever
+/// allowed to treat it as this call's generic authority.
+///
+/// `type_check_function_with_table` accepts a caller-supplied `FnTable` (a
+/// deliberately checkable public trust boundary -- see the `malformed_fn_sig_*`
+/// regressions for #1665/#1722's precedent), so a callee's `FnSig` cannot be
+/// assumed to have been built by the canonical `build_fn_table` authority,
+/// which is the only thing that actually guarantees every `TypeVar` in
+/// `params`/`ret` was canonicalized within `type_params` scope. Without this
+/// check, a malformed `FnSig` whose `params`/`ret` nests a `TypeVar` never
+/// listed in `type_params` would have that undeclared variable silently
+/// "adopted": `collect_generic_constraints` would bind it like any other
+/// declared parameter the moment it appears structurally nested (exactly the
+/// shape the pre-#1648 shallow first pass could never see in the first
+/// place, so this was not a reachable gap before recursion was added). This
+/// is a distinct concern from `collect_generic_constraints`'s own algorithm,
+/// which is unchanged: an *actual* argument type being a bare `TypeVar` --
+/// including an enclosing generic function's own still-opaque parameter, per
+/// the comment above -- remains a legitimate binding *value*; what this
+/// function polices is which symbols the *expected*, declared signature
+/// shape is entitled to reference as a generic parameter at all.
+fn ensure_typevars_declared(
+    ty: &Type,
+    declared: &[SymbolId],
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    match ty {
+        Type::TypeVar(id) => {
+            if declared.contains(id) {
+                Ok(())
+            } else {
+                Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "type variable '{}' is not declared as one of this function's type parameters",
+                        resolve_symbol_name(arena, *id)?
+                    ),
+                })
+            }
+        }
+        Type::Tuple(items) => {
+            for item in items {
+                ensure_typevars_declared(item, declared, arena)?;
+            }
+            Ok(())
+        }
+        Type::Sequence(sequence) => {
+            ensure_typevars_declared(sequence.item.as_ref(), declared, arena)
+        }
+        Type::Map(map) => {
+            ensure_typevars_declared(map.key.as_ref(), declared, arena)?;
+            ensure_typevars_declared(map.val.as_ref(), declared, arena)
+        }
+        Type::Closure(closure) => {
+            ensure_typevars_declared(closure.param.as_ref(), declared, arena)?;
+            ensure_typevars_declared(closure.ret.as_ref(), declared, arena)
+        }
+        Type::Measured(base, _) => ensure_typevars_declared(base, declared, arena),
+        Type::Option(item) => ensure_typevars_declared(item, declared, arena),
+        Type::Result(ok_ty, err_ty) => {
+            ensure_typevars_declared(ok_ty, declared, arena)?;
+            ensure_typevars_declared(err_ty, declared, arena)
+        }
+        Type::Quad
+        | Type::QVec(_)
+        | Type::Bool
+        | Type::Text
+        | Type::I32
+        | Type::U32
+        | Type::Fx
+        | Type::F64
+        | Type::RangeI32
+        | Type::Record(_)
+        | Type::Adt(_)
+        | Type::Unit => Ok(()),
+    }
+}
+
 /// Recursively derives `TypeVar` constraints for a generic call argument
 /// (FA-02-016 / #1648): given the declared, canonicalized `expected` shape
 /// (which may contain the callee's own declared type parameter, directly or
@@ -3089,6 +3169,26 @@ fn infer_expr_type(
             // -- and apply it before checking argument/return types.
             if !sig.type_params.is_empty() {
                 let fn_name = resolve_symbol_name(arena, *name)?;
+                // FA-02-016 / #1648 corrective: prove sig.type_params is an
+                // honest ownership boundary before trusting it -- table is a
+                // public, caller-suppliable FnTable, not necessarily built
+                // by build_fn_table. See ensure_typevars_declared.
+                for p in &sig.params {
+                    ensure_typevars_declared(p, &sig.type_params, arena)?;
+                }
+                ensure_typevars_declared(&sig.ret, &sig.type_params, arena)?;
+                for bound in &sig.trait_bounds {
+                    if !sig.type_params.contains(&bound.param) {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: format!(
+                                "trait bound references type parameter '{}' which is not declared on '{}'",
+                                resolve_symbol_name(arena, bound.param)?,
+                                fn_name,
+                            ),
+                        });
+                    }
+                }
                 // First pass: recursively collect TypeVar constraints from
                 // every argument's declared (expected) shape against its
                 // actual inferred type. Operates on the final bound
@@ -3481,6 +3581,161 @@ mod tests {
     fn typecheck_source(src: &str) -> Result<(), FrontendError> {
         let program = parse_program(src)?;
         type_check_program(&program)
+    }
+
+    // FA-02-016 / #1648 corrective: `type_check_function_with_table` accepts
+    // a caller-supplied `FnTable`, so a callee's `FnSig` cannot be assumed
+    // to have been built by the canonical `build_fn_table` authority.
+    // Recursive constraint collection means an undeclared `TypeVar` nested
+    // inside a malformed `params`/`ret` shape would otherwise be silently
+    // "adopted" as this call's generic authority the moment it is
+    // structurally reachable -- exactly the shape the pre-#1648 shallow
+    // first pass could never see, so this was not a reachable gap before
+    // recursion was added. `ensure_typevars_declared` closes it.
+
+    fn generic_callee_and_caller(src: &str) -> (Program, SymbolId, Function) {
+        let program = parse_program(src).expect("parse");
+        let callee_id = *program
+            .arena
+            .symbol_to_id
+            .get("callee")
+            .expect("callee interned");
+        let caller = program
+            .functions
+            .iter()
+            .find(|f| program.arena.try_symbol_name(f.name) == Some("caller"))
+            .expect("caller exists")
+            .clone();
+        (program, callee_id, caller)
+    }
+
+    #[test]
+    fn malformed_fn_sig_undeclared_typevar_nested_in_param_fails_closed() {
+        let (mut program, callee_id, caller) = generic_callee_and_caller(
+            r#"
+                fn callee<T>(a: T) -> T { return a; }
+                fn caller() -> text {
+                    let pair: (i32, text) = (1, "x");
+                    return callee(pair);
+                }
+                fn main() { return; }
+            "#,
+        );
+        let x_sym = program.arena.intern_symbol("X");
+        let mut table = build_fn_table(&program).expect("canonical table builds");
+        let sig = table.get_mut(&callee_id).expect("callee sig present");
+        let t_sym = sig.type_params[0];
+        // type_params = [T]; params = [(T, X)]; X is never declared.
+        sig.params[0] = Type::Tuple(vec![Type::TypeVar(t_sym), Type::TypeVar(x_sym)]);
+        sig.ret = Type::TypeVar(x_sym);
+        let err = type_check_function_with_table(&caller, &program.arena, &table)
+            .expect_err("an undeclared TypeVar nested in a param must not be silently adopted");
+        assert!(
+            err.message.contains('X') && err.message.contains("not declared"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn malformed_fn_sig_undeclared_typevar_in_return_only_fails_closed() {
+        // The undeclared variable appears only in `ret`, never in any
+        // `params` position, so it never participates in constraint
+        // collection at all -- proving ensure_typevars_declared's ret check
+        // is independently required, not merely incidental coverage of the
+        // param check above.
+        let (mut program, callee_id, caller) = generic_callee_and_caller(
+            r#"
+                fn callee<T>(a: T) -> T { return a; }
+                fn caller() -> i32 {
+                    let y = callee(1);
+                    let _ = y;
+                    return 0;
+                }
+                fn main() { return; }
+            "#,
+        );
+        let x_sym = program.arena.intern_symbol("X");
+        let mut table = build_fn_table(&program).expect("canonical table builds");
+        let sig = table.get_mut(&callee_id).expect("callee sig present");
+        // type_params = [T]; params = [T] (honest, so a call still supplies
+        // a real T-binding argument); ret = Option(X); X is never declared
+        // and never appears in params.
+        sig.ret = Type::Option(Box::new(Type::TypeVar(x_sym)));
+        let err = type_check_function_with_table(&caller, &program.arena, &table)
+            .expect_err("an undeclared TypeVar appearing only in the return type must reject");
+        assert!(
+            err.message.contains('X') && err.message.contains("not declared"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn generic_to_generic_delegation_with_shared_opaque_typevar_still_typechecks() {
+        // Preserves the legitimate pattern the corrective checks above must
+        // not break: an *actual* argument type being a bare TypeVar --
+        // including an enclosing generic function's own still-opaque
+        // parameter -- remains a valid binding value, distinct from an
+        // *expected*, declared signature shape referencing an undeclared
+        // TypeVar (malformed FnSig, rejected above). `outer` and `id` both
+        // spell their type parameter `T`; since symbol names are interned
+        // program-wide, this is the same SymbolId in both declarations.
+        let src = r#"
+            fn id<T>(y: T) -> T {
+                return y;
+            }
+            fn outer<T>(x: T) -> T {
+                return id(x);
+            }
+            fn main() {
+                return;
+            }
+        "#;
+        typecheck_source(src).expect(
+            "a generic function delegating to another generic function via its own opaque \
+             parameter must still typecheck",
+        );
+    }
+
+    #[test]
+    fn malformed_fn_sig_undeclared_typevar_in_trait_bound_fails_closed() {
+        // Same ownership gap, third site: a trait bound naming a TypeVar
+        // that isn't one of type_params.
+        let (mut program, callee_id, caller) = generic_callee_and_caller(
+            r#"
+                trait Marker {
+                    fn mark(v: Self) -> i32;
+                }
+                fn callee<T>(a: T) -> T { return a; }
+                fn caller() -> i32 {
+                    let y = callee(1);
+                    let _ = y;
+                    return 0;
+                }
+                fn main() { return; }
+            "#,
+        );
+        let x_sym = program.arena.intern_symbol("X");
+        let marker_sym = *program
+            .arena
+            .symbol_to_id
+            .get("Marker")
+            .expect("Marker interned");
+        let mut table = build_fn_table(&program).expect("canonical table builds");
+        let sig = table.get_mut(&callee_id).expect("callee sig present");
+        // type_params = [T]; trait_bounds = [X: Marker]; X is never declared.
+        sig.trait_bounds = vec![TraitBound {
+            param: x_sym,
+            bound: marker_sym,
+        }];
+        let err = type_check_function_with_table(&caller, &program.arena, &table)
+            .expect_err("a trait bound naming an undeclared type parameter must reject");
+        assert!(
+            err.message.contains('X') && err.message.contains("not declared"),
+            "unexpected error: {}",
+            err.message
+        );
     }
 
     // FA-02-016 / #1648: generic call-site inference and substitution now


### PR DESCRIPTION
SSF-07: #1578

Fixes #1648

## Baseline

Expected `37d9087057b43689b2e8d822771c762d2d404167`. `main` had advanced to `cd57d502f23170b08eecad196f7c78d23ca4779a` (3 commits: `.github/workflows/*.yml` least-privilege token-permission declarations only — confirmed via `git diff --stat`, zero `crates/` changes). Worked from the real current SHA; no re-audit of the live root was needed since the finding is unrelated to CI workflow files.

## Exact pre-fix reproductions

- **A (control).** `fn id<T>(x: T) -> T { ... } let y: i32 = id(1);` — already worked pre-fix (direct `TypeVar` binding).
- **B (`Option(T)`).** `fn identity_via_option<T>(x: Option(T)) -> Option(T) { return x; }` called with `Option(i32)` — pre-fix `Err("cannot infer type for type parameter 'T'... no argument constrains it")`. `Option(T)`'s field is never inspected because `sig.params[0]` isn't *directly* `TypeVar`.
- **C (`Sequence(T)`).** `fn first<T>(xs: Sequence(T)) -> T { return xs[0]; }` — identical pre-fix rejection, same cause.
- **D (Tuple).** `fn tuple_first<T>(pair: (T, i32)) -> T` — identical pre-fix rejection.
- **E (`Result(T, concrete)`).** `fn result_marker<T>(r: Result(T, text)) -> i32` (single function type parameter only, per #1634) — identical pre-fix rejection.

All four reproduced via the exact "no argument constrains it" diagnostic, confirming the failure is specifically the shallow-first-pass gap, not an unrelated parser/runtime issue.

## Current generic-call pipeline (traced before coding)

```
parsed generic Function
→ build_fn_table (FA-02-002/#1634: type_params.len() <= 1, unchanged)
→ FnSig { type_params, trait_bounds, params, ret }  (canonicalized via canonicalize_declared_type_generic, already admits nested TypeVar in declarations)
→ infer_expr_type's Expr::Call arm
  → reorder_call_args → OrderedCallArgs.slots (ABI-bound order, #1722)
  → [generic branch] first pass: per-slot inference → collect_generic_constraints (new)
  → "every declared type parameter must have been bound" check (pre-existing, kept)
  → trait-bound satisfaction check (pre-existing, unchanged — consumes the now-fully-populated subst)
  → subst_apply(params/ret, subst)  (now recursive)
  → second pass: infer_expr_type_with_expected against the now-concrete expected type, exact-equality check (pre-existing, unchanged)
```

`infer_expr_type_with_expected`'s own `Expr::Call` arm delegates to `infer_expr_type` (one call-inference implementation, not two).

## Type-family inventory

| Variant | Classification |
|---|---|
| `TypeVar` | bind/check site |
| `Tuple(Vec<Type>)` | RECURSE (pairwise, arity must match) |
| `Sequence(SequenceType)` | RECURSE (`item`) |
| `Map(MapType)` | RECURSE (`key`, `val` independently) |
| `Option(Box<Type>)` | RECURSE |
| `Result(Box<Type>, Box<Type>)` | RECURSE (both positions) |
| `Closure(ClosureType)` | RECURSE (`param`, `ret`; `family`/`capture` must match) |
| `Measured(Box<Type>, SymbolId)` | RECURSE base only; unit must match exactly |
| `Record(SymbolId)` | NOMINAL LEAF (#1650 boundary — no applied arguments exist to recurse into) |
| `Adt(SymbolId)` | NOMINAL LEAF (same) |
| `Quad`, `Bool`, `Text`, `I32`, `U32`, `Fx`, `F64`, `RangeI32`, `Unit`, `QVec(usize)` | LEAF |

Exhaustive in both `subst_apply` and `collect_generic_constraints` — no `_ => ...` arm, matching the `#1647` discipline.

## Inference helper design

`collect_generic_constraints(expected, actual, arena, subst) -> Result<(), FrontendError>` — new, narrowly owned, recursive. Walks `expected`/`actual` in lockstep; at a `TypeVar(tid)` leaf in `expected`, binds `subst[tid] = actual` if unbound, or checks `existing == actual` if already bound (conflict → `Err`). For every other family, recurses into matching substructure; **a structural shape mismatch (`if let ... = actual` fails) yields no constraint, not an error** — see "Structural mismatch semantics" below. Leaves (`Record`/`Adt`/scalars) never produce a constraint on their own.

## Substitution helper design

`subst_apply` (existing function, rewritten) — the one recursive substitution authority, reused for params, return, and (transitively, since it substitutes the whole `sig.params`/`sig.ret` shapes) everywhere a concrete type is needed. No duplicated ad-hoc substitution was added for any specific family. Workspace-wide search for `substitute`/`subst`/`replace_type_var`/`instantiate`/`monomorph` found only `subst_apply` (generic substitution) and the unrelated `substitute_trait_self_type` (trait/impl `Self` substitution, different ownership, untouched).

## Conflict semantics

- `T = i32` then `T = i32` again → OK (`existing == actual`).
- `T = i32` then `T = Text` → `Err("conflicting generic constraints for type parameter 'T': I32 vs Text")`.
- No "last binding wins", no first-binding silent ignore (the old `if subst.contains_key(tid) { continue; }` — which never checked the *second* binding at all — is removed).
- Nested conflict (`Option(T)` vs `Option(T)` differing) and cross-parameter conflict (`Option(T)` vs `Sequence(T)` differing) both reject through the same mechanism, recursively.

## Structural mismatch semantics

Chosen model: **collect constraints only where shapes align; the existing second-pass parameter-compatibility check remains the final authority.** Proven with a dedicated regression (`generic_call_structural_mismatch_rejects_via_second_pass`): `fn wrap<T>(a: T, b: Option(T))` called with `a` binding `T` directly and `b` passed a `Sequence(i32)` (wrong shape) — `collect_generic_constraints` yields no constraint for `b` (silently, not an error), but the call still deterministically rejects via the unchanged second pass: `"arg 1 for 'wrap' has type Sequence(...), expected Option(I32)"`. No duplicate/disagreeing diagnostic was introduced.

## Direct TypeVar

Unaffected — `generic_call_direct_typevar_still_works` (control) and `generic_call_direct_typevar_conflicting_constraints_reject` (`fn same<T>(a: T, b: T) -> T; same(1, "x")`, #1648's own named reproducer) both pass post-fix.

## Sequence result

`generic_call_infers_and_substitutes_through_sequence` — `first<T>(xs: Sequence(T)) -> T` called with `Sequence(i32)` infers `T = i32` and the call's inferred/returned type is concrete `i32` (proven by the enclosing `let y: i32 = ...` type-check succeeding — a residual `TypeVar(T)` would fail it).

## Option result

`generic_call_infers_and_substitutes_through_option` — same proof shape via `Option(T) -> Option(T)`, `let r: Option(i32) = ...`.

## Tuple result

`generic_call_infers_and_substitutes_through_tuple`, plus the two required repeated-constraint regressions: `generic_call_tuple_repeated_consistent_constraint_succeeds` (`(T,T)` + `(i32,i32)`) and `generic_call_tuple_repeated_conflicting_constraint_rejects` (`(T,T)` + `(i32,text)`).

## Result result

`generic_call_infers_through_result` — `Result(T, text)` infers `T` from the `Ok`-position concrete argument; only one function type parameter used (`Result(T, E)` requiring two was not fabricated, per #1634).

## Map classification/result

RECURSE, both positions independent. No source literal syntax exists for `Map` (only `map_empty()` + `map_set(...)`), so tested as a focused unit test directly on `collect_generic_constraints`/`subst_apply`: `collect_generic_constraints_and_subst_apply_recurse_through_map_both_positions` proves `Map(text, T)`+`Map(text, i32)` → `T=i32` and `Map(T, i32)`+`Map(text, i32)` → `T=text` independently (not two generic variables — the same single `T` exercised in each position separately).

## Closure classification/result

RECURSE, both `param`/`ret` positions (arity/family/capture checked, matching `ClosureValueFamily::UnaryDirect` shape). No corresponding call-site source form exists for a generic closure-typed parameter with a clean enough construction path; tested as a focused unit test: `collect_generic_constraints_and_subst_apply_recurse_through_closure_both_positions`. Type-structure work only — no runtime closure capture/calling semantics touched.

## Measured classification/result

RECURSE base only; **unit identity is preserved exactly, never absorbed into T**. `collect_generic_constraints_and_subst_apply_recurse_through_measured_preserving_unit` proves both: `Measured(T, ms)` + `Measured(i32, ms)` → `T=i32`, unit `ms` preserved; and `Measured(T, ms)` vs `Measured(i32, kg)` (different unit) → **no constraint** (not a coercion, not an error here — left to final compatibility), proving no unit erasure/coercive magic.

## Nominal Record/Adt classification

NOMINAL LEAVES — hard #1650 boundary, explicitly tested: `collect_generic_constraints_treats_record_and_adt_as_nominal_leaves` proves `Record`/`Adt` never recurse (no applied arguments exist to recurse into), while `T` can still bind *to* a `Record`/`Adt` value as an ordinary opaque leaf from a direct `TypeVar` position. No `Record(name, args)`/`Adt(name, args)` representation added; no declaration `type_params` reinterpreted at call sites; no generic record/ADT instantiation implemented.

## Nested return substitution proof

Proven by construction in the Option/Sequence/Tuple end-to-end tests above: each asserts a `let` binding of the fully concrete substituted type (`Option(i32)`, `i32`), which could not type-check if the call's inferred type still contained `TypeVar(T)`.

## No-unresolved-TypeVar / cannot-infer proof

**Corrected from the original PR description** (a reviewer caught this overclaim before merge — see "Corrective commit" below): the invariant is **not** "successful generic call → no `TypeVar` exists in the result." It is narrower and context-dependent:

- **Concrete call context** (the caller is not itself generic, or is calling with a fully resolved argument): every declared callee `TypeVar` must resolve to a fully concrete type. Enforced by the pre-existing "every declared type parameter must have been bound" check (`subst.contains_key(tp)`, unchanged).
- **Generic body-check context**: a declared callee `TypeVar` may legitimately resolve to the *enclosing* generic function's own still-opaque `TypeVar` (see "Design correction" below) — this is not a leak, since nothing downstream treats it as concrete yet.

`generic_call_unused_type_param_cannot_infer` (`fn unused<T>(x: i32) -> i32`, T never appears in params/return) proves the "cannot infer" path still rejects deterministically; this is pre-existing behavior, confirmed unaffected by this slice.

**Separately and unconditionally enforced** (added in the corrective commit, not part of the above): every `TypeVar` a callee's `FnSig` *declares as generic authority* — in `params`, `ret`, and `trait_bounds` — must actually belong to that `FnSig`'s own `type_params`. This is an ownership/well-formedness check on the signature itself, orthogonal to which concrete-or-opaque value a declared parameter resolves to. See "Corrective commit" below.

## Design correction during this slice (documented for transparency)

An earlier version of this change also (a) rejected any `TypeVar` constraint whose value was itself a `TypeVar` of the same symbol ("self-binding"), and (b) added a post-substitution recursive check rejecting any `subst` value that still structurally contained a declared type parameter. Both were removed after empirically verifying (via a temporary probe against the true pre-fix baseline) that they would have **broken a legitimate, already-working pattern**: a generic function delegating to another generic function using its own still-opaque parameter, e.g. `fn outer<T>(x: T) -> T { return id(x); } fn id<T>(y: T) -> T { return y; }`. Because symbol names are interned program-wide, two unrelated declarations both spelled `<T>` share one `SymbolId`; `outer`'s body-check legitimately produces `subst = {T: TypeVar(T)}` for the inner call, and `subst_apply`'s single-pass (non-fixpoint) design means this carries no cyclic/infinite-recursion risk. Confirmed this pattern typechecks identically pre- and post-fix (`Ok(())` both times). No unresolved-TypeVar leak is actually reachable at a genuinely concrete call site, since `env` can only ever carry the *enclosing* function's own type parameter as an opaque value, never a foreign/unrelated one.

## Corrective commit: undeclared nested `TypeVar` on the public `FnTable` boundary

A reviewer found a real blocking gap before merge. `collect_generic_constraints`'s `TypeVar(tid)` case binds whatever `tid` it encounters in `expected`, without checking `tid ∈ sig.type_params`. `build_fn_table`-constructed signatures can never contain such a variable (`canonicalize_declared_type_generic` only ever produces a `TypeVar` within `type_params` scope), but `type_check_function_with_table` accepts a caller-supplied `FnTable` — a deliberately checkable public trust boundary, per the existing `malformed_fn_sig_*` precedent for #1665/#1722. Recursive constraint collection meant an undeclared `TypeVar` nested inside a malformed `params`/`ret` shape would be silently "adopted" as generic authority the moment it became structurally reachable — a gap that did not exist pre-#1648, since the shallow first pass could never see a nested position at all.

Empirically reproduced against the pre-corrective HEAD: a `callee<T>(a: T) -> T` signature hand-mutated (via the same `build_fn_table`-then-mutate pattern the existing malformed-`FnSig` tests use) to `params = [(T, X)]`, `ret = X` (`X` never declared) — called with `(i32, text)` — returned `Ok(())`, with `X` fully resolved to `text` throughout.

**Fix**: new `ensure_typevars_declared(ty, declared, arena)`, an exhaustive recursive helper (same structural families as `collect_generic_constraints`/`subst_apply`) proving every `TypeVar` in a type belongs to `declared`. Called against every `sig.params[i]`, `sig.ret`, and each `sig.trait_bounds[*].param`, unconditionally, at the top of the generic call branch — before any inference runs. The core structural algorithm (`collect_generic_constraints`, `subst_apply`) is untouched, exactly as suggested: this is an additive validation gate, not a change to the inference/substitution model.

New regressions (4):
- `malformed_fn_sig_undeclared_typevar_nested_in_param_fails_closed` — the exact reproducer above, now rejects: `"type variable 'X' is not declared as one of this function's type parameters"`.
- `malformed_fn_sig_undeclared_typevar_in_return_only_fails_closed` — `X` appears *only* in `ret` (never in any `params`), so it never participates in constraint collection at all; proves the `ret` check is independently required, not incidental coverage of the `params` check.
- `malformed_fn_sig_undeclared_typevar_in_trait_bound_fails_closed` — same ownership gap at the third site (`trait_bounds`), proactively closed alongside the two the reviewer named.
- `generic_to_generic_delegation_with_shared_opaque_typevar_still_typechecks` — the boundary the fix must *not* cross: `fn outer<T>(x: T) -> T { return id(x); } fn id<T>(y: T) -> T { return y; }` (an *actual* argument type being a bare, enclosing-function-owned `TypeVar` is a legitimate binding *value*) still typechecks, distinct from an *expected*, declared signature shape referencing an undeclared `TypeVar` (malformed `FnSig`, rejected above).

Pre-fix → post-fix proof: all three ownership-violation regressions temporarily reverted to a no-op (`if false { ... }`) and rerun — all three failed exactly as the vulnerability predicts; the delegation-preservation test passed unaffected, confirming independence. Restored byte-identical; diff verified before qualification.

## Trait-bound behavior

`generic_call_bound_satisfied_through_nested_option` (nested `Option(T)` + `T: Zeroable` + satisfying impl → passes, whole-program test since `type_check_function` has no validated impl context by design, #1649) and `generic_call_bound_missing_through_nested_option_fails_closed` (same shape, no impl → fails closed). Bound checking itself is untouched — it already consumed `subst` after inference; this slice only ensures `subst` is correctly populated when the bound's type parameter is nested inside a compound argument shape.

## Named/default argument audit (#1722/#1665)

Inference operates on `ordered_args.slots[i]` (the canonically bound parameter slot), exactly as before — never source position. New regression `generic_call_inference_uses_bound_parameter_slot_not_source_position`: `fn pick<T>(a: T, b: i32) -> T` called as `pick(b = 2, a = "hello")` (named, reverse source order) correctly infers `T = text` from the bound slot, not the source-written first argument. All 13 pre-existing named/default-argument tests and all 4 malformed-`FnSig` metadata-length regressions rerun green, unmodified.

## #1634 regression

`fn pair<T, U>(...)`, multi-param record, multi-param ADT all still reject — reran the full `build_fn_table`/`build_record_table`/`build_adt_table`/`build_trait_table` arity-check suite (10 tests), all green, unmodified. Owner guards untouched.

## #1649 regression

New `type_check_function_and_type_check_program_agree_on_sequence_generic_declaration` extends the existing #1649 consistency guard to a compound family; both share the exact call-inference code this PR changed, so their admission verdict for a `Sequence(T)` declaration still agrees. All pre-existing #1649 tests rerun green.

## #1650 classification

`#1650 — UNAFFECTED.` No applied nominal type representation added (`Record`/`Adt` remain bare `SymbolId`, no argument list); no source nominal-application syntax; no field/payload monomorphisation. Explicitly tested as a hard boundary above.

## #1717 classification

`#1717 — UNAFFECTED.` Zero changes to `sm-ir`, `passes/`, SemCode lowering, or the VM (diff confined entirely to `crates/sm-front/src/typecheck.rs`). This is frontend call-site type substitution, not IR monomorphisation — a different layer, explicitly distinguished in the new doc comments.

## Fallback/bypass audit

**Corrected from the original PR description**, which claimed "zero matches in production code" — inaccurate. The full diff's production code does contain one `unwrap_or_else`: `subst_apply`'s `Type::TypeVar(id) => subst.get(id).cloned().unwrap_or_else(|| ty.clone())`. This is pre-existing (unchanged from before this PR — `subst_apply` always fell back to the original `TypeVar` when unbound; that half of the function was never rewritten), and it is not the fallback pattern this audit exists to forbid: it's not "unproved metadata → silently ignore → success." Its correctness now depends on the corrective ownership check (below) actually running first — without it, an unbound-and-undeclared `TypeVar` reaching `subst_apply` would render unchanged rather than erroring, which is exactly the class of gap the corrective commit closes at the point where the variable is *collected*, before substitution ever runs. No other forbidden pattern (`if let Ok/Some`, `let ... else`, `Default::default()`, catch-all `match _ =>`, silently-ignored structural mismatch) exists in production code; all other grep matches are `.expect(...)` in test setup, the established convention.

## Stale-comment audit

Rewrote the `subst_apply` doc comment (previously claimed "Only direct TypeVar occurrences are substituted... compound types... are deferred to the monomorphisation pass" — now false) and the inline comment above the generic call branch. Left `type_check_function_with_tables`'s "Body type-check is deferred until Wave 3 monomorphisation" comment untouched — it governs IR-level monomorphisation (#1717, still genuinely deferred and unaffected by this PR), not frontend call-site substitution; body-checking already ran unconditionally for generic functions before this PR (confirmed in the #1649 slice). Also audited and left untouched: `canonicalize_declared_type`'s unrelated "Wave 2" TypeVar-rejection message (non-generic canonicalizer, different code path, not touched here) and an equality-support check's "Wave 2" comment (unrelated to call-site inference).

## Docs

`docs/spec/foundation_source_profile_v1.md` — audited, contains no wording claiming or denying recursive compound generic inference; not touched.

## Qualification

- `cargo check --workspace --all-targets` — clean
- `cargo test -p sm-front` — 559 passed, 0 failed (up from 536; 19 original + 4 corrective)
- `cargo test --test public_api_contracts` — 88 passed, no drift
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed
- `cargo fmt -p sm-front --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Targeted: 43 tests across `build_fn_table`/`build_record_table`/`build_adt_table`/`build_trait_table` arity (#1634), `type_check_function` (#1649), trait-bound generic calls, malformed-`FnSig` (#1665), blanket-impl rejection (#1668) — all green; 13 named/default-argument tests (#1722) — all green
- Workspace-wide `cargo fmt --check` — same pre-existing unrelated Windows path-length OS error, confirmed unchanged

## Changed files

- `crates/sm-front/src/typecheck.rs` (`subst_apply` rewritten; new `collect_generic_constraints`; new `ensure_typevars_declared` (corrective); generic call branch's first pass, ownership-validation gate, and "must be bound" check; 23 new tests total)

## Out of scope

This PR does not implement multi-parameter generics.
This PR does not implement applied generic nominal types (#1650).
This PR does not implement IR monomorphisation (#1717).
This PR does not close #1578.
This PR does not authorize SSF-08.

## Remaining SSF-07 work

#1650, #1717 remain open, classified above. #1578 remains open.

