### PR TITLE
fix(front): reject unrepresentable generic nominal declarations (#1650)

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -1675,10 +1675,11 @@ fn main() {
     // applied nominal type identity (Type::Record/Type::Adt carry no type
     // arguments, and no source application syntax exists), so first-wave
     // Stable Foundation nominal admission requires zero type parameters --
-    // stricter than #1634's "at most one" arity bound, which remains
-    // correct for functions/traits' own generic surface but does not by
-    // itself make a generic record/ADT representable. Raw parser fidelity
-    // is preserved (see generic_record_type_params_are_parsed_and_stored /
+    // stricter than #1634's "at most one" arity bound, which remains the
+    // current first-wave contract for generic functions; traits and impls
+    // already require zero type parameters under their separate
+    // owner-layer contracts (#1635, #1668). Raw parser fidelity is
+    // preserved (see generic_record_type_params_are_parsed_and_stored /
     // generic_enum_type_params_are_parsed_and_stored in parser.rs, both
     // unmodified and still green): only canonical table-construction
     // admission is narrowed, mirroring the #1635 trait precedent.

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -563,18 +563,32 @@ pub fn build_record_table(program: &Program) -> Result<RecordTable, FrontendErro
                 ),
             });
         }
-        // FA-02-002 / #1634: first-wave generic definitions admit at most
-        // one type parameter (see build_fn_table above for the identical
-        // rule and its rationale). The parser has no arity limit, so
-        // admission is enforced here at table-construction time.
-        if record.type_params.len() > 1 {
+        // FA-02-018 / #1650: the current nominal Type representation
+        // (Type::Record(SymbolId)) has no applied type arguments, and no
+        // source syntax exists to write one (parse_type's `Foo`/`Foo(Args)`
+        // dispatch is hardcoded per builtin family -- Option/Result/
+        // Sequence/Map/Closure -- with no general nominal-application rule
+        // for a user-declared name; a bare declared name always parses as
+        // an unparameterized Type::Record). A record declaring type
+        // parameters therefore has no faithful concrete type identity any
+        // use site could ever construct: canonicalize_declared_type (the
+        // non-generic canonicalizer every record-literal/field-access call
+        // site already uses) unconditionally rejects a declaration
+        // TypeVar, so every construction attempt already fails today --
+        // just not at the declaration boundary, and not with an honest
+        // diagnostic. Reject the declaration itself, superseding #1634's
+        // narrower ">1" arity check with this stricter zero-arity contract
+        // (an admitted first-wave generic record is not merely
+        // arity-bounded, it does not exist yet at all), mirroring the
+        // zero-arity precedent #1635 established for traits.
+        if !record.type_params.is_empty() {
             return Err(FrontendError {
                 pos: 0,
                 message: format!(
-                    "record '{}' declares {} type parameters; first-wave generic \
-                     definitions admit at most one",
-                    resolve_symbol_name(&program.arena, record.name)?,
-                    record.type_params.len()
+                    "generic record '{}' is not part of the current Stable Foundation \
+                     nominal type contract because applied record type arguments are \
+                     not representable",
+                    resolve_symbol_name(&program.arena, record.name)?
                 ),
             });
         }
@@ -596,18 +610,21 @@ pub fn build_adt_table(program: &Program) -> Result<AdtTable, FrontendError> {
                 ),
             });
         }
-        // FA-02-002 / #1634: first-wave generic definitions admit at most
-        // one type parameter (see build_fn_table above for the identical
-        // rule and its rationale). The parser has no arity limit, so
-        // admission is enforced here at table-construction time.
-        if adt.type_params.len() > 1 {
+        // FA-02-018 / #1650: identical rationale to build_record_table
+        // above -- Type::Adt(SymbolId) has no applied type arguments, no
+        // source application syntax exists, and canonicalize_declared_type
+        // already unconditionally rejects a payload TypeVar at every
+        // constructor call site, so a generic ADT's declaration is
+        // admitted while every construction already fails. Supersedes
+        // #1634's ">1" check with this stricter zero-arity contract.
+        if !adt.type_params.is_empty() {
             return Err(FrontendError {
                 pos: 0,
                 message: format!(
-                    "enum '{}' declares {} type parameters; first-wave generic \
-                     definitions admit at most one",
-                    resolve_symbol_name(&program.arena, adt.name)?,
-                    adt.type_params.len()
+                    "generic enum '{}' is not part of the current Stable Foundation \
+                     nominal type contract because applied enum type arguments are \
+                     not representable",
+                    resolve_symbol_name(&program.arena, adt.name)?
                 ),
             });
         }
@@ -1654,8 +1671,23 @@ fn main() {
         );
     }
 
