### PR TITLE
security(hub): prevent cleartext exposure of sensitive audit correlation metadata (#1866)

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,56 +1,25 @@
 task:
-  id: SEMANTIC-STABLE-FOUNDATION-SSF-07
-  title: "language: close or bound numeric/text/collection/closure/generic/trait/pattern abstractions"
-  type: type_and_abstraction_closure_contract_qualification_and_bounded_implementation
+  id: SECURITY-MAINT-1866-HUB-AUDIT-CONFIDENTIALITY
+  title: "security(hub): prevent cleartext exposure of sensitive audit correlation metadata"
+  type: security_maintenance_hub_audit_confidentiality
   mode: active
-  supersedes: SEMANTIC-STABLE-FOUNDATION-SSF-06
   authorized_by: >-
-    Repository owner direct instruction (chat, 2026-08-08) to execute GitHub
-    umbrella #1569 continuously in strict SSF-00 through SSF-12 dependency
-    order. SSF-06 closed through PR #1597 at merge commit
-    92be6c0412140a3547cdd9627e0f9a8971965855, after an eleven-pass repair cycle
-    documented in issue #1598 (Decision Log DL-009 through DL-023); only
-    SSF-07 is now active.
+    Repository owner direct authorization for Issue #1866 (2026-08-31):
+    temporary out-of-band R3 security maintenance. This envelope does not
+    supersede the normal SSF-07 development task.
 
 intent:
   summary: >-
-    Read SSF-00...06 outputs and build a gap table only for abstractions
-    already selected by the frozen Stable Foundation target; separate
-    contract gaps from implementation bugs. Freeze numeric overflow/
-    conversion policy, UTF-8 text semantics, collection equality/ordering/
-    mutability, first-wave closure capture semantics, generic/trait
-    monomorphisation and coherence, and pattern alignment across the
-    parser/typechecker/exhaustiveness/lowering/ownership/diagnostics
-    pipeline, each before implementing it. Add positive end-to-end tests and
-    deterministic negative cases for every included abstraction; give every
-    deferred form an explicit non-goal and a deterministic rejection
-    diagnostic instead of leaving it silently unsupported.
+    Define and enforce a safe default presentation contract for smc hub audit
+    without changing persisted audit/provenance records, deterministic request
+    lookup, Hub admission, capabilities, storage, or other Hub semantics.
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - README.md
-    - CHANGELOG.md
-    - docs/LANGUAGE.md
-    - docs/examples_index.md
-    - docs/getting_started.md
-    - docs/spec/**
-    - docs/status/feature_maturity_matrix.md
-    - docs/roadmap/public_maturity_snapshot.md
-    - docs/roadmap/public_status_model.md
-    - docs/roadmap/v1_readiness.md
-    - docs/roadmap/stable_foundation/**
-    - examples/canonical/**
-    - examples/qualification/**
-    - tests/**
-    - crates/sm-format/**
-    - crates/sm-front/**
-    - crates/sm-sema/**
-    - crates/sm-ir/**
-    - crates/sm-emit/**
-    - crates/sm-verify/**
-    - crates/sm-vm/**
     - crates/smc-cli/**
+    - tests/**
+    - docs/spec/hub/**
 
   forbidden_paths:
     - .github/**
@@ -59,10 +28,11 @@ scope:
     - src/**
     - third_party/**
     - ton618_legacy/**
+    - crates/semantic-hub/**
 
 authorization:
   rust_implementation: true
-  language_implementation: true
+  language_implementation: false
   documentation_addition: true
   documentation_correction: true
   test_addition: true
@@ -70,35 +40,17 @@ authorization:
   dependency_changes: false
   github_issue_lifecycle: true
   git_commit_push_pr: true
-  merge_after_review_and_checks: true
+  merge_after_review_and_checks: false
   stable_promotion: false
 
 constraints:
-  one_active_ssf_phase: true
-  active_phase: SSF-07
-  issue: 1578
-  umbrella_issue: 1569
+  issue: 1866
   base_branch: main
   one_logical_change_per_pr: true
   evidence_before_claims: true
   current_main_is_not_stable: true
-  gap_table_scoped_to_already_selected_abstractions_only: true
-  contract_gaps_separated_from_implementation_bugs: true
-  no_new_abstraction_added_merely_because_convenient: true
-  numeric_overflow_and_conversion_policy_frozen_before_implementation: true
-  text_utf8_semantics_frozen_before_implementation: true
-  collections_equality_ordering_mutability_iteration_frozen_before_implementation: true
-  closures_first_wave_capture_and_invocation_semantics_frozen_before_implementation: true
-  generics_traits_deterministic_monomorphisation_and_coherence_required: true
-  patterns_aligned_across_parser_typechecker_exhaustiveness_lowering_ownership_diagnostics: true
-  positive_and_deterministic_negative_tests_required_per_included_abstraction: true
-  deferred_forms_have_explicit_non_goals_and_deterministic_rejection: true
-  no_global_refactor_unless_invariant_cannot_be_preserved_otherwise: true
-  no_stable_abstraction_depends_on_unstable_internal_crate_apis: true
-  no_async_await: true
-  no_broad_dynamic_dispatch_or_reflection: true
-  no_macro_system: true
-  no_gc_object_runtime: true
-  no_systems_language_claims_beyond_evidence: true
-  no_stable_release_claim: true
-  no_historical_document_rewrite: true
+  preserve_persisted_audit_and_provenance: true
+  preserve_deterministic_request_lookup: true
+  no_raw_output_fallback_or_compatibility_path: true
+  no_codeql_suppression_or_dismissal: true
+  restore_ssf_07_harness_before_pr: true

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,7 +1,7 @@
 task:
   id: SECURITY-MAINT-1866-HUB-AUDIT-CONFIDENTIALITY
-  title: "security(hub): prevent cleartext exposure of sensitive audit correlation metadata"
-  type: security_maintenance_hub_audit_confidentiality
+  title: "security(hub): prevent cleartext exposure of sensitive Hub CLI metadata"
+  type: security_maintenance_hub_cli_confidentiality
   mode: active
   authorized_by: >-
     Repository owner direct authorization for Issue #1866 (2026-08-31):
@@ -10,9 +10,10 @@ task:
 
 intent:
   summary: >-
-    Define and enforce a safe default presentation contract for smc hub audit
-    without changing persisted audit/provenance records, deterministic request
-    lookup, Hub admission, capabilities, storage, or other Hub semantics.
+    Define and enforce safe default presentation contracts for smc hub audit
+    and smc hub session without changing persisted audit/provenance records,
+    deterministic request lookup, Hub admission, capabilities, storage, or
+    other Hub semantics.
 
 scope:
   allowed_paths:
@@ -53,4 +54,5 @@ constraints:
   preserve_deterministic_request_lookup: true
   no_raw_output_fallback_or_compatibility_path: true
   no_codeql_suppression_or_dismissal: true
+  no_raw_session_or_caller_cli_presentation: true
   restore_ssf_07_harness_before_pr: true

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,26 +1,56 @@
 task:
-  id: SECURITY-MAINT-1866-HUB-AUDIT-CONFIDENTIALITY
-  title: "security(hub): prevent cleartext exposure of sensitive Hub CLI metadata"
-  type: security_maintenance_hub_cli_confidentiality
+  id: SEMANTIC-STABLE-FOUNDATION-SSF-07
+  title: "language: close or bound numeric/text/collection/closure/generic/trait/pattern abstractions"
+  type: type_and_abstraction_closure_contract_qualification_and_bounded_implementation
   mode: active
+  supersedes: SEMANTIC-STABLE-FOUNDATION-SSF-06
   authorized_by: >-
-    Repository owner direct authorization for Issue #1866 (2026-08-31):
-    temporary out-of-band R3 security maintenance. This envelope does not
-    supersede the normal SSF-07 development task.
+    Repository owner direct instruction (chat, 2026-08-08) to execute GitHub
+    umbrella #1569 continuously in strict SSF-00 through SSF-12 dependency
+    order. SSF-06 closed through PR #1597 at merge commit
+    92be6c0412140a3547cdd9627e0f9a8971965855, after an eleven-pass repair cycle
+    documented in issue #1598 (Decision Log DL-009 through DL-023); only
+    SSF-07 is now active.
 
 intent:
   summary: >-
-    Define and enforce safe default presentation contracts for smc hub audit
-    and smc hub session without changing persisted audit/provenance records,
-    deterministic request lookup, Hub admission, capabilities, storage, or
-    other Hub semantics.
+    Read SSF-00...06 outputs and build a gap table only for abstractions
+    already selected by the frozen Stable Foundation target; separate
+    contract gaps from implementation bugs. Freeze numeric overflow/
+    conversion policy, UTF-8 text semantics, collection equality/ordering/
+    mutability, first-wave closure capture semantics, generic/trait
+    monomorphisation and coherence, and pattern alignment across the
+    parser/typechecker/exhaustiveness/lowering/ownership/diagnostics
+    pipeline, each before implementing it. Add positive end-to-end tests and
+    deterministic negative cases for every included abstraction; give every
+    deferred form an explicit non-goal and a deterministic rejection
+    diagnostic instead of leaving it silently unsupported.
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - crates/smc-cli/**
+    - README.md
+    - CHANGELOG.md
+    - docs/LANGUAGE.md
+    - docs/examples_index.md
+    - docs/getting_started.md
+    - docs/spec/**
+    - docs/status/feature_maturity_matrix.md
+    - docs/roadmap/public_maturity_snapshot.md
+    - docs/roadmap/public_status_model.md
+    - docs/roadmap/v1_readiness.md
+    - docs/roadmap/stable_foundation/**
+    - examples/canonical/**
+    - examples/qualification/**
     - tests/**
-    - docs/spec/hub/**
+    - crates/sm-format/**
+    - crates/sm-front/**
+    - crates/sm-sema/**
+    - crates/sm-ir/**
+    - crates/sm-emit/**
+    - crates/sm-verify/**
+    - crates/sm-vm/**
+    - crates/smc-cli/**
 
   forbidden_paths:
     - .github/**
@@ -29,11 +59,10 @@ scope:
     - src/**
     - third_party/**
     - ton618_legacy/**
-    - crates/semantic-hub/**
 
 authorization:
   rust_implementation: true
-  language_implementation: false
+  language_implementation: true
   documentation_addition: true
   documentation_correction: true
   test_addition: true
@@ -41,18 +70,35 @@ authorization:
   dependency_changes: false
   github_issue_lifecycle: true
   git_commit_push_pr: true
-  merge_after_review_and_checks: false
+  merge_after_review_and_checks: true
   stable_promotion: false
 
 constraints:
-  issue: 1866
+  one_active_ssf_phase: true
+  active_phase: SSF-07
+  issue: 1578
+  umbrella_issue: 1569
   base_branch: main
   one_logical_change_per_pr: true
   evidence_before_claims: true
   current_main_is_not_stable: true
-  preserve_persisted_audit_and_provenance: true
-  preserve_deterministic_request_lookup: true
-  no_raw_output_fallback_or_compatibility_path: true
-  no_codeql_suppression_or_dismissal: true
-  no_raw_session_or_caller_cli_presentation: true
-  restore_ssf_07_harness_before_pr: true
+  gap_table_scoped_to_already_selected_abstractions_only: true
+  contract_gaps_separated_from_implementation_bugs: true
+  no_new_abstraction_added_merely_because_convenient: true
+  numeric_overflow_and_conversion_policy_frozen_before_implementation: true
+  text_utf8_semantics_frozen_before_implementation: true
+  collections_equality_ordering_mutability_iteration_frozen_before_implementation: true
+  closures_first_wave_capture_and_invocation_semantics_frozen_before_implementation: true
+  generics_traits_deterministic_monomorphisation_and_coherence_required: true
+  patterns_aligned_across_parser_typechecker_exhaustiveness_lowering_ownership_diagnostics: true
+  positive_and_deterministic_negative_tests_required_per_included_abstraction: true
+  deferred_forms_have_explicit_non_goals_and_deterministic_rejection: true
+  no_global_refactor_unless_invariant_cannot_be_preserved_otherwise: true
+  no_stable_abstraction_depends_on_unstable_internal_crate_apis: true
+  no_async_await: true
+  no_broad_dynamic_dispatch_or_reflection: true
+  no_macro_system: true
+  no_gc_object_runtime: true
+  no_systems_language_claims_beyond_evidence: true
+  no_stable_release_claim: true
+  no_historical_document_rewrite: true

--- a/crates/smc-cli/src/hub.rs
+++ b/crates/smc-cli/src/hub.rs
@@ -1016,10 +1016,9 @@ fn cmd_hub_session(args: &[String]) -> Result<(), String> {
         };
         match &session_caller {
             Some(caller) if caller != &request.caller_identity => {
-                return Err(format!(
-                "InputRejected: session requests use multiple caller identities ('{}' and '{}')",
-                caller, request.caller_identity
-            ))
+                return Err(
+                    "InputRejected: session requests use multiple caller identities".to_string(),
+                )
             }
             None => session_caller = Some(request.caller_identity.clone()),
             _ => {}
@@ -1161,8 +1160,6 @@ fn cmd_hub_session(args: &[String]) -> Result<(), String> {
     let summary = session.summary();
     let summary_json = serde_json::json!({
         "session_summary": {
-            "session_id": summary.session_id.as_str(),
-            "caller_identity": summary.caller_identity.as_str(),
             "capability_ceiling": summary.capability_ceiling.iter().map(|cap| cap.as_str()).collect::<Vec<_>>(),
             "privacy_ceiling": summary.privacy_ceiling.to_string(),
             "requests_submitted": summary.requests_submitted,
@@ -1331,18 +1328,16 @@ fn cmd_hub_audit(args: &[String]) -> Result<(), String> {
     };
 
     println!("request_id: {}", record.request_id);
-    println!("session_id: {}", record.session_id);
-    println!("caller_identity: {}", record.caller_identity);
     println!("tool_id: {}", record.tool_id);
     println!("tool_version: {}", record.tool_version);
-    println!("adapter_provenance: {}", record.adapter_provenance);
+    println!("adapter_provenance: <redacted>");
     println!("operation_id: {}", record.operation_id);
     println!("execution_mode: {}", record.execution_mode);
     println!("determinism: {}", record.determinism);
     println!("trust_class: {}", record.trust_class);
     println!("privacy_class: {}", record.privacy_class);
-    println!("input_digest: {}", record.input_digest);
-    println!("output_digest: {}", record.output_digest);
+    println!("input_digest: <redacted>");
+    println!("output_digest: <redacted>");
     println!("worker_state_after: {}", record.worker_state_after);
     println!("status: {}", record.status_code);
     println!("fault_code: {}", record.fault_code.unwrap_or("-"));

--- a/docs/spec/hub/hub_audit_presentation_v0.md
+++ b/docs/spec/hub/hub_audit_presentation_v0.md
@@ -9,8 +9,10 @@ export of the canonical audit record.
 
 The persisted audit format remains defined by
 [`hub_api_v0.md`](hub_api_v0.md#10-canonical-audit-encoding). In particular,
-the record retains its request, session, and caller fields for provenance and
-lookup. Default stdout deliberately does not disclose those fields.
+the record retains its request, session, and caller fields for provenance.
+`request_id` remains the public deterministic lookup handle and is emitted
+verbatim by default audit output. Raw `session_id` and `caller_identity` are
+not disclosed by the presentation layer.
 
 ## Field classification
 
@@ -49,7 +51,9 @@ without receiving a raw session or caller value.
 ## Boundary
 
 The command is for default human inspection of tool, operation, execution,
-classification, worker, and outcome data. It must not expose audit correlation
-handles, caller identity, unbounded adapter text, or weak content-correlation
-fingerprints. Callers retain the request ID supplied to the command and can
-repeat the same deterministic lookup without the audit response echoing it.
+classification, worker, and outcome data. It must not expose raw session
+correlation handles, caller identity, unbounded adapter text, or weak
+content-correlation fingerprints. The validated `request_id` remains the
+public lookup/correlation handle and may be echoed verbatim. Callers retain
+the request ID supplied to the command; the audit response may echo that same
+validated public handle, and it can be reused for deterministic lookup.

--- a/docs/spec/hub/hub_audit_presentation_v0.md
+++ b/docs/spec/hub/hub_audit_presentation_v0.md
@@ -1,0 +1,55 @@
+# Hub CLI metadata presentation v0
+
+Status: current `smc hub audit` default-output contract
+
+`smc hub audit --request <request-id>` accepts the original, validated
+`HubRequestId` and uses it to find one persisted `HubAuditRecord`. This lookup
+is deterministic. The CLI presents a human-readable summary; it is not an
+export of the canonical audit record.
+
+The persisted audit format remains defined by
+[`hub_api_v0.md`](hub_api_v0.md#10-canonical-audit-encoding). In particular,
+the record retains its request, session, and caller fields for provenance and
+lookup. Default stdout deliberately does not disclose those fields.
+
+## Field classification
+
+| Field | Persisted audit | Lookup | Default stdout classification | Evidence |
+| --- | --- | --- | --- | --- |
+| `request_id` | required | required input | `SAFE_VERBATIM` | `HubAuditRecord` and canonical field 2 retain it; the CLI accepts it for lookup and the public audit response echoes it. |
+| `session_id` | required | no | `SENSITIVE_OMIT` | Canonical field 3 is a correlation handle. |
+| `caller_identity` | required | no | `SENSITIVE_OMIT` | Canonical field 4 identifies the issuing component or user. |
+| `tool_id` | required | no | `SAFE_VERBATIM` | Validated tool identifier and required human inspection context. |
+| `tool_version` | required | no | `SAFE_VERBATIM` | Registered descriptor version. |
+| `adapter_provenance` | required | no | `SENSITIVE_REDACT` | Canonical field 7 is free text, not a closed public vocabulary. |
+| `operation_id` | required | no | `SAFE_VERBATIM` | Validated operation identifier and required inspection context. |
+| `execution_mode` | required | no | `SAFE_VERBATIM` | Closed `HubExecutionMode` vocabulary. |
+| `determinism` | required | no | `SAFE_VERBATIM` | Closed determinism-class vocabulary. |
+| `trust_class` | required | no | `SAFE_VERBATIM` | Closed trust-class vocabulary. |
+| `privacy_class` | required | no | `SAFE_VERBATIM` | Closed privacy-class vocabulary; communicates handling classification. |
+| `input_digest` | required | no | `SENSITIVE_REDACT` | A non-cryptographic correlation fingerprint with byte length. |
+| `output_digest` | required | no | `SENSITIVE_REDACT` | A non-cryptographic correlation fingerprint with byte length. |
+| `worker_state_after` | required | no | `SAFE_VERBATIM` | Closed worker-state vocabulary. |
+| `status` | required | no | `SAFE_VERBATIM` | Closed reply-status vocabulary. |
+| `fault_code` | required | no | `SAFE_VERBATIM` | Closed fault-code vocabulary or `-`. |
+
+`SENSITIVE_REDACT` renders the literal `<redacted>`. `SENSITIVE_OMIT` emits
+no line. The presentation contract defines no raw-output flag, alternate JSON
+mode, environment switch, stderr route, logging route, or compatibility path.
+
+## Session summary presentation
+
+`HubSessionSummary` retains raw `session_id` and `caller_identity` internally
+for session validation and provenance. The external `smc hub session` NDJSON
+`session_summary` is a separate presentation object: it omits both fields.
+Per-request reply objects retain their public `request_id`, so a consumer can
+correlate every result and later use that value for `smc hub audit --request`
+without receiving a raw session or caller value.
+
+## Boundary
+
+The command is for default human inspection of tool, operation, execution,
+classification, worker, and outcome data. It must not expose audit correlation
+handles, caller identity, unbounded adapter text, or weak content-correlation
+fingerprints. Callers retain the request ID supplied to the command and can
+repeat the same deterministic lookup without the audit response echoing it.

--- a/docs/spec/hub/hub_session_v0.md
+++ b/docs/spec/hub/hub_session_v0.md
@@ -103,7 +103,7 @@ resource_usage field is Some(n) -> cumulative += n (saturating, never
                                     silently wrapping)
 ```
 
-`HubSessionSummary` (from `HubSession::summary()`) reports:
+The internal `HubSessionSummary` (from `HubSession::summary()`) reports:
 
 ```text
 session_id, caller_identity, capability_ceiling, privacy_ceiling, ceiling
@@ -197,7 +197,6 @@ in submission order (the same shape `smc hub invoke` produces -- see
 
 ```json
 {"session_summary": {
-  "session_id": "...", "caller_identity": "cli:local",
   "capability_ceiling": ["PrivateStorageRead", "VectorSearch"],
   "privacy_ceiling": "ProjectLocal",
   "requests_submitted": 6, "requests_admitted": 6,
@@ -206,6 +205,14 @@ in submission order (the same shape `smc hub invoke` produces -- see
   "first_logical_sequence": 0, "last_logical_sequence": 5
 }}
 ```
+
+This external presentation object is not the internal `HubSessionSummary`:
+it deliberately omits raw `session_id` and `caller_identity`. Those values
+remain internal for session validation and persisted audit provenance. Each
+per-request reply retains its public `request_id`, which is sufficient for
+consumer correlation and for later `smc hub audit --request <request-id>`
+lookup. No alternate raw, compatibility, debug, environment-controlled, or
+logging output path is defined.
 
 ### 7.3 Exit code
 

--- a/tests/hub_cli.rs
+++ b/tests/hub_cli.rs
@@ -256,10 +256,19 @@ fn audit_lookup_omits_sensitive_correlation_and_identity_metadata() {
         audit_text.contains("adapter_provenance: <redacted>"),
         "{audit_text}"
     );
-    assert!(audit_text.contains("input_digest: <redacted>"), "{audit_text}");
-    assert!(audit_text.contains("output_digest: <redacted>"), "{audit_text}");
+    assert!(
+        audit_text.contains("input_digest: <redacted>"),
+        "{audit_text}"
+    );
+    assert!(
+        audit_text.contains("output_digest: <redacted>"),
+        "{audit_text}"
+    );
     assert!(!audit_text.contains("fnv1a64:"), "{audit_text}");
-    assert!(audit_text.contains("tool_id: vector.turbovec"), "{audit_text}");
+    assert!(
+        audit_text.contains("tool_id: vector.turbovec"),
+        "{audit_text}"
+    );
     assert!(audit_text.contains("status: Success"), "{audit_text}");
 
     let persisted_audit = fs::read_to_string(dir.join(".semantic/hub/audit.log")).unwrap();

--- a/tests/hub_cli.rs
+++ b/tests/hub_cli.rs
@@ -240,42 +240,48 @@ fn audit_lookup_omits_sensitive_correlation_and_identity_metadata() {
     assert!(invoke.status.success(), "{:?}", invoke);
 
     let audit = smc_in(&dir, &["hub", "audit", "--request", request_id]);
-    assert!(audit.status.success(), "{:?}", audit);
+    assert!(audit.status.success(), "audit lookup must succeed");
     let audit_text = String::from_utf8_lossy(&audit.stdout);
     assert!(
         audit_text.contains(&format!("request_id: {request_id}")),
-        "audit stdout must retain its public lookup handle: {audit_text}"
+        "audit stdout must retain its public lookup handle"
     );
     for sensitive_value in [session_id, caller_identity] {
         assert!(
             !audit_text.contains(sensitive_value),
-            "audit stdout leaked {sensitive_value:?}: {audit_text}"
+            "audit stdout leaked sensitive metadata"
         );
     }
     assert!(
         audit_text.contains("adapter_provenance: <redacted>"),
-        "{audit_text}"
+        "audit stdout must redact adapter provenance"
     );
     assert!(
         audit_text.contains("input_digest: <redacted>"),
-        "{audit_text}"
+        "audit stdout must redact input digest"
     );
     assert!(
         audit_text.contains("output_digest: <redacted>"),
-        "{audit_text}"
+        "audit stdout must redact output digest"
     );
-    assert!(!audit_text.contains("fnv1a64:"), "{audit_text}");
+    assert!(
+        !audit_text.contains("fnv1a64:"),
+        "audit stdout must not expose a correlation fingerprint"
+    );
     assert!(
         audit_text.contains("tool_id: vector.turbovec"),
-        "{audit_text}"
+        "audit stdout must retain safe tool metadata"
     );
-    assert!(audit_text.contains("status: Success"), "{audit_text}");
+    assert!(
+        audit_text.contains("status: Success"),
+        "audit stdout must retain safe status metadata"
+    );
 
     let persisted_audit = fs::read_to_string(dir.join(".semantic/hub/audit.log")).unwrap();
     for persisted_value in [request_id, session_id, caller_identity] {
         assert!(
             persisted_audit.contains(persisted_value),
-            "audit persistence unexpectedly lost {persisted_value:?}"
+            "audit persistence unexpectedly lost required provenance"
         );
     }
 }
@@ -1288,14 +1294,20 @@ fn session_summary_omits_sensitive_session_and_caller_metadata() {
             output_path.to_str().unwrap(),
         ],
     );
-    assert!(output.status.success(), "{:?}", output);
-    assert!(output.stdout.is_empty(), "{:?}", output);
-    assert!(output.stderr.is_empty(), "{:?}", output);
+    assert!(output.status.success(), "session command must succeed");
+    assert!(
+        output.stdout.is_empty(),
+        "session command must not use stdout with --out"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "session command must not use stderr with --out"
+    );
     let output_text = fs::read_to_string(&output_path).unwrap();
     for sensitive_value in [session_id, caller_identity] {
         assert!(
             !output_text.contains(sensitive_value),
-            "session stdout leaked {sensitive_value:?}: {output_text}"
+            "session output leaked sensitive metadata"
         );
     }
 
@@ -1306,8 +1318,14 @@ fn session_summary_omits_sensitive_session_and_caller_metadata() {
     assert_eq!(lines.len(), 2, "one reply plus one summary");
     assert_eq!(lines[0]["request_id"], request_id);
     let summary = &lines[1]["session_summary"];
-    assert!(summary.get("session_id").is_none(), "{summary}");
-    assert!(summary.get("caller_identity").is_none(), "{summary}");
+    assert!(
+        summary.get("session_id").is_none(),
+        "session summary must omit session ID"
+    );
+    assert!(
+        summary.get("caller_identity").is_none(),
+        "session summary must omit caller identity"
+    );
     assert_eq!(summary["requests_submitted"], 1);
     assert_eq!(summary["requests_admitted"], 1);
 
@@ -1315,7 +1333,7 @@ fn session_summary_omits_sensitive_session_and_caller_metadata() {
     for persisted_value in [request_id, session_id, caller_identity] {
         assert!(
             persisted_audit.contains(persisted_value),
-            "audit persistence unexpectedly lost {persisted_value:?}"
+            "audit persistence unexpectedly lost required provenance"
         );
     }
 }
@@ -1350,16 +1368,19 @@ fn session_mixed_caller_rejection_does_not_echo_caller_identity() {
         &dir,
         &["hub", "session", "--requests", requests.to_str().unwrap()],
     );
-    assert!(!output.status.success(), "{:?}", output);
+    assert!(
+        !output.status.success(),
+        "mixed-caller session must be rejected"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.starts_with("InputRejected: session requests use multiple caller identities"),
-        "{stderr}"
+        "mixed-caller rejection must retain its public error classification"
     );
     for sensitive_value in [first_caller, second_caller] {
         assert!(
             !stderr.contains(sensitive_value),
-            "session stderr leaked {sensitive_value:?}: {stderr}"
+            "session stderr leaked sensitive metadata"
         );
     }
     assert!(output.stdout.is_empty());

--- a/tests/hub_cli.rs
+++ b/tests/hub_cli.rs
@@ -210,6 +210,67 @@ fn full_workflow_create_insert_search_filter_remove_search_again_audit() {
     assert_eq!(stdout_json(&describe_after_reset)["payload"]["len"], 0);
 }
 
+#[test]
+fn audit_lookup_omits_sensitive_correlation_and_identity_metadata() {
+    let dir = temp_dir("hub_cli_audit_confidentiality");
+    let request_id = "confidential-request-id";
+    let session_id = "confidential-session-id";
+    let caller_identity = "confidential-caller-identity";
+    let request = serde_json::json!({
+        "request_id": request_id,
+        "session_id": session_id,
+        "caller_identity": caller_identity,
+        "capabilities": ["VectorIndexCreate", "PrivateStorageRead", "PrivateStorageWrite"],
+        "payload": {"index": "confidentiality-docs", "dim": 8, "bit_width": 4}
+    });
+    let input = dir.join("confidentiality_request.json");
+    fs::write(&input, serde_json::to_vec(&request).unwrap()).unwrap();
+
+    let invoke = smc_in(
+        &dir,
+        &[
+            "hub",
+            "invoke",
+            "vector.turbovec",
+            "vector.index.create",
+            "--input",
+            input.to_str().unwrap(),
+        ],
+    );
+    assert!(invoke.status.success(), "{:?}", invoke);
+
+    let audit = smc_in(&dir, &["hub", "audit", "--request", request_id]);
+    assert!(audit.status.success(), "{:?}", audit);
+    let audit_text = String::from_utf8_lossy(&audit.stdout);
+    assert!(
+        audit_text.contains(&format!("request_id: {request_id}")),
+        "audit stdout must retain its public lookup handle: {audit_text}"
+    );
+    for sensitive_value in [session_id, caller_identity] {
+        assert!(
+            !audit_text.contains(sensitive_value),
+            "audit stdout leaked {sensitive_value:?}: {audit_text}"
+        );
+    }
+    assert!(
+        audit_text.contains("adapter_provenance: <redacted>"),
+        "{audit_text}"
+    );
+    assert!(audit_text.contains("input_digest: <redacted>"), "{audit_text}");
+    assert!(audit_text.contains("output_digest: <redacted>"), "{audit_text}");
+    assert!(!audit_text.contains("fnv1a64:"), "{audit_text}");
+    assert!(audit_text.contains("tool_id: vector.turbovec"), "{audit_text}");
+    assert!(audit_text.contains("status: Success"), "{audit_text}");
+
+    let persisted_audit = fs::read_to_string(dir.join(".semantic/hub/audit.log")).unwrap();
+    for persisted_value in [request_id, session_id, caller_identity] {
+        assert!(
+            persisted_audit.contains(persisted_value),
+            "audit persistence unexpectedly lost {persisted_value:?}"
+        );
+    }
+}
+
 // ---- adversarial / rejection paths --------------------------------------
 
 #[test]
@@ -1185,6 +1246,114 @@ fn session_processes_a_full_create_insert_search_remove_search_recover_workflow_
         summary["last_logical_sequence"],
         replies[5]["logical_sequence"]
     );
+}
+
+#[test]
+fn session_summary_omits_sensitive_session_and_caller_metadata() {
+    let dir = temp_dir("hub_cli_session_confidentiality");
+    let request_id = "session-confidential-request";
+    let session_id = "session-confidential-session";
+    let caller_identity = "session-confidential-caller";
+    let requests = dir.join("confidentiality_session.ndjson");
+    let output_path = dir.join("confidentiality_session_output.ndjson");
+    let request = serde_json::json!({
+        "request_id": request_id,
+        "caller_identity": caller_identity,
+        "tool_id": "vector.turbovec",
+        "operation_id": "vector.index.create",
+        "capabilities": ["VectorIndexCreate", "PrivateStorageRead", "PrivateStorageWrite"],
+        "payload": {"index": "session-confidentiality-docs", "dim": 8, "bit_width": 4}
+    });
+    fs::write(&requests, serde_json::to_string(&request).unwrap()).unwrap();
+
+    let output = smc_in(
+        &dir,
+        &[
+            "hub",
+            "session",
+            "--requests",
+            requests.to_str().unwrap(),
+            "--session-id",
+            session_id,
+            "--out",
+            output_path.to_str().unwrap(),
+        ],
+    );
+    assert!(output.status.success(), "{:?}", output);
+    assert!(output.stdout.is_empty(), "{:?}", output);
+    assert!(output.stderr.is_empty(), "{:?}", output);
+    let output_text = fs::read_to_string(&output_path).unwrap();
+    for sensitive_value in [session_id, caller_identity] {
+        assert!(
+            !output_text.contains(sensitive_value),
+            "session stdout leaked {sensitive_value:?}: {output_text}"
+        );
+    }
+
+    let lines: Vec<serde_json::Value> = output_text
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(lines.len(), 2, "one reply plus one summary");
+    assert_eq!(lines[0]["request_id"], request_id);
+    let summary = &lines[1]["session_summary"];
+    assert!(summary.get("session_id").is_none(), "{summary}");
+    assert!(summary.get("caller_identity").is_none(), "{summary}");
+    assert_eq!(summary["requests_submitted"], 1);
+    assert_eq!(summary["requests_admitted"], 1);
+
+    let persisted_audit = fs::read_to_string(dir.join(".semantic/hub/audit.log")).unwrap();
+    for persisted_value in [request_id, session_id, caller_identity] {
+        assert!(
+            persisted_audit.contains(persisted_value),
+            "audit persistence unexpectedly lost {persisted_value:?}"
+        );
+    }
+}
+
+#[test]
+fn session_mixed_caller_rejection_does_not_echo_caller_identity() {
+    let dir = temp_dir("hub_cli_session_mixed_caller_confidentiality");
+    let first_caller = "first-confidential-caller";
+    let second_caller = "second-confidential-caller";
+    let requests = dir.join("mixed_callers.ndjson");
+    let request = |request_id: &str, caller_identity: &str| {
+        serde_json::json!({
+            "request_id": request_id,
+            "caller_identity": caller_identity,
+            "tool_id": "vector.turbovec",
+            "operation_id": "vector.index.create",
+            "capabilities": ["VectorIndexCreate", "PrivateStorageRead", "PrivateStorageWrite"],
+            "payload": {"index": "mixed-caller-docs", "dim": 8, "bit_width": 4}
+        })
+    };
+    fs::write(
+        &requests,
+        format!(
+            "{}\n{}",
+            serde_json::to_string(&request("mixed-caller-1", first_caller)).unwrap(),
+            serde_json::to_string(&request("mixed-caller-2", second_caller)).unwrap(),
+        ),
+    )
+    .unwrap();
+
+    let output = smc_in(
+        &dir,
+        &["hub", "session", "--requests", requests.to_str().unwrap()],
+    );
+    assert!(!output.status.success(), "{:?}", output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("InputRejected: session requests use multiple caller identities"),
+        "{stderr}"
+    );
+    for sensitive_value in [first_caller, second_caller] {
+        assert!(
+            !stderr.contains(sensitive_value),
+            "session stderr leaked {sensitive_value:?}: {stderr}"
+        );
+    }
+    assert!(output.stdout.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Closes #1866

## Scope and contract

This PR changes only the external `smc hub audit` and `smc hub session` presentation boundary. It does not alter `semantic-hub`, session admission, identity semantics, persistent audit records, capabilities, provenance storage, or dependencies.

The approved scope expansion is recorded at https://github.com/skulmakov-oss/Semantic/issues/1866#issuecomment-5477126982. The classification contract is in `docs/spec/hub/hub_audit_presentation_v0.md`:

| Classification | Fields |
| --- | --- |
| SAFE_VERBATIM | request_id; tool_id/version; operation_id; execution, determinism, trust, privacy and worker state; status and fault fields |
| SENSITIVE_OMIT | session_id; caller_identity |
| SENSITIVE_REDACT | adapter_provenance; input_digest; output_digest |

`request_id` remains the raw public lookup/correlation handle. No raw, compatibility, debug, environment, stderr, or alternate-output escape hatch was added; no fingerprint was substituted for omitted values.

## Change

- `smc hub audit` now omits raw session and caller values and redacts adapter provenance plus input/output digests.
- `smc hub session` summary output omits raw session and caller values while retaining per-request raw request IDs.
- The mixed-caller session rejection no longer echoes caller identities to stderr.
- Canonical persisted audit data remains raw and unchanged by design.

## Evidence

Red regressions demonstrated the original audit, session-summary, and mixed-caller stderr leaks. Green coverage includes the human audit path, machine-readable `hub session --out` sink, mixed-caller rejection, and preservation of raw values in canonical audit persistence.

- `cargo test --test hub_cli --quiet` — 37 passed
- `pwsh -File scripts/admission_guard.ps1 -FullPreflight` — all compilation/test/format/clippy steps passed; final clean-tree assertion is blocked only by the repository test suite recreating untracked `crates/smc-cli/.semantic-cache/*` in a new temporary worktree.
- `pwsh -File tools/7hell/run_ci.ps1` — FAST 7HELL GATE PASSED (Hells 1–5 PASS)

An independent R3 adversarial review found no critical issue; its required direct `--out` regression was added. Fresh CodeQL qualification passed on the final exact head (`ad6ca3400729878558c88b33d6f16877d864148a`): Actions, Python, and Rust analysis all succeeded in https://github.com/skulmakov-oss/Semantic/actions/runs/33403130635, and the PR ref has no open CodeQL alerts.

## Harness

The controlled Harness transition is preserved in ordered commits and the final `.harness/current.task.yaml` blob is exactly the `origin/main` SSF-07 blob (`5fc6e33bcb1841c10e3e99c824356cf9003e1421`).