### PR TITLE
fix(front): reject discarded non-function generic bounds (#1633)

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -331,18 +331,17 @@ impl<'a> Parser<'a> {
         let (params, bounds) = self.parse_type_params_with_bounds()?;
         if !bounds.is_empty() {
             // `parse_type_params_with_bounds` already pushed `params` onto
-            // `type_param_scope` and expects its caller to eventually pop
-            // them via `pop_type_param_scope` after parsing the declaration
-            // body. This early return skips that call, but it is safe: this
-            // `FrontendError` propagates via `?` all the way out of
-            // `parse_program`, which is always called on a freshly
-            // constructed `Parser` that is dropped immediately on any `Err`
-            // (see `parse_rustlike_with_profile`/`parse_logos_with_profile`)
-            // -- there is no error-recovery or speculative-parse path in
-            // this parser that would observe or reuse `type_param_scope`
-            // after this point.
+            // `type_param_scope`, and its caller normally pops exactly that
+            // many entries via `pop_type_param_scope` after parsing the
+            // declaration body. This early return skips that later call, so
+            // it must do the equivalent unwind itself here -- popping only
+            // the `params.len()` entries this call pushed, not the whole
+            // scope, so an outer caller's own entries (if any) are left
+            // untouched.
+            let pos = self.pos();
+            self.pop_type_param_scope(params.len());
             return Err(FrontendError {
-                pos: self.pos(),
+                pos,
                 message: format!(
                     "trait bounds on type parameters are not supported by {family} declarations"
                 ),
@@ -7012,43 +7011,40 @@ fn apply<T: Eq, U>(x: T, y: U) -> i32 {
     }
 
     #[test]
-    fn rejecting_a_bounded_declaration_leaves_one_unpopped_type_param_scope_entry_confined_to_a_dead_parser(
-    ) {
+    fn rejecting_a_bounded_declaration_restores_type_param_scope_to_its_pre_call_depth() {
         // G (scope-state integrity, direct proof): `parse_type_params_with_bounds`
         // pushes each parameter name onto `type_param_scope` *before* the
-        // caller learns whether bounds are present, so `parse_type_params`
-        // rejecting on a non-empty `bounds` list returns before its own
-        // caller's normal `pop_type_param_scope` call runs -- this directly
-        // inspects that a `Parser` instance's `type_param_scope` after
-        // rejection confirms one entry is genuinely left unpopped. That is
-        // safe, not corrupting, only because of the surrounding architecture
-        // (proven by the previous test and by inspection): `parse_program`
-        // has no recovery path that would resume parsing with this `Parser`
-        // after an `Err`, and every public entrypoint
-        // (`parse_rustlike_with_profile`) constructs a fresh `Parser` per
-        // call and drops it immediately on any `Err` -- so this leaked entry
-        // can never be observed by a later parse. No explicit unwind is
-        // added because the actual control flow never requires one; this
-        // test is the evidence for that claim, not just an assertion of it.
+        // caller learns whether bounds are present. `parse_type_params` now
+        // unwinds exactly those `params.len()` entries itself before
+        // returning the rejection, rather than leaving them for a
+        // `pop_type_param_scope` call it is about to skip. This constructs a
+        // `Parser` with one pre-existing "outer" scope entry already present
+        // (a sentinel, standing in for an enclosing scope this call did not
+        // introduce and must not touch) to prove the unwind pops only the
+        // entries *this* call pushed -- not the whole scope.
         let src = "record R<T: SomeTrait> { x: T }\n";
         let tokens = lex_tokens(src).expect("lex");
         let profile = ParserProfile::foundation_default();
+        let mut arena = AstArena::default();
+        let sentinel = arena.intern_symbol("OuterSentinel");
         let mut p = Parser {
             tokens,
             idx: 0,
             source: src.to_string(),
-            arena: AstArena::default(),
+            arena,
             policy: CompilePolicyView::new(&profile),
-            type_param_scope: Vec::new(),
+            type_param_scope: vec![sentinel],
             self_type_scope: None,
         };
+        assert_eq!(p.type_param_scope, vec![sentinel], "scope before the call");
         let result = p.parse_program();
         assert!(result.is_err(), "bound-bearing record must reject");
         assert_eq!(
-            p.type_param_scope.len(),
-            1,
-            "expected exactly the one parameter pushed by \
-             parse_type_params_with_bounds to remain unpopped"
+            p.type_param_scope,
+            vec![sentinel],
+            "type_param_scope must be restored to exactly its pre-call depth \
+             and contents -- only the entries this call pushed should be \
+             popped, leaving the pre-existing outer entry untouched"
         );
     }
 

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -311,13 +311,43 @@ impl<'a> Parser<'a> {
         Ok((params, bounds))
     }
 
-    /// Parse an optional `<T, U, ...>` type parameter list (no bounds).
+    /// Parse an optional `<T, U, ...>` type parameter list for a declaration
+    /// form with no `TraitBound`-carrying AST field (record, ADT, trait,
+    /// impl -- see each's `type_params: Vec<SymbolId>` in `types.rs`).
     ///
-    /// Thin wrapper over `parse_type_params_with_bounds` that discards any
-    /// bounds. Used for record and ADT declarations where trait bounds on type
-    /// parameters are not admitted in first wave.
-    fn parse_type_params(&mut self) -> Result<Vec<SymbolId>, FrontendError> {
-        let (params, _bounds) = self.parse_type_params_with_bounds()?;
+    /// `family` names the declaration form for diagnostics (e.g. `"record"`,
+    /// `"enum"`, `"trait"`, `"impl"`).
+    ///
+    /// A bare `<T, U>` list is admitted -- the parameter names themselves are
+    /// faithfully represented in `type_params`, and existing owner-layer
+    /// authorities (#1635 traits, #1650 records/ADTs, #1668 impls) already
+    /// reject a non-empty `type_params` deterministically for these forms.
+    /// A `: Bound` on any parameter is rejected here instead: this codebase's
+    /// invariant is that recognized semantic information is never silently
+    /// discarded in favor of a successfully-parsed but weaker AST, and none
+    /// of these four declaration kinds have anywhere to faithfully store a
+    /// parsed `TraitBound` (FA-02-001 / #1633).
+    fn parse_type_params(&mut self, family: &'static str) -> Result<Vec<SymbolId>, FrontendError> {
+        let (params, bounds) = self.parse_type_params_with_bounds()?;
+        if !bounds.is_empty() {
+            // `parse_type_params_with_bounds` already pushed `params` onto
+            // `type_param_scope` and expects its caller to eventually pop
+            // them via `pop_type_param_scope` after parsing the declaration
+            // body. This early return skips that call, but it is safe: this
+            // `FrontendError` propagates via `?` all the way out of
+            // `parse_program`, which is always called on a freshly
+            // constructed `Parser` that is dropped immediately on any `Err`
+            // (see `parse_rustlike_with_profile`/`parse_logos_with_profile`)
+            // -- there is no error-recovery or speculative-parse path in
+            // this parser that would observe or reuse `type_param_scope`
+            // after this point.
+            return Err(FrontendError {
+                pos: self.pos(),
+                message: format!(
+                    "trait bounds on type parameters are not supported by {family} declarations"
+                ),
+            });
+        }
         Ok(params)
     }
 
@@ -331,7 +361,7 @@ impl<'a> Parser<'a> {
     fn parse_trait_decl(&mut self) -> Result<TraitDecl, FrontendError> {
         self.expect(TokenKind::KwTrait, "expected 'trait'")?;
         let name = self.expect_symbol()?;
-        let type_params = self.parse_type_params()?;
+        let type_params = self.parse_type_params("trait")?;
         self.expect(TokenKind::LBrace, "expected '{' after trait name")?;
         let self_placeholder = Type::TypeVar(self.arena.intern_symbol("Self"));
         let methods = self.with_self_type_scope(self_placeholder, |parser| {
@@ -394,7 +424,7 @@ impl<'a> Parser<'a> {
     /// Parse an `impl TraitName for TypeName { fn method(...) { ... } ... }` block.
     fn parse_impl_decl(&mut self) -> Result<ImplDecl, FrontendError> {
         self.expect(TokenKind::KwImpl, "expected 'impl'")?;
-        let type_params = self.parse_type_params()?;
+        let type_params = self.parse_type_params("impl")?;
         let trait_name = self.expect_symbol()?;
         self.expect(TokenKind::KwFor, "expected 'for' after trait name in impl")?;
         let for_type = self.expect_symbol()?;
@@ -428,7 +458,7 @@ impl<'a> Parser<'a> {
     fn parse_record_decl(&mut self) -> Result<RecordDecl, FrontendError> {
         self.expect(TokenKind::KwRecord, "expected 'record'")?;
         let name = self.expect_symbol()?;
-        let type_params = self.parse_type_params()?;
+        let type_params = self.parse_type_params("record")?;
         self.expect(TokenKind::LBrace, "expected '{' after record name")?;
         let mut fields = Vec::new();
         while !self.check(TokenKind::RBrace) {
@@ -666,7 +696,7 @@ impl<'a> Parser<'a> {
     fn parse_adt_decl(&mut self) -> Result<AdtDecl, FrontendError> {
         self.expect(TokenKind::KwEnum, "expected 'enum'")?;
         let name = self.expect_symbol()?;
-        let type_params = self.parse_type_params()?;
+        let type_params = self.parse_type_params("enum")?;
         self.expect(TokenKind::LBrace, "expected '{' after enum name")?;
         let mut variants = Vec::new();
         while !self.check(TokenKind::RBrace) {
@@ -6882,6 +6912,144 @@ fn apply<T: Eq, U>(x: T, y: U) -> i32 {
         let func = &program.functions[0];
         assert_eq!(func.type_params.len(), 2);
         assert_eq!(func.trait_bounds.len(), 1);
+    }
+
+    // FA-02-001 / #1633: trait bounds on non-function type parameters have no
+    // AST field to faithfully represent them, so `parse_type_params` rejects
+    // them deterministically instead of silently discarding the bound and
+    // returning a weaker-but-successful AST. `E` (function bounds retained)
+    // is covered above by `function_with_trait_bound_is_parsed` and
+    // `function_with_multiple_type_params_mixed_bounds_is_parsed` -- both
+    // already pass unaffected, since `parse_function` calls
+    // `parse_type_params_with_bounds` directly and never goes through the
+    // now-rejecting `parse_type_params` wrapper this issue changes.
+
+    #[test]
+    fn record_with_trait_bound_is_rejected_at_parse_time() {
+        let src = "record R<T: SomeTrait> { x: T }\n";
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("bound-bearing record must reject during parsing");
+        assert!(
+            err.message.contains("record") && err.message.contains("trait bounds"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn adt_with_trait_bound_is_rejected_at_parse_time() {
+        let src = "enum E<T: SomeTrait> { A(T) }\n";
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("bound-bearing enum must reject during parsing");
+        assert!(
+            err.message.contains("enum") && err.message.contains("trait bounds"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn trait_with_trait_bound_is_rejected_at_parse_time() {
+        // Distinct from #1635's later canonical rejection of *any* generic
+        // trait (bound or not) at `build_trait_table` -- this proves the
+        // raw parser itself never silently drops the bound, independent of
+        // that separate, later, zero-arity owner-layer authority.
+        let src = "trait Tr<T: SomeTrait> {\n    fn f(x: T) -> T;\n}\n";
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("bound-bearing trait must reject during parsing");
+        assert!(
+            err.message.contains("trait") && err.message.contains("trait bounds"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn impl_with_trait_bound_is_rejected_at_parse_time() {
+        let src = "trait Tr {\n    fn f(x: i32) -> i32;\n}\nrecord R { x: i32 }\nimpl<T: SomeTrait> Tr for R {\n    fn f(x: i32) -> i32 { return x; }\n}\n";
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("bound-bearing impl must reject during parsing");
+        assert!(
+            err.message.contains("impl") && err.message.contains("trait bounds"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn nonfunction_nobound_raw_syntax_still_parses_for_all_four_families() {
+        // F: this issue rejects a *bound* on a non-function type parameter,
+        // not the bare parameter list itself. Raw `<T>` syntax with no bound
+        // remains future-capable and must keep parsing -- its later
+        // canonical zero-arity rejection belongs to #1650 (record/ADT),
+        // #1635 (trait), #1668 (impl), not to this parser-level change.
+        let src = "record R<T> { x: T }\nenum E<T> { A(T) }\ntrait Tr<T> {\n    fn f(x: T) -> T;\n}\nimpl<T> Tr for R {\n    fn f(x: i32) -> i32 { return x; }\n}\n";
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("no-bound raw syntax must still parse for record/enum/trait/impl");
+        assert_eq!(program.records[0].type_params.len(), 1);
+        assert_eq!(program.adts[0].type_params.len(), 1);
+        assert_eq!(program.traits[0].type_params.len(), 1);
+        assert_eq!(program.impls[0].type_params.len(), 1);
+    }
+
+    #[test]
+    fn rejecting_a_bounded_record_is_fatal_to_the_whole_program_not_partial() {
+        // G (scope-state integrity, external proof): `parse_program` parses
+        // every declaration with `?` -- there is no catch/continue recovery
+        // anywhere in this loop, so the first `Err` aborts the entire parse.
+        // A well-formed function declared *after* the rejected record must
+        // therefore never be reached, and the result must be exactly one
+        // deterministic `Err`, never a partial `Program` or a differently
+        // shaped error caused by inconsistent parser state.
+        let src = "record R<T: SomeTrait> { x: T }\nfn f(x: i32) -> i32 { return x; }\n";
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("the rejected record must fail the whole program");
+        assert!(
+            err.message.contains("record") && err.message.contains("trait bounds"),
+            "unexpected error (possible scope-state corruption): {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn rejecting_a_bounded_declaration_leaves_one_unpopped_type_param_scope_entry_confined_to_a_dead_parser(
+    ) {
+        // G (scope-state integrity, direct proof): `parse_type_params_with_bounds`
+        // pushes each parameter name onto `type_param_scope` *before* the
+        // caller learns whether bounds are present, so `parse_type_params`
+        // rejecting on a non-empty `bounds` list returns before its own
+        // caller's normal `pop_type_param_scope` call runs -- this directly
+        // inspects that a `Parser` instance's `type_param_scope` after
+        // rejection confirms one entry is genuinely left unpopped. That is
+        // safe, not corrupting, only because of the surrounding architecture
+        // (proven by the previous test and by inspection): `parse_program`
+        // has no recovery path that would resume parsing with this `Parser`
+        // after an `Err`, and every public entrypoint
+        // (`parse_rustlike_with_profile`) constructs a fresh `Parser` per
+        // call and drops it immediately on any `Err` -- so this leaked entry
+        // can never be observed by a later parse. No explicit unwind is
+        // added because the actual control flow never requires one; this
+        // test is the evidence for that claim, not just an assertion of it.
+        let src = "record R<T: SomeTrait> { x: T }\n";
+        let tokens = lex_tokens(src).expect("lex");
+        let profile = ParserProfile::foundation_default();
+        let mut p = Parser {
+            tokens,
+            idx: 0,
+            source: src.to_string(),
+            arena: AstArena::default(),
+            policy: CompilePolicyView::new(&profile),
+            type_param_scope: Vec::new(),
+            self_type_scope: None,
+        };
+        let result = p.parse_program();
+        assert!(result.is_err(), "bound-bearing record must reject");
+        assert_eq!(
+            p.type_param_scope.len(),
+            1,
+            "expected exactly the one parameter pushed by \
+             parse_type_params_with_bounds to remain unpopped"
+        );
     }
 
     // M9.4 Wave 2 — richer pattern surface parser admission

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -323,14 +323,36 @@ First-wave generic-capable *function* definitions admit at most one type
 parameter per definition site; zero is non-generic and one is the
 contracted generic surface. The parser has no arity limit of its own
 (`parse_type_params_with_bounds` may represent `<T, U, ...>` and mixed
-bound combinations like `<T: Bound, U>` as raw AST, and does so
-deliberately, exactly as it does for the generic trait/impl syntax
-`build_trait_table`/`validate_trait_coherence` reject above); admission is
-enforced at `build_fn_table`, never by truncating to the first parameter or
-silently admitting the extras. Traits and impls already require zero type
-parameters under the stricter contracts described above, so an
-out-of-contract arity there was already rejected before this boundary
+bound combinations like `<T: Bound, U>` as raw AST, since `Function` has a
+`trait_bounds: Vec<TraitBound>` field to faithfully retain them); admission
+of the arity is enforced at `build_fn_table`, never by truncating to the
+first parameter or silently admitting the extras. Traits and impls already
+require zero type parameters under the stricter contracts described above,
+so an out-of-contract arity there was already rejected before this boundary
 existed; it is not a new restriction for those two families.
+
+Trait bounds on a *non-function* type parameter (`record`/`enum`/`trait`/
+`impl`) are a different case from bare arity, and are not admitted at the
+parser at all: `TraitDecl`/`ImplDecl`/`RecordDecl`/`AdtDecl` each carry only
+a bare `type_params: Vec<SymbolId>`, with nowhere to store a parsed
+`TraitBound`. Before SSF-07 #1633, `parse_type_params` (the thin wrapper
+these four declaration forms use, as opposed to `Function`'s
+`parse_type_params_with_bounds`) parsed and then silently discarded any
+bound on a non-function type parameter — the raw parser accepted
+`record R<T: SomeTrait> { ... }` and returned `Ok` with a `RecordDecl` whose
+`type_params` carried `T` but no trace that a bound was ever written, a
+recognized-then-erased-semantics defect independent of and prior to any
+later owner-layer rejection. `parse_type_params` now rejects deterministically
+whenever the parsed bound list is non-empty, for all four declaration forms,
+before returning to its caller. A **bare**, unbounded type-parameter list
+(`record R<T> { ... }`, `enum E<T> { ... }`, `trait Tr<T> { ... }`,
+`impl<T> Trait for X { ... }`) is unaffected and continues to parse as raw
+AST exactly as before — its later canonical zero-arity rejection remains the
+separate, later authority described above (`build_record_table`/
+`build_adt_table` for #1650, `build_trait_table` for #1635,
+`validate_trait_coherence` for #1668); #1633 only closes the parser-level
+gap where a *bound specifically* went from recognized to discarded to a
+successful, weaker AST.
 
 Records and ADTs are non-generic in the current Stable Foundation nominal
 type contract: `build_record_table`/`build_adt_table` require


### PR DESCRIPTION
SSF-07 reconciliation: #1578
Fixes #1633

## Baseline

Fetched fresh `origin/main`; branched from `17d4b7dc255bf3cf96685dc33c8e4b48118e7a19` (the exact baseline given for this slice) in an isolated `EnterWorktree` worktree.

## Pre-fix reproduction matrix

Empirically reproduced against the exact baseline before writing any production code (temporary probes, run, observed, then removed before implementation):

| Case | `parse_program` result | `type_params` in AST | bound in AST | Owner-layer downstream on current `main` |
|---|---|---|---|---|
| A. `record R<T: SomeTrait> { x: T }` | `Ok` | `[T]` (1 param) | absent — no field exists to hold it | `Err`: `"generic record 'R' is not part of the current Stable Foundation nominal type contract because applied record type arguments are not representable"` (#1650) |
| B. `enum E<T: SomeTrait> { A(T) }` | `Ok` | `[T]` | absent | `Err`: `"generic enum 'E' ... applied enum type arguments are not representable"` (#1650) |
| C. `trait Tr<T: SomeTrait> { fn f(x: T) -> T; }` | `Ok` | `[T]` | absent | `Err`: `"trait 'Tr' declares type parameters; generic traits are not supported"` (#1635) |
| D. `impl<T: SomeTrait> Tr for R { ... }` | `Ok` | `[T]` | absent | `Err`: `"impl of trait 'Tr' for type 'R' declares type parameters; generic/blanket impls are not supported"` (#1668) |
| E. `fn print_all<T: Display>(x: T) -> i32 { ... }` (positive control) | `Ok` | `[T]` | **present**, `func.trait_bounds[0].param == func.type_params[0]` | N/A (function generics are frontend-admitted) |
| F. Bare `<T>` (no bound) for all four non-function families | `Ok` | `[T]` each | N/A (no bound written) | unaffected, unchanged |

The table proves the defect is real and independent of the eventual owner-layer rejection: for A-D, `parse_program` itself already returns `Ok` with a `RecordDecl`/`AdtDecl`/`TraitDecl`/`ImplDecl` whose `type_params` field is populated but which carries no trace that a `: SomeTrait` bound was ever written in the source — the bound is recognized by the parser (a `TraitBound { param, bound }` value is constructed in `parse_type_params_with_bounds`) and then thrown away, before any owner-layer authority ever runs. That later `Err` from #1650/#1635/#1668 exists for an unrelated reason (non-empty `type_params`, bound or not) and never mentions the bound at all.

## Parser-vs-canonical-owner distinction

Two independent layers were already in play before this fix, and this PR only touches the first:
- **Parser (raw syntax) layer**: is a declaration's syntax recognized and faithfully represented as AST, or rejected? Before this fix, non-function bound syntax was recognized, then silently discarded, then accepted anyway — a genuine representation-fidelity violation, independent of what any later layer does.
- **Owner (canonical admission) layer**: `build_record_table`/`build_adt_table` (#1650), `build_trait_table` (#1635), `validate_trait_coherence` (#1668) already reject any non-empty `type_params` on these four declaration forms, unconditionally, whether or not a bound was ever present. This PR does not touch, weaken, or duplicate any of these three authorities.

## Root cause

`crates/sm-front/src/parser.rs`'s `parse_type_params_with_bounds` (used directly by `parse_function`) correctly returns `(Vec<SymbolId>, Vec<TraitBound>)`. Its thin wrapper `parse_type_params` (used by `parse_record_decl`, `parse_adt_decl`, `parse_trait_decl`, `parse_impl_decl`) discarded the second element:

```rust
fn parse_type_params(&mut self) -> Result<Vec<SymbolId>, FrontendError> {
    let (params, _bounds) = self.parse_type_params_with_bounds()?;
    Ok(params)
}
```

`RecordDecl`, `AdtDecl`, `TraitDecl`, `ImplDecl` each declare only `type_params: Vec<SymbolId>` (confirmed by reading `types.rs`) — none has anywhere to faithfully store a parsed `TraitBound`. A bound that is parsed and then discarded is not a faithful raw representation of the source, violating this codebase's standing invariant: recognized semantic information is never silently discarded in favor of a successfully-parsed but weaker AST.

## Repair

Contract narrowing at the parser boundary, not AST expansion (per the issue's explicit direction — no new field, no new generic semantics for any of the four families):

```rust
fn parse_type_params(&mut self, family: &'static str) -> Result<Vec<SymbolId>, FrontendError> {
    let (params, bounds) = self.parse_type_params_with_bounds()?;
    if !bounds.is_empty() {
        let pos = self.pos();
        self.pop_type_param_scope(params.len());
        return Err(FrontendError {
            pos,
            message: format!(
                "trait bounds on type parameters are not supported by {family} declarations"
            ),
        });
    }
    Ok(params)
}
```

`family` is a tiny, `&'static str` contextual parameter (`"record"`, `"enum"`, `"trait"`, `"impl"`) threaded through the four call sites — no broader parser refactor. A bare, unbounded `<T, U>` list is unaffected and continues to parse and populate `type_params` exactly as before; only a non-empty `bounds` list now rejects.

## Parser scope-state analysis

`parse_type_params_with_bounds` pushes each parameter name onto `self.type_param_scope` *before* it returns to `parse_type_params`. The rejection path now unwinds exactly what it caused to be pushed — `self.pop_type_param_scope(params.len())` — before propagating the deterministic `FrontendError`, instead of returning early and leaving those entries for a `pop_type_param_scope` call further up the call stack that this early return skips. Popping only `params.len()` entries, not the whole scope, matters because a non-function declaration can be lexically nested inside a scope that already holds outer entries this call did not introduce and must not touch.

*(Review round 1 on this PR found an earlier revision of this section: the first version of this fix skipped the pop, argued the leak was safe because the `Parser` instance is dropped immediately on any `Err` in every current call site, and pinned that leak with a regression asserting it as expected. That argument was true of this parser's current architecture, but the error path should restore state it owns rather than rely on an external excuse for not doing so — corrected in the second commit on this PR.)*

Proof, via a test that seeds a pre-existing "outer" sentinel scope entry before the call:
1. **Scope restoration** (`rejecting_a_bounded_declaration_restores_type_param_scope_to_its_pre_call_depth`): constructs a `Parser` with `type_param_scope: vec![sentinel]`, asserts the scope equals `vec![sentinel]` before the call, calls `.parse_program()` on a bound-bearing record, confirms it errors, then asserts `type_param_scope` is **still exactly** `vec![sentinel]` — proving the unwind pops only the entries this call pushed, not the pre-existing outer entry, and not the whole scope.
2. **Whole-program-fatal proof** (`rejecting_a_bounded_record_is_fatal_to_the_whole_program_not_partial`, kept unchanged as a separate, complementary check): a well-formed `fn f(x: i32) -> i32 { ... }` declared *after* a rejected bound-bearing record is never reached — the result is one deterministic `Err`, never a partial `Program`.

## Regressions (`crates/sm-front/src/parser.rs`, new)

- `record_with_trait_bound_is_rejected_at_parse_time` (A)
- `adt_with_trait_bound_is_rejected_at_parse_time` (B)
- `trait_with_trait_bound_is_rejected_at_parse_time` (C, with a comment distinguishing this from #1635's separate later no-bound rejection)
- `impl_with_trait_bound_is_rejected_at_parse_time` (D)
- `nonfunction_nobound_raw_syntax_still_parses_for_all_four_families` (F — proves bare `<T>` is unaffected for all four families)
- `rejecting_a_bounded_record_is_fatal_to_the_whole_program_not_partial` (G, whole-program proof)
- `rejecting_a_bounded_declaration_restores_type_param_scope_to_its_pre_call_depth` (G, direct sentinel-scope proof — replaces the round-1 test that asserted the leak as expected behavior)

E (function bounds retained) is already covered by the pre-existing `function_with_trait_bound_is_parsed` and `function_with_multiple_type_params_mixed_bounds_is_parsed`, both unaffected since `parse_function` never goes through the changed wrapper — both still pass.

## Pre-fix → post-fix proof

Two rounds, one per commit on this PR, each with its own saved-patch / neutralize / rerun / restore / byte-identical-diff cycle:

1. **First commit** (the rejection logic itself): saved `git diff -- crates/sm-front/src/parser.rs`, temporarily neutralized the check (`if false && !bounds.is_empty() { // TEMP-DISABLED-FOR-PREFIX-PROOF`), ran the 6 central regressions — **all 6 failed** with concrete evidence, e.g. `record_with_trait_bound_is_rejected_at_parse_time` panicked with `RecordDecl { name: SymbolId(0), type_params: [SymbolId(1)], fields: [RecordField { name: SymbolId(3), ty: TypeVar(SymbolId(1)) }] }` — a successful parse, bound silently gone, exactly the defect. Restored, confirmed zero residual markers and byte-identical diff.
2. **Second commit** (the scope-restoration corrective fix): saved the corrective diff, temporarily commented out only the new `self.pop_type_param_scope(params.len());` line, reran the sentinel-scope test — **failed** with `left: [SymbolId(0), SymbolId(2)]` (sentinel plus the leaked `T`) vs `right: [SymbolId(0)]` (sentinel alone), concrete evidence the pop is load-bearing. Restored, confirmed zero residual markers and byte-identical diff.

## Sibling audit

- **#1634** (function arity ≤ 1) — unaffected; `parse_function` unchanged, still calls `parse_type_params_with_bounds` directly.
- **#1635** (generic traits rejected by `build_trait_table`) — unaffected; not touched. `trait_with_trait_bound_is_rejected_at_parse_time`'s comment explicitly distinguishes this PR's parser-level bound rejection from #1635's separate, later, zero-arity rejection of *any* generic trait (bound or not). `build_trait_table_rejects_generic_trait_*` tests still pass.
- **#1648/#1649** (recursive generic call inference / canonical `FnSig` construction) — unaffected; `typecheck.rs` not touched.
- **#1650** (generic record/ADT applied nominal contract narrowing) — unaffected; `build_record_table`/`build_adt_table` not touched. `build_record_table_rejects_generic_record_with_single_type_param`, `type_check_program_rejects_generic_record_declaration`, `generic_record_syntax_still_parses_but_type_check_program_rejects` still pass.
- **#1668** (generic impl rejection) — unaffected; `validate_trait_coherence` not touched. `blanket_impl_with_type_params_is_rejected`, `two_type_param_impl_is_rejected_by_existing_zero_arity_contract` still pass.
- **#1717** (IR generic execution / monomorphisation contract) — unaffected; this diff touches only `crates/sm-front/src/parser.rs` and one doc file, nothing in `crates/sm-ir`.
- **#1861** (storage type admission catch-all) — unaffected; lives in a different function (`ensure_storage_type_supported`-adjacent code) untouched by this diff; `git diff --stat` confirms only `parser.rs` and `foundation_source_profile_v1.md` changed.

15 targeted sibling regressions run explicitly (arity, generic record/enum/trait/impl rejection, blanket-impl rejection) — all pass, confirming none of these owner boundaries were reopened or weakened.

## Fallback/bypass audit

`git diff | grep -E "^\+" | grep -viE "^\+\+\+" | grep -iE "unwrap_or|unwrap_or_default|unwrap_or_else|or_else|if let Ok|if let Some|let Ok\(|let Some\(|Default::default\(\)|\.ok\(\)|ignored|catch-all|truncate|clear\(\)|take\(0\)"` — zero matches in the diff.

## Documentation

`docs/spec/foundation_source_profile_v1.md`: the function-arity paragraph previously drew an analogy ("`parse_type_params_with_bounds` may represent ... mixed bound combinations like `<T: Bound, U>` as raw AST ... exactly as it does for the generic trait/impl syntax") that became false for the bound portion after this fix — trait/impl bound syntax no longer parses at all. Rewrote that sentence to state only what's still true (functions retain bounds via `Function.trait_bounds`), and added a new paragraph immediately after the records/ADTs paragraph explaining the #1633 fix: bare unbounded `<T, U>` remains raw-AST-representable and future-capable for all four non-function families (unaffected, still the separate #1650/#1635/#1668 authorities' job to reject downstream), while a `: Bound` on any of their type parameters is now rejected at parse time because none of the four has anywhere to store it. Does not claim broader generic functionality anywhere.

## Qualification

Re-run in full on the corrective commit's exact HEAD (`c991d0b5`):

- `cargo build -p sm-front --tests --offline` — clean
- `cargo test -p sm-front --offline` — 572 passed, 0 failed (565 baseline + 7 new; same count as round 1 — one test replaced, not added)
- `cargo check --workspace --all-targets --offline` — clean
- `cargo test --test public_api_contracts` — 88 passed, 0 failed
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed, 0 failed
- `cargo fmt -p sm-front --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` (workspace-wide) — reproduces the known pre-existing Windows path-length OS error (`os error 206`), confirmed unchanged, not a regression from this diff
- Targeted #1633 + sibling regression sweep (17 tests: A–D/F/E controls plus arity/generic-record/generic-enum/generic-trait/blanket-impl) — all pass
- Fallback/bypass audit re-run on the corrective diff — zero matches

## Changed files

- `crates/sm-front/src/parser.rs` — `parse_type_params` gains a `family` parameter, bound rejection, and a matching `type_param_scope` unwind on the rejection path; 4 call sites updated; 7 new regression tests
- `docs/spec/foundation_source_profile_v1.md` — corrected the now-false trait/impl bound-representation analogy; added normative wording for the #1633 boundary

## Out of scope

This PR does **not**: add generic record/ADT/trait/impl semantics of any kind; add a new applied nominal type; erase or weaken any existing owner-layer authority (#1634/#1635/#1648/#1649/#1650/#1668/#1717/#1861); retain a type parameter while silently dropping its bound in any other way; reinterpret a bound as documentation-only metadata; move the problem downstream; reject the bare, unbounded `<T, U>` raw syntax that remains legitimately future-capable for record/enum/trait/impl; or close #1578 (the SSF-07 parent umbrella). It closes exactly one gap: a trait bound on a non-function type parameter can no longer be silently recognized, discarded, and parsed away into a successful-but-weaker AST — it is now rejected deterministically, at the same layer that recognized it, with a diagnostic naming the declaration family.