+    // FA-02-018 / #1650: generic Record/ADT declarations have no faithful
+    // applied nominal type identity (Type::Record/Type::Adt carry no type
+    // arguments, and no source application syntax exists), so first-wave
+    // Stable Foundation nominal admission requires zero type parameters --
+    // stricter than #1634's "at most one" arity bound, which remains
+    // correct for functions/traits' own generic surface but does not by
+    // itself make a generic record/ADT representable. Raw parser fidelity
+    // is preserved (see generic_record_type_params_are_parsed_and_stored /
+    // generic_enum_type_params_are_parsed_and_stored in parser.rs, both
+    // unmodified and still green): only canonical table-construction
+    // admission is narrowed, mirroring the #1635 trait precedent.
+
     #[test]
-    fn build_record_table_admits_single_type_param() {
+    fn build_record_table_rejects_generic_record_with_single_type_param() {
+        // Central #1650 regression: a single, otherwise first-wave-legal
+        // type parameter is still rejected -- generic record admission is
+        // zero-arity, not merely bounded by #1634's bare arity limit.
         let program = parse_program(
             r#"
                 record Box<T> { value: T }
@@ -1663,7 +1695,19 @@ fn main() {
             "#,
         )
         .expect("parse");
-        build_record_table(&program).expect("single type parameter record must remain admitted");
+        let err = build_record_table(&program)
+            .expect_err("a generic record must not be admitted -- no applied type identity exists");
+        assert!(
+            err.message.contains("Box")
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation")
+                && err
+                    .message
+                    .contains("applied record type arguments are not representable"),
+            "unexpected error: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -1679,15 +1723,17 @@ fn main() {
             .expect_err("a record declaring two type parameters must reject");
         assert!(
             err.message.contains("Pair")
-                && err.message.contains("2 type parameters")
-                && err.message.contains("at most one"),
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation"),
             "unexpected error: {}",
             err.message
         );
     }
 
     #[test]
-    fn build_adt_table_admits_single_type_param() {
+    fn build_adt_table_rejects_generic_adt_with_single_type_param() {
+        // Central #1650 regression, ADT side.
         let program = parse_program(
             r#"
                 enum Maybe<T> { Some(T), None }
@@ -1695,7 +1741,19 @@ fn main() {
             "#,
         )
         .expect("parse");
-        build_adt_table(&program).expect("single type parameter enum must remain admitted");
+        let err = build_adt_table(&program)
+            .expect_err("a generic enum must not be admitted -- no applied type identity exists");
+        assert!(
+            err.message.contains("Maybe")
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation")
+                && err
+                    .message
+                    .contains("applied enum type arguments are not representable"),
+            "unexpected error: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -1711,8 +1769,9 @@ fn main() {
             .expect_err("an enum declaring two type parameters must reject");
         assert!(
             err.message.contains("Either")
-                && err.message.contains("2 type parameters")
-                && err.message.contains("at most one"),
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation"),
             "unexpected error: {}",
             err.message
         );

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -3583,6 +3583,149 @@ mod tests {
         type_check_program(&program)
     }
 
+    // FA-02-018 / #1650: generic record/ADT declarations are rejected at
+    // the canonical owner boundary (build_record_table/build_adt_table),
+    // never merely tolerated until an unrelated later error happens to
+    // catch them. These are whole-program (type_check_program) regressions
+    // complementing the direct build_record_table/build_adt_table unit
+    // tests in lib.rs.
+
+    #[test]
+    fn type_check_program_rejects_generic_record_declaration() {
+        let src = r#"
+            record Box<T> { value: T }
+            fn main() { return; }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("a generic record declaration must not be admitted into Stable Foundation");
+        assert!(
+            err.message.contains("Box")
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation"),
+            "unexpected error: {}",
+            err.message
+        );
+        // Owner-boundary proof: this must be #1650's declaration-admission
+        // diagnostic, not the old accidental construction-time failure
+        // (which never runs, because the declaration is rejected first).
+        assert!(
+            !err.message.contains("deferred to M9.1 Wave 2"),
+            "rejection must come from the owner boundary, not the old accidental \
+             construction-time TypeVar-canonicalization failure: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn type_check_program_rejects_generic_adt_declaration() {
+        let src = r#"
+            enum Maybe<T> { Some(T), None }
+            fn main() { return; }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("a generic enum declaration must not be admitted into Stable Foundation");
+        assert!(
+            err.message.contains("Maybe")
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation"),
+            "unexpected error: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("deferred to M9.1 Wave 2"),
+            "rejection must come from the owner boundary, not the old accidental \
+             construction-time TypeVar-canonicalization failure: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn type_check_program_rejects_generic_record_with_nested_typevar_field() {
+        // The rejection must fire on type_params alone, independent of how
+        // (or whether) T is actually used in field types -- proving it is
+        // the owner-layer declaration check, not something that happens to
+        // trip over a nested TypeVar during field canonicalization.
+        let src = r#"
+            record Box<T> { value: Option(T) }
+            fn main() { return; }
+        "#;
+        let err = typecheck_source(src).expect_err(
+            "a generic record must reject regardless of nested field TypeVar positions",
+        );
+        assert!(
+            err.message.contains("Box")
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn type_check_program_rejects_generic_adt_with_nested_typevar_payload() {
+        let src = r#"
+            enum Wrapper<T> { Boxed(Option(T)) }
+            fn main() { return; }
+        "#;
+        let err = typecheck_source(src).expect_err(
+            "a generic enum must reject regardless of nested payload TypeVar positions",
+        );
+        assert!(
+            err.message.contains("Wrapper")
+                && err
+                    .message
+                    .contains("not part of the current Stable Foundation"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn type_check_program_admits_non_generic_record_and_adt_unaffected() {
+        // Positive control: ordinary non-generic records/ADTs, including
+        // construction, field access, and ADT constructors, remain fully
+        // admitted and unaffected by the #1650 zero-arity nominal
+        // narrowing.
+        let src = r#"
+            record Point { x: i32, y: i32 }
+            enum Color { Red, Green, Blue }
+            fn main() {
+                let p = Point { x: 1, y: 2 };
+                let x: i32 = p.x;
+                let p2 = p with { x: x };
+                let _ = p2;
+                let c = Color::Red;
+                let _ = c;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect(
+            "ordinary non-generic record/ADT declarations and use sites must be unaffected",
+        );
+    }
+
+    #[test]
+    fn generic_record_syntax_still_parses_but_type_check_program_rejects() {
+        // Parser fidelity (Model B precedent from #1635/#1634): raw AST
+        // representation of `<T>` on a record/ADT is deliberately
+        // preserved (see generic_record_type_params_are_parsed_and_stored
+        // in parser.rs, unmodified); only canonical Stable Foundation
+        // admission is narrowed.
+        let program = parse_program(
+            r#"
+                record Box<T> { value: T }
+                fn main() { return; }
+            "#,
+        )
+        .expect("generic record syntax must still parse -- raw AST fidelity is preserved");
+        assert_eq!(program.records[0].type_params.len(), 1);
+        type_check_program(&program)
+            .expect_err("canonical admission must still reject the parsed generic declaration");
+    }
+
     // FA-02-016 / #1648 corrective: `type_check_function_with_table` accepts
     // a caller-supplied `FnTable`, so a callee's `FnSig` cannot be assumed
     // to have been built by the canonical `build_fn_table` authority.

--- a/docs/roadmap/language_maturity/generics_full_scope.md
+++ b/docs/roadmap/language_maturity/generics_full_scope.md
@@ -154,3 +154,27 @@ Before closing this track:
 - [x] spec/docs are synced
 - [x] public API or golden snapshots are updated if needed
 - [x] compatibility/release-facing wording is honest
+
+## Post-Close-Out Correction (SSF-07 #1650)
+
+This track's "completed" status and its "generic record and ADT
+definitions [...] admitted" claim (Included In This Track /
+Initial First-Wave Reading, above) did not hold: `RecordDecl`/`AdtDecl`
+declaration admission existed, but `Type::Record`/`Type::Adt` never gained
+applied type arguments, no source syntax existed to apply them, and every
+record literal / ADT constructor already unconditionally rejected a
+declaration `TypeVar` — so a generic record/ADT declaration was admitted
+while every construction of it already failed, a phase-inconsistent,
+false-ready surface rather than the deterministic first-wave model this
+document's Acceptance Reading requires. Corrected by narrowing canonical
+record/ADT admission to zero type parameters (`build_record_table`/
+`build_adt_table`); see `docs/spec/foundation_source_profile_v1.md` for the
+current normative wording. This entry is left in place as the historical
+record of this track's original scope and self-reported completion state,
+not retroactively edited. The Wave 3 (IR monomorphisation / lowering)
+portion of this track's claimed completion is separately tracked as
+FALSE-READY / INERT-CONTRACT by #1717, which remains open; #1650 addresses
+only the frontend record/ADT declaration-admission and type-identity
+portion of this document's overclaim. Generic *function* definitions and
+call-site instantiation, by contrast, are genuinely closed (#1634, #1648,
+#1649) and this correction does not apply to that portion of the track.

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -319,22 +319,39 @@ directly or nested, exactly like an unknown nominal type. `TraitTable`
 success therefore means both canonical identity is proven *and* the current
 executable/admitted type surface is proven — never identity alone.
 
-First-wave generic-capable definitions — functions, records, and ADTs —
-admit at most one type parameter per definition site; zero is non-generic
-and one is the contracted generic surface. The parser has no arity limit of
-its own (`parse_type_params_with_bounds` may represent `<T, U, ...>` and
-mixed bound combinations like `<T: Bound, U>` as raw AST, and does so
-deliberately, exactly as it does for the generic trait/impl syntax `build_trait_table`/`validate_trait_coherence`
-reject above); admission is enforced at each family's own canonical
-table-construction authority instead (`build_fn_table`, `build_record_table`,
-`build_adt_table`), never by truncating to the first parameter or silently
-admitting the extras. Traits and impls already require zero type parameters
-under the stricter contracts described above, so an out-of-contract arity
-there was already rejected before this boundary existed; it is not a new
-restriction for those two families. Admission of the contracted one-parameter
-form for records/ADTs is a declaration-time fact only — it does not imply a
-faithful applied nominal instantiation path for generic source use, which
-remains a separate, open gap.
+First-wave generic-capable *function* definitions admit at most one type
+parameter per definition site; zero is non-generic and one is the
+contracted generic surface. The parser has no arity limit of its own
+(`parse_type_params_with_bounds` may represent `<T, U, ...>` and mixed
+bound combinations like `<T: Bound, U>` as raw AST, and does so
+deliberately, exactly as it does for the generic trait/impl syntax
+`build_trait_table`/`validate_trait_coherence` reject above); admission is
+enforced at `build_fn_table`, never by truncating to the first parameter or
+silently admitting the extras. Traits and impls already require zero type
+parameters under the stricter contracts described above, so an
+out-of-contract arity there was already rejected before this boundary
+existed; it is not a new restriction for those two families.
+
+Records and ADTs are non-generic in the current Stable Foundation nominal
+type contract: `build_record_table`/`build_adt_table` require
+`type_params.is_empty()`, rejecting any declared type parameter regardless
+of arity. This is stricter than the one-parameter function surface above,
+not an extension of it — `Type::Record(SymbolId)`/`Type::Adt(SymbolId)`
+carry no applied type arguments, no source syntax exists to write one for a
+user-declared nominal name (`parse_type`'s `Foo`/`Foo(Args)` dispatch is
+hardcoded per builtin family — `Option`/`Result`/`Sequence`/`Map`/
+`Closure` — with no general nominal-application rule; a bare declared name
+always parses as an unparameterized `Type::Record`), and every record
+literal / ADT constructor already unconditionally rejects a declaration
+`TypeVar` via the same non-generic canonicalizer ordinary field/payload
+type-checking uses. A generic record/ADT declaration was therefore
+previously admitted while every construction of it already failed — a
+phase-inconsistent, false-ready surface, not a working one. The parser
+still represents `record Box<T> { ... }` / `enum Maybe<T> { ... }` as raw
+AST (mirroring the trait/impl precedent above); only canonical admission is
+narrowed. No applied nominal type representation, source instantiation
+syntax, or field/payload monomorphisation has been implemented — that
+remains a distinct, larger undertaking, not attempted here.
 
 ## Deterministically unsupported forms
 


### PR DESCRIPTION
SSF-07: #1578

Fixes #1650

## Baseline

`817dee91b16c49471cea7ab29909f0a5137e234f` — matched the assignment's expected baseline exactly; confirmed via fresh `origin/main` fetch, isolated worktree from the start.

## Pre-fix Record proof

`record Box<T> { value: T }` alone (no use site) — `type_check_program` → `Ok(())`. Declaration admitted, empirically confirmed via `build_record_table` returning `Ok({..., RecordDecl { type_params: [T], fields: [{ty: TypeVar(T)}] } })`.

`Box { value: 1 }` (construction attempt) — `Err("policy violation: type variable 'T' is not admitted in the executable type-check path yet; generic monomorphisation is deferred to M9.1 Wave 2")`. Every construction already failed, via the non-generic `canonicalize_declared_type`'s unconditional `TypeVar` rejection — an accidental path, not a deliberate boundary, with a stale/misleading diagnostic.

`fn f(x: Box) -> i32` (bare name, no arguments, as a plain type reference) — `Ok(())`. A generic record's bare name is a perfectly valid (if semantically empty) type reference; this is unaffected by and orthogonal to construction.

`fn f(x: Box(i32)) -> i32` (attempted nominal application syntax) — parser error `"expected ')'"` at the position right after `Box`. Confirms zero application grammar exists for a user-declared name.

## Pre-fix ADT proof

`enum Maybe<T> { Some(T), None }` alone — `Ok(())`, declaration admitted (`AdtDecl { type_params: [T], variants: [Some(TypeVar(T)), None] }`).

`Maybe::Some(1)` (constructor invocation) — identical `"deferred to M9.1 Wave 2"` rejection, same cause (`infer_adt_ctor_type` also canonicalizes payload types via the non-generic `canonicalize_declared_type`).

## Current nominal Type representation

`Type::Record(SymbolId)` / `Type::Adt(SymbolId)` — bare nominal identity, no applied type arguments. `Box<i32>` and `Box<text>` both collapse to the identical `Type::Record(box_symbol)`; there is no representation that can distinguish them. `Maybe<i32>` vs `Maybe<text>` likewise both collapse to `Type::Adt(maybe_symbol)`. This is the central identity-collision proof #1650 requires: different semantic instantiations cannot be expressed as distinct `Type` values at all today.

## Current source type grammar

`parse_type` dispatches `Option`/`Result`/`Sequence`/`Map`/`Closure` as **hardcoded, per-name special cases**, each with its own bespoke `(Args)` grammar — there is no general "declared nominal identifier followed by a type-argument list" rule. For any other identifier (including every user-declared record/ADT name), `parse_type` consumes exactly one bare symbol and produces `Type::Record(name)` (or `Type::TypeVar(name)` if the name is in `type_param_scope`); no parenthesized/angle-bracketed continuation is ever considered. Confirmed empirically above (`Box(i32)` → parse error, not a graceful application).

## Declaration-field TypeVar behavior

`value: T` in `record Box<T> { value: T }` parses to `RecordField { ty: TypeVar(T) }` and is stored verbatim in `RecordDecl` (confirmed via direct `build_record_table` inspection). It is never substituted (no instantiation mechanism exists) and never erased at the declaration level — it simply sits there, structurally valid but semantically inert, until a use site (`canonicalize_declared_type` in every record-literal/field-access/ADT-constructor call site) unconditionally rejects it. This is empirically distinct from `#1861`'s finding (`ensure_storage_type_supported`'s broad catch-all in `validate_record_declarations`, a *separate*, later pass) — see "#1861 classification" below.

## Frontend→IR nominal identity audit

Not reached in practice: since every construction site already rejects a generic record/ADT before a value of that type can ever exist, no generic record/ADT value can currently flow to `sm-ir`. `crates/sm-ir/src/legacy_lowering.rs` contains 23 `Type::Record`/`Type::Adt` pattern-match sites, none aware of applied type arguments (there are none to be aware of). Confirms: implementing Model A's frontend representation change would require auditing and likely modifying this lowering layer to remain honest, and #1717 (no IR monomorphisation for even *functions* yet) means there is no monomorphisation machinery to lower distinct record/ADT instantiations to correct, possibly-differently-laid-out concrete SemCode — Model A would either be untruthful at the frontend/IR boundary or require #1717-scale work.

## Blast-radius inventory

Workspace-wide `Type::Record`/`Type::Adt` pattern-match sites: 119 total — `sm-front/src/typecheck.rs` (59), `sm-ir/src/legacy_lowering.rs` (23), `sm-front/src/lib.rs` (15), `sm-front/src/parser.rs` (12), `smc-cli` (4 files, 7 sites), `sm-sema/src/std_adapters.rs` (2). Changing `Type::Record`/`Type::Adt`'s shape (e.g. to `Record(SymbolId, Vec<Type>)`) would require reviewing every one of these sites for correctness, not merely recompiling — a scope far beyond "narrow enough for one repair slice."

## Architecture decision: Model B

**MODEL B — CONTRACT NARROWING.**

Evaluated against the task's Model-A criteria, all of which must hold and none do cleanly:
1. *Clearly part of the current Stable Foundation promise* — NO. `docs/spec/foundation_source_profile_v1.md`'s "Experimental but currently accepted extensions" section already lists "broad generics... beyond direct-record `Iterable`" as explicitly experimental, not a Foundation Source 1.2 compatibility promise.
2. *Existing or naturally bounded source syntax* — NO, empirically disproven above (hardcoded per-builtin dispatch, zero general rule, `Box(i32)` is a raw parse error).
3. *Narrow enough for one repair slice* — NO, given the 119-site blast radius and the IR-lowering audit above.
4–6. *Preserves identity end-to-end / no #1717-scale IR work / no half-applied representation lowering can't classify* — all fail together: without #1717-scale monomorphisation, any frontend-only applied-nominal representation would be a half-applied representation lowering cannot honestly classify.

## Rejected alternative and why

Model A was seriously evaluated (see the above six-point failure) before this decision, not dismissed on diff size alone, per the task's explicit instruction. The evidence — no promised contract, no existing syntax, 119-site blast radius reaching into IR lowering, and #1717's still-open monomorphisation gap — makes Model A untruthful within this slice's scope. Model B is the architecture the repository has already established for exactly this situation (#1635 for generic traits, #1634/#1648/#1649 corrective for generic function arity/inference/trust-boundary): reject deterministically at the canonical owner boundary rather than ship a partially-represented feature.

## Exact Stable Foundation invariant

```
RecordDecl.type_params.is_empty()
AdtDecl.type_params.is_empty()
```

required for canonical Stable Foundation admission (`build_record_table`/`build_adt_table`). This **supersedes**, rather than sits alongside, #1634's "at most one" arity bound for these two families specifically — a declared type parameter (arity exactly 1, which #1634 alone would admit) is now also rejected, because arity-boundedness alone does not make a generic record/ADT representable.

## Record behavior

`record Box<T> { value: T }` → `build_record_table` rejects: `"generic record 'Box' is not part of the current Stable Foundation nominal type contract because applied record type arguments are not representable"`. Rejection is on `type_params` alone, independent of how (or whether) T is used in any field — proven with a nested-field-position regression (`value: Option(T)`) that rejects identically. `record User { ... }` (non-generic) — fully unaffected: declaration, literal construction, field access, and `with`-update all continue to typecheck.

## ADT behavior

`enum Maybe<T> { Some(T), None }` → `build_adt_table` rejects with the enum-specific equivalent message. Nested payload position (`enum Wrapper<T> { Boxed(Option(T)) }`) rejects identically. `enum Color { Red, Green, Blue }` (non-generic) — fully unaffected: declaration and constructor use continue to typecheck.

## Parser behavior

Unchanged. `record Box<T> { ... }` / `enum Maybe<T> { ... }` still parse successfully, preserving `type_params` in the raw AST (confirmed: the pre-existing `generic_record_type_params_are_parsed_and_stored`/`generic_enum_type_params_are_parsed_and_stored` parser tests rerun green, unmodified) — only canonical table-construction admission (`build_record_table`/`build_adt_table`) rejects. Mirrors the #1635 trait precedent exactly.

## Type identity behavior

Unchanged (Model B makes no representation change) — `Type::Record(SymbolId)`/`Type::Adt(SymbolId)` remain exactly as before. No identity-collision fix was attempted; the collision is avoided instead by never admitting the declarations that would need it.

## Field/payload substitution behavior

N/A under Model B — no substitution mechanism was implemented or attempted, since the declarations requiring it are now rejected before any field/payload type is ever consulted for construction.

## Generic-function interaction

N/A — #1648's structural generic-call inference is untouched; `Record`/`Adt` remain nominal leaves in `collect_generic_constraints`/`subst_apply`/`ensure_typevars_declared`, exactly as #1648 established, since this PR makes no `Type` representation change (their exhaustive matches needed no update).

## #1634 classification

Superseded (for records/ADTs only) rather than reopened or weakened. The existing `>1`-arity check in `build_record_table`/`build_adt_table` is replaced by the strictly stronger `!type_params.is_empty()` check — every case the old check rejected, the new one still rejects, plus the arity-1 case the old check admitted. #1634's own arity bound for *functions* (`build_fn_table`, still `>1`) is completely untouched. All #1634 tests rerun green (existing two-param tests updated only to match the new diagnostic wording, not weakened; two tests renamed from `_admits_single_type_param` to `_rejects_generic_..._with_single_type_param` since that is now the correct, central #1650 regression).

## #1648 classification

UNAFFECTED. No `Type` variant or shape changed; `Record`/`Adt` remain nominal leaves exactly as #1648 left them. All #1648 regressions (recursive inference, conflict detection, the `ensure_typevars_declared` corrective trust-boundary fix, generic-to-generic delegation) rerun green, unmodified.

## #1667/#1669 classification

UNAFFECTED. Canonical nominal resolution (`canonicalize_declared_type_generic`'s record-vs-ADT-vs-ambiguous-vs-unknown resolution) is untouched; this PR adds a check *before* any of that machinery runs for a generic declaration, never a second resolution path. All `build_trait_table`/impl-conformance regressions rerun green.

## #1717 classification

UNAFFECTED; IR monomorphisation gap remains open. Zero changes to `sm-ir`, `passes/`, SemCode lowering, or the VM. `sm-ir` test suite (121 tests) rerun green, unmodified — confirms zero impact, since no generic record/ADT value could ever have reached lowering even before this fix (construction already failed at every use site).

## #1861 classification

`#1861` — narrowed for one specific manifestation, not closed, and not touched. `ensure_storage_type_supported`'s broad catch-all (the actual target of #1861) lives in `validate_record_declarations`, a pass that runs *after* `build_record_table` in `type_check_program`. Since `build_record_table` now rejects any record with `type_params` before `validate_record_declarations` ever sees it, the specific cross-boundary scenario #1861 names (`unsupported field type → record declaration admitted → ...`) is now unreachable **for the generic-TypeVar-in-a-generic-record case specifically**, as an incidental side effect of this PR — not because `ensure_storage_type_supported` was touched. #1861's core finding (the broad catch-all itself, covering *any* unsupported/reserved `Type` family in a *non-generic* record/ADT's fields) remains fully open and is not addressed here; `ensure_storage_type_supported` was not modified.

## Public API impact

None. `Type` enum unchanged (0 variants added/modified); no public function signature changed. `public_api_contracts` golden-snapshot suite (88 tests) passed unchanged, confirming this directly.

## Fallback/bypass audit

Grepped the full diff for `unwrap_or*`, `or_else`, `if let Ok/Some`, `let Ok/Some ... else`, `Default::default()`, `.unwrap()`, `.expect()`, `first()`, `truncate`, `clear()`, `Vec::new()`, catch-all `match _ =>`. Zero matches in production code. The two new checks are plain `if !type_params.is_empty() { return Err(...) }` — no truncation, no silent erasure of `type_params`, no fallback to treating the declaration as non-generic. All `.expect(...)` matches are in test setup, the established convention.

## Pre-fix → post-fix proof

All 7 new central regressions — `build_record_table_rejects_generic_record_with_single_type_param`, `build_adt_table_rejects_generic_adt_with_single_type_param`, the four `type_check_program`-level end-to-end tests (`type_check_program_rejects_generic_record_declaration`, `type_check_program_rejects_generic_adt_declaration`, `type_check_program_rejects_generic_record_with_nested_typevar_field`, `type_check_program_rejects_generic_adt_with_nested_typevar_payload`), and `generic_record_syntax_still_parses_but_type_check_program_rejects` (the parser-fidelity test, which also asserts `type_check_program` rejection) — temporarily reverted to the exact original `#1634 "> 1"` condition and rerun: all 7 failed exactly as the pre-fix bug predicts, with concrete evidence (`RecordDecl { type_params: [T], ... }`/`AdtDecl { type_params: [T], ... }` successfully stored). Restored byte-identical; diff verified before final qualification.

## Docs

`docs/spec/foundation_source_profile_v1.md`: corrected the #1634-era paragraph that stated records/ADTs "admit at most one type parameter" (now false); replaced with the accurate zero-arity nominal contract and the reasoning above. `docs/roadmap/language_maturity/generics_full_scope.md`: this document's self-reported "Status: completed" and "generic record and ADT definitions [...] admitted" claim was found false by this audit — a corrective addendum was appended (the original historical record is left in place, not retroactively edited) stating the record/ADT portion of the claim did not hold, distinguishing it from #1717's separate, still-open IR-monomorphisation overclaim about the same document, and explicitly noting generic *functions* (#1634/#1648/#1649) are genuinely closed and unaffected by this correction.

**Corrective commit `7cbe2eee`** (comment-only, zero production logic changed): a reviewer caught one inaccurate claim in the new `lib.rs` test-comment block — it said #1634's "at most one" arity bound "remains correct for functions/traits' own generic surface," which is wrong for traits (#1635 already tightened trait declarations to zero type parameters; #1668 does the same for impls). Function generics are the only surface #1634's "at most one" bound still governs. The normative `foundation_source_profile_v1.md` wording in this same PR already stated this correctly — only the inline test comment was wrong. Also corrected in this pass: the "Pre-fix → post-fix proof" section above previously said "7 failed" while naming only 6 tests; the 7th (`generic_record_syntax_still_parses_but_type_check_program_rejects`) is now named explicitly.

## Qualification

- `cargo check --workspace --all-targets` — clean
- `cargo test -p sm-front` — 565 passed, 0 failed (up from 559; 4 renamed/updated + 6 new)
- `cargo test -p sm-ir` — 121 passed, 0 failed, unmodified
- `cargo test --test public_api_contracts` — 88 passed, no drift
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed
- `cargo fmt -p sm-front --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Targeted: 63 tests across record/ADT tables, generic arity (#1634), recursive generic inference + trust-boundary corrective (#1648), single-function canonical FnSig (#1649), nominal Record/Adt resolution (#1667/#1669), generic-bound calls — all green
- Workspace-wide `cargo fmt --check` — same pre-existing unrelated Windows path-length OS error, confirmed unchanged

## Changed files

- `crates/sm-front/src/lib.rs` (`build_record_table`/`build_adt_table` zero-arity check; 4 tests updated/renamed)
- `crates/sm-front/src/typecheck.rs` (6 new end-to-end regressions)
- `docs/spec/foundation_source_profile_v1.md` (corrected #1634-era paragraph)
- `docs/roadmap/language_maturity/generics_full_scope.md` (corrective addendum)

## Out of scope

This PR does not implement multi-parameter generics.
This PR does not implement generic impls.
This PR does not claim IR monomorphisation complete (#1717).
This PR does not close #1578.
This PR does not authorize SSF-08.

This PR deliberately narrows the current Stable Foundation contract rather than representing generic nominal type arguments incompletely.

## Remaining SSF-07 work

#1717 remains open (IR monomorphisation). #1861 remains open (its core finding, unaffected by the narrow side-effect noted above). #1578 remains open.

