### PR TITLE
fix(front): preserve statement match default presence (#1639)

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -2468,7 +2468,7 @@ impl<'a> Parser<'a> {
         Ok(self.arena.alloc_stmt(Stmt::Match {
             scrutinee,
             arms,
-            default: default.unwrap_or_default(),
+            default,
         }))
     }
 
@@ -4922,17 +4922,17 @@ fn main() {
             panic!("expected leading match statement");
         };
         assert_eq!(arms.len(), 1);
-        assert!(default.is_empty());
+        assert_eq!(*default, None, "no `_` arm at all must store None (#1639)");
     }
 
     #[test]
     fn rustlike_parser_accepts_match_statement_with_one_default_arm() {
-        // The default arm's block must be non-empty here: `Stmt::Match`
-        // stores `default` as a bare `Vec<StmtId>` (not `Option<...>`), so an
-        // empty default block is indistinguishable from "no default arm" by
-        // inspecting the stored AST alone. The parser's own transient
-        // `Option<Vec<StmtId>>` tracking (which this fix's duplicate check
-        // reads) does not share that ambiguity.
+        // FA-02-007 / #1639: `Stmt::Match.default` is `Option<Vec<StmtId>>`,
+        // so this non-empty default arm is distinguishable in the stored AST
+        // itself from both "no default arm" (`None`) and an explicit but
+        // empty default arm (`Some(vec![])`) -- inspecting the stored AST
+        // alone is now sufficient, no need to rely on the parser's transient
+        // tracking.
         let src = r#"
 fn main() {
     match T {
@@ -4950,7 +4950,72 @@ fn main() {
             panic!("expected leading match statement");
         };
         assert_eq!(arms.len(), 1);
-        assert!(!default.is_empty());
+        assert!(
+            default.as_ref().is_some_and(|body| !body.is_empty()),
+            "expected Some(nonempty), got {default:?}"
+        );
+    }
+
+    #[test]
+    fn rustlike_parser_distinguishes_absent_from_empty_present_default_arm() {
+        // FA-02-007 / #1639, items 1-2 of the regression matrix: no `_` arm
+        // at all must parse to `None`, while an explicitly present but empty
+        // `_ => {}` must parse to `Some(Vec::new())` -- never the same AST
+        // value, even though both are "empty" in the sense of contributing
+        // zero statements.
+        let no_wildcard_src = r#"
+fn main() {
+    match T {
+        T => { }
+        F => { }
+    }
+    return;
+}
+"#;
+        let empty_wildcard_src = r#"
+fn main() {
+    match T {
+        T => { }
+        _ => { }
+    }
+    return;
+}
+"#;
+
+        let no_wildcard =
+            parse_rustlike_with_profile(no_wildcard_src, &ParserProfile::foundation_default())
+                .expect("match with no wildcard should parse");
+        let Stmt::Match {
+            default: no_wildcard_default,
+            ..
+        } = no_wildcard.arena.stmt(no_wildcard.functions[0].body[0])
+        else {
+            panic!("expected leading match statement");
+        };
+
+        let empty_wildcard =
+            parse_rustlike_with_profile(empty_wildcard_src, &ParserProfile::foundation_default())
+                .expect("match with empty wildcard should parse");
+        let Stmt::Match {
+            default: empty_wildcard_default,
+            ..
+        } = empty_wildcard
+            .arena
+            .stmt(empty_wildcard.functions[0].body[0])
+        else {
+            panic!("expected leading match statement");
+        };
+
+        assert_eq!(*no_wildcard_default, None, "no `_` arm must store None");
+        assert_eq!(
+            *empty_wildcard_default,
+            Some(Vec::new()),
+            "an explicitly empty `_ => {{}}` must store Some(vec![]), not None"
+        );
+        assert_ne!(
+            no_wildcard_default, empty_wildcard_default,
+            "absent and present-but-empty wildcards must never collapse to the same AST value"
+        );
     }
 
     #[test]
@@ -5654,7 +5719,7 @@ fn main() {
         match program.arena.stmt(unwrap.body[1]) {
             Stmt::Match { arms, default, .. } => {
                 assert!(
-                    default.is_empty(),
+                    default.is_none(),
                     "exhaustive Result match should omit default"
                 );
                 let MatchPattern::Adt(pat) = &arms[1].pat else {

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1775,8 +1775,8 @@ fn check_stmt(
             // M9.7: apply path-based state for each arm's moves/borrows to scrutinee.
             apply_plans_to_scrutinee(*scrutinee, &arm_plans, arena, env);
 
-            if default.is_empty() {
-                match missing_exhaustive_sum_variants(
+            match default {
+                None => match missing_exhaustive_sum_variants(
                     &st,
                     arms.iter().map(|arm| (&arm.pat, arm.guard)),
                     arena,
@@ -1792,24 +1792,25 @@ fn check_stmt(
                             message: "match requires default arm '_'".to_string(),
                         });
                     }
+                },
+                Some(default_body) => {
+                    let mut def_env = env.clone();
+                    def_env.push_scope();
+                    for s in default_body {
+                        check_stmt(
+                            *s,
+                            arena,
+                            &mut def_env,
+                            ret_ty.clone(),
+                            table,
+                            record_table,
+                            adt_table,
+                            loop_stack,
+                            impl_list,
+                        )?;
+                    }
+                    def_env.pop_scope();
                 }
-            } else {
-                let mut def_env = env.clone();
-                def_env.push_scope();
-                for s in default {
-                    check_stmt(
-                        *s,
-                        arena,
-                        &mut def_env,
-                        ret_ty.clone(),
-                        table,
-                        record_table,
-                        adt_table,
-                        loop_stack,
-                        impl_list,
-                    )?;
-                }
-                def_env.pop_scope();
             }
             Ok(())
         }
@@ -8501,6 +8502,138 @@ mod tests {
             .contains("non-exhaustive match expression for Option(T); missing variants: None"));
     }
 
+    // FA-02-007 / #1639: statement-form match presence-vs-emptiness matrix.
+    // These exercise the plain `Stmt::Match` handler (as opposed to the
+    // `Expr::Match`/value-producing-loop handlers above, which already used
+    // `Option<...>` and were unaffected).
+
+    #[test]
+    fn statement_match_quad_without_wildcard_rejects() {
+        let src = r#"
+            fn main() {
+                match T {
+                    T => { return; }
+                    F => { return; }
+                }
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("quad match statement with no `_` arm at all must reject");
+        assert!(
+            err.message.contains("match requires default arm '_'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn statement_match_empty_and_nonempty_wildcard_satisfy_identical_quad_presence_requirement() {
+        // Item 4 of the FA-02-007 regression matrix: an empty `_ => {}` and a
+        // non-empty `_ => { ... }` must both satisfy the same "a wildcard is
+        // present" requirement -- neither is special-cased relative to the
+        // other, and in particular the empty one is never treated as if no
+        // wildcard were written at all.
+        let empty_src = r#"
+            fn main() {
+                match T {
+                    T => { return; }
+                    _ => { }
+                }
+                return;
+            }
+        "#;
+        let nonempty_src = r#"
+            fn main() {
+                match T {
+                    T => { return; }
+                    _ => { let _ = 0; }
+                }
+                return;
+            }
+        "#;
+
+        typecheck_source(empty_src).expect("empty wildcard must satisfy the presence requirement");
+        typecheck_source(nonempty_src)
+            .expect("non-empty wildcard must satisfy the presence requirement");
+    }
+
+    #[test]
+    fn statement_match_enum_present_empty_wildcard_admits_non_exhaustive_arms() {
+        // The exact bug reproduced pre-fix: non-exhaustive arms (only
+        // Flag::A covered out of three variants) plus an explicitly present,
+        // empty wildcard `_ => {}`. Before this fix, `default.is_empty()`
+        // could not distinguish this from "no wildcard at all" and rejected
+        // with a non-exhaustive-match error despite the real (if empty)
+        // catch-all in the source.
+        let src = r#"
+            enum Flag { A, B, C }
+
+            fn main() {
+                let f: Flag = Flag::A;
+                match f {
+                    Flag::A => { }
+                    _ => { }
+                }
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect(
+            "non-exhaustive arms plus a present (even empty) wildcard must typecheck, not \
+             reject as non-exhaustive",
+        );
+    }
+
+    #[test]
+    fn statement_match_enum_exhaustive_arms_may_still_omit_wildcard() {
+        // Item 6: guard against accidentally making the wildcard mandatory.
+        // A match family/form already allowed to omit `_` when arms are
+        // independently exhaustive must remain admitted after this fix.
+        let src = r#"
+            enum Flag { A, B }
+
+            fn main() {
+                let f: Flag = Flag::A;
+                match f {
+                    Flag::A => { }
+                    Flag::B => { }
+                }
+                return;
+            }
+        "#;
+
+        typecheck_source(src)
+            .expect("exhaustive enum match statement with no wildcard should still typecheck");
+    }
+
+    #[test]
+    fn statement_match_enum_non_exhaustive_arms_without_wildcard_still_rejects() {
+        // Item 5: a genuinely missing wildcard (no `_` arm at all, `None`)
+        // over non-exhaustive arms must still reject deterministically.
+        let src = r#"
+            enum Flag { A, B, C }
+
+            fn main() {
+                let f: Flag = Flag::A;
+                match f {
+                    Flag::A => { }
+                }
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("non-exhaustive enum match statement with no wildcard must reject");
+        assert!(
+            err.message
+                .contains("non-exhaustive match for enum 'Flag'; missing variants: B, C"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn result_pattern_family_must_match_result_scrutinee() {
         let src = r#"
@@ -11782,11 +11915,11 @@ fn check_loop_expr_stmt(
             // The per-arm loop (which rejects any or-pattern arm deterministically,
             // regardless of wildcard presence) must run before the default-arm
             // check below, mirroring the ordering used by the statement- and
-            // expression-form match handlers. Checking `default.is_empty()` first
-            // would let a naive "no `_` arm at all" rejection pre-empt the
-            // or-pattern diagnostic for an or-pattern match with no wildcard arm,
-            // breaking the promise that or-pattern rejection is uniform regardless
-            // of wildcard presence (SSF-07).
+            // expression-form match handlers. Checking `default`'s presence
+            // (`None` vs `Some`) first would let a naive "no `_` arm at all"
+            // rejection pre-empt the or-pattern diagnostic for an or-pattern
+            // match with no wildcard arm, breaking the promise that or-pattern
+            // rejection is uniform regardless of wildcard presence (SSF-07).
             let mut arm_plans: Vec<BindingPlan> = Vec::new();
             for arm in arms {
                 let (plan, mut arm_env) =
@@ -11822,50 +11955,56 @@ fn check_loop_expr_stmt(
             }
             apply_plans_to_scrutinee(*scrutinee, &arm_plans, arena, env);
 
-            if default.is_empty() {
-                // Mirror the plain statement-form match handler: an empty
-                // default arm is only a hard rejection when the covered sum-
-                // family variants aren't already exhaustive. A naive
-                // "default.is_empty() => reject" check here (as opposed to
-                // this exhaustiveness-aware one) would wrongly reject an
-                // exhaustive enum/Option/Result match with no wildcard arm
-                // inside a value-producing loop, even though the ordinary
-                // statement-form match already admits the identical program
-                // (SSF-07 review finding).
-                match missing_exhaustive_sum_variants(
-                    &st,
-                    arms.iter().map(|arm| (&arm.pat, arm.guard)),
-                    arena,
-                    adt_table,
-                )? {
-                    Some((family_label, missing)) if !missing.is_empty() => {
-                        return Err(non_exhaustive_match_error(&family_label, &missing, false)?)
-                    }
-                    Some(_) => {}
-                    None => {
-                        return Err(FrontendError {
-                            pos: 0,
-                            message: "match requires default arm '_'".to_string(),
-                        });
-                    }
-                }
-            } else {
-                let mut def_env = env.clone();
-                def_env.push_scope();
-                for stmt in default {
-                    check_loop_expr_stmt(
-                        *stmt,
+            match default {
+                None => {
+                    // Mirror the plain statement-form match handler: a truly
+                    // absent default arm is only a hard rejection when the
+                    // covered sum-family variants aren't already exhaustive.
+                    // A naive "no `_` arm at all => reject" check here (as
+                    // opposed to this exhaustiveness-aware one) would wrongly
+                    // reject an exhaustive enum/Option/Result match with no
+                    // wildcard arm inside a value-producing loop, even though
+                    // the ordinary statement-form match already admits the
+                    // identical program (SSF-07 review finding). An
+                    // explicitly present but empty wildcard (`_ => {}`) is
+                    // `Some(vec![])`, not `None`, and never reaches this
+                    // branch (FA-02-007 / #1639).
+                    match missing_exhaustive_sum_variants(
+                        &st,
+                        arms.iter().map(|arm| (&arm.pat, arm.guard)),
                         arena,
-                        &mut def_env,
-                        table,
-                        record_table,
                         adt_table,
-                        ret_ty.clone(),
-                        loop_stack,
-                        impl_list,
-                    )?;
+                    )? {
+                        Some((family_label, missing)) if !missing.is_empty() => {
+                            return Err(non_exhaustive_match_error(&family_label, &missing, false)?)
+                        }
+                        Some(_) => {}
+                        None => {
+                            return Err(FrontendError {
+                                pos: 0,
+                                message: "match requires default arm '_'".to_string(),
+                            });
+                        }
+                    }
                 }
-                def_env.pop_scope();
+                Some(default_body) => {
+                    let mut def_env = env.clone();
+                    def_env.push_scope();
+                    for stmt in default_body {
+                        check_loop_expr_stmt(
+                            *stmt,
+                            arena,
+                            &mut def_env,
+                            table,
+                            record_table,
+                            adt_table,
+                            ret_ty.clone(),
+                            loop_stack,
+                            impl_list,
+                        )?;
+                    }
+                    def_env.pop_scope();
+                }
             }
             Ok(())
         }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -496,7 +496,12 @@ pub enum Stmt {
     Match {
         scrutinee: ExprId,
         arms: Vec<MatchArm>,
-        default: Vec<StmtId>,
+        /// `None` means the source had no `_` default arm at all. `Some(body)`
+        /// means the source had an explicit `_ => { ... }` arm, independently
+        /// of whether `body` is empty -- an empty wildcard body (`_ => {}`)
+        /// is `Some(Vec::new())`, never conflated with `None` (FA-02-007 /
+        /// #1639). Mirrors `MatchExpr::default: Option<BlockExpr>` above.
+        default: Option<Vec<StmtId>>,
     },
     Break(Option<ExprId>),
     Continue,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -6529,7 +6529,7 @@ fn lower_stmt(
                             .to_string(),
                 });
             }
-            let exhaustive_without_default = if default.is_empty() {
+            let exhaustive_without_default = if default.is_none() {
                 match missing_exhaustive_sum_variants(
                     &scr_ty,
                     arms.iter().map(|arm| (&arm.pat, arm.guard)),
@@ -6884,6 +6884,9 @@ fn lower_stmt(
                 });
                 ctx.instrs.push(IrInstr::Assert { cond });
             } else {
+                let default = default
+                    .as_ref()
+                    .expect("non-exhaustive match statement requires explicit default in lowering");
                 let mut def_env = env.clone();
                 def_env.push_scope();
                 for s in default {
@@ -8259,7 +8262,7 @@ fn lower_loop_expr_stmt(
                             .to_string(),
                 });
             }
-            let exhaustive_without_default = if default.is_empty() {
+            let exhaustive_without_default = if default.is_none() {
                 match missing_exhaustive_sum_variants(
                     &scr_ty,
                     arms.iter().map(|arm| (&arm.pat, arm.guard)),
@@ -8579,6 +8582,9 @@ fn lower_loop_expr_stmt(
                 });
                 out.push(IrInstr::Assert { cond });
             } else {
+                let default = default
+                    .as_ref()
+                    .expect("non-exhaustive match statement requires explicit default in lowering");
                 let mut def_env = env.clone();
                 def_env.push_scope();
                 for stmt in default {
@@ -10752,6 +10758,75 @@ mod opt_tests {
             .instrs
             .iter()
             .any(|instr| matches!(instr, IrInstr::Assert { .. })));
+    }
+
+    // FA-02-007 / #1639, items 8-9: statement-form match lowering must
+    // preserve the same presence-vs-absence distinction as the AST -- an
+    // explicitly present but empty default (`Some(vec![])`) lowers as a real,
+    // reachable (if empty) branch, never collapsed into the "provably
+    // unreachable" trap backstop that a genuinely absent default (`None`)
+    // over exhaustive arms gets.
+
+    #[test]
+    fn lower_statement_match_exhaustive_without_default_to_trap_backstop() {
+        // Item 9: a legally exhaustive statement-form match with `None`
+        // (no `_` arm at all) must still lower correctly, with the
+        // impossible-to-reach default branch backed by an `Assert` trap.
+        let src = r#"
+            enum Flag { A, B }
+
+            fn main() {
+                let f: Flag = Flag::A;
+                match f {
+                    Flag::A => { }
+                    Flag::B => { }
+                }
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src)
+            .expect("exhaustive statement match without default should lower");
+        let main = &ir[0];
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::Assert { .. })));
+    }
+
+    #[test]
+    fn lower_statement_match_present_empty_default_does_not_emit_trap() {
+        // Item 8: an explicitly present but empty default (`_ => {}`, i.e.
+        // `Some(vec![])`) over non-exhaustive arms must lower successfully
+        // as a real branch. It must not be treated as absent and must not
+        // be routed through the impossible-match `Assert` trap -- if
+        // lowering ever regressed to inferring presence from body
+        // emptiness, this case (non-exhaustive arms, so the trap path would
+        // otherwise be unreachable) would either wrongly reject with
+        // "match requires default arm '_'" or wrongly emit an assert(false).
+        let src = r#"
+            enum Flag { A, B, C }
+
+            fn main() {
+                let f: Flag = Flag::A;
+                match f {
+                    Flag::A => { }
+                    _ => { }
+                }
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src)
+            .expect("non-exhaustive statement match with a present empty default should lower");
+        let main = &ir[0];
+        assert!(
+            !main
+                .instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::Assert { .. })),
+            "a present, empty default must not be lowered as the impossible-match trap"
+        );
     }
 
     #[test]

--- a/crates/smc-cli/src/executable_bundle.rs
+++ b/crates/smc-cli/src/executable_bundle.rs
@@ -745,7 +745,7 @@ fn collect_local_calls_from_stmt(
                     collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
                 }
             }
-            for stmt in default {
+            for stmt in default.iter().flatten() {
                 collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
             }
         }

--- a/tests/support/executable_bundle_support.rs
+++ b/tests/support/executable_bundle_support.rs
@@ -694,7 +694,7 @@ fn collect_local_calls_from_stmt(
                     collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
                 }
             }
-            for stmt in default {
+            for stmt in default.iter().flatten() {
                 collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
             }
         }


### PR DESCRIPTION
SSF-07 reconciliation: #1578
Fixes #1639

## Baseline

Fetched fresh `origin/main`; branched from `6959195a7f23adc52fcc78f9dc3c9dcb7bc3ff9d` (the exact baseline given for this slice) in an isolated `EnterWorktree` worktree.

## Pre-fix reproduction (empirical, on the exact baseline)

Constructed A/B/C via temporary probe tests, ran, recorded, then removed before implementation:

| Case | Source | `parse_program` result | Raw `default` |
|---|---|---|---|
| A. No wildcard | `Flag::A => {} Flag::B => {}` | `Ok` | `[]` |
| B. Empty wildcard | `Flag::A => {} _ => {}` | `Ok` | `[]` — **identical to A** |
| C. Non-empty wildcard | `Flag::A => {} _ => { return; }` | `Ok` | `[StmtId(1)]` |

A and B collapse to the exact same AST value, proving the defect directly on the raw AST, before any typechecking runs.

**Semantic consequence**, traced through `sm-front` typechecking (not just AST inspection): a 3-variant enum, arms covering only one variant, plus an explicitly present, empty `_ => {}`:

```rust
enum Flag { A, B, C }
fn main() {
    let f: Flag = Flag::A;
    match f {
        Flag::A => { }
        _ => { }
    }
    return;
}
```

Pre-fix result: `Err(FrontendError { pos: 0, message: "non-exhaustive match for enum 'Flag'; missing variants: B, C" })` — `_ => {}` treated exactly as if no wildcard had been written at all, because `default.is_empty()` sent this down the "no wildcard, check whether the arms alone are exhaustive" branch in `check_stmt`'s `Stmt::Match` handler (`crates/sm-front/src/typecheck.rs`).

## Root cause

`crates/sm-front/src/types.rs`: `Stmt::Match { default: Vec<StmtId>, .. }`. `parse_match_stmt_after_kw_match` (`crates/sm-front/src/parser.rs`) already tracks presence correctly during parsing — a local `let mut default: Option<Vec<StmtId>> = None;` is used for the duplicate-`_`-arm check (`default.is_some()`, #1637's own mechanism) — but then discards that presence information at AST-construction time:

```rust
Ok(self.arena.alloc_stmt(Stmt::Match {
    scrutinee,
    arms,
    default: default.unwrap_or_default(),   // <- presence erased here
}))
```

Every later consumer (typecheck, IR lowering) then had to infer presence from `default.is_empty()`, which cannot distinguish "no `_` arm at all" from "`_` arm present, body happens to be empty."

## Architecture decision

Changed `Stmt::Match.default` to `Option<Vec<StmtId>>`, mirroring `MatchExpr.default: Option<BlockExpr>` (`crates/sm-front/src/types.rs`), which already got this right for the expression form — same field name, same semantics, now consistent across both statement and expression match. No new field, no sentinel value, no dummy statement inserted into empty bodies — the presence the parser was already computing locally is simply no longer thrown away.

## Consumer inventory (workspace-wide)

`Stmt::Match` is matched in exactly 5 files (confirmed via `grep -rl "Stmt::Match"` across the whole workspace, not just the files named in the task):

- `crates/sm-front/src/parser.rs` — construction site; presence tracking already existed, just stopped discarding it. Also updated 3 existing tests that read `default` directly.
- `crates/sm-front/src/typecheck.rs` — **two independent copies** of the same match-checking logic: the plain statement handler (`check_stmt`'s `Stmt::Match` arm) and the value-producing-loop handler (`check_loop_expr_stmt`'s `Stmt::Match` arm, added for a prior, unrelated PR #1615 fix). Both changed `default.is_empty()` → `match default { None => ..., Some(body) => ... }`.
- `crates/sm-ir/src/legacy_lowering.rs` — same two-handler split at the IR layer (ordinary lowering and loop-expr-stmt lowering). Both changed the `exhaustive_without_default` computation from `default.is_empty()` to `default.is_none()`, and the default-branch lowering loop now unwraps the `Some` explicitly (mirroring the pre-existing `match_expr.default.as_ref().expect(...)` idiom used by the expression-form lowering a few hundred lines below).
- `crates/smc-cli/src/executable_bundle.rs` — pure call-collector walk (`for stmt in default { ... }`); mechanical `for stmt in default.iter().flatten() { ... }`, no semantic change (this function never distinguished presence from absence, only walked whatever statements exist).
- `tests/support/executable_bundle_support.rs` — an identical standalone copy of the same call-collector walk used by integration tests; same mechanical fix.

`docs/spec/foundation_source_profile_v1.md`, `docs/spec/source_semantics.md`, and `docs/spec/syntax.md` were inspected (see Documentation below); none needed changes.

A full `cargo build --workspace --all-targets --offline` (every crate, including `prom-ui`/`iced`-dependent UI crates and examples) was run after the fix to confirm no consumer was missed — clean, 0 errors.

## Semantic rule (presence vs. exhaustiveness, kept separate)

`default == None` means no wildcard arm exists in the source. `default == Some(body)` means the source explicitly wrote `_ => { ... }`, regardless of `body.len() == 0`. Any rule that requires a wildcard now tests presence (`is_none()`/`match`), never body contents. Any rule that may omit the wildcard because the non-default arms are independently exhaustive (Option/Result/enum) is untouched — the wildcard is not made mandatory anywhere; the existing per-scrutinee exhaustiveness policy is preserved exactly.

## Regressions

**A/B/C (raw AST, `crates/sm-front/src/parser.rs`):**
- `rustlike_parser_accepts_match_statement_with_no_default_arm` — updated: asserts `default == None` (A).
- `rustlike_parser_accepts_match_statement_with_one_default_arm` — updated: asserts `Some(nonempty)` (C); its stale comment documenting the #1639 limitation as a known fact is corrected.
- `rustlike_parser_distinguishes_absent_from_empty_present_default_arm` — new: parses both the no-wildcard and empty-wildcard forms side by side, asserts `None` vs `Some(vec![])` explicitly, and asserts the two are `!=` each other (A vs B, directly).

**4 (semantic equivalence) / 5 (missing-wildcard negative) / 6 (independently-exhaustive admission), `crates/sm-front/src/typecheck.rs`:**
- `statement_match_empty_and_nonempty_wildcard_satisfy_identical_quad_presence_requirement` — a quad match (always requires `_`) typechecks identically with `_ => {}` and `_ => { let _ = 0; }` (item 4).
- `statement_match_quad_without_wildcard_rejects` — quad match with no `_` at all still rejects with `"match requires default arm '_'"` (item 5).
- `statement_match_enum_present_empty_wildcard_admits_non_exhaustive_arms` — the exact bug reproduction, now typechecks successfully (the money-shot regression).
- `statement_match_enum_exhaustive_arms_may_still_omit_wildcard` — exhaustive enum arms with no `_` at all still typecheck (item 6, guards against accidentally making the wildcard mandatory).
- `statement_match_enum_non_exhaustive_arms_without_wildcard_still_rejects` — non-exhaustive arms, genuinely no `_`, still rejects with the correct "missing variants" message (item 5's enum-family counterpart).

**7 (duplicate-wildcard sibling, re-run, not modified):**
- `rustlike_parser_rejects_duplicate_default_match_statement_arm` (#1637) and `rustlike_parser_rejects_duplicate_default_match_expression_arm` (#1638) both still pass — this representation change does not restore "last wildcard wins" or any duplicate-default overwrite behavior, since the duplicate check already ran on the parser's own local `Option` before this fix and is untouched.

**8/9 (lowering, `crates/sm-ir/src/legacy_lowering.rs`):**
- `lower_statement_match_present_empty_default_does_not_emit_trap` — `Some(empty)` over non-exhaustive arms lowers successfully as a real, reachable (if empty) branch; explicitly asserts no `IrInstr::Assert` (impossible-match trap) is emitted for it (item 8).
- `lower_statement_match_exhaustive_without_default_to_trap_backstop` — a legally exhaustive match with `None` continues lowering correctly, backed by the `Assert` trap at the (genuinely unreachable) default label (item 9).

## Public API implications

`Stmt` is `pub`, so this is technically a public field-type change. Investigated whether it's covered by any golden snapshot:
- `crates/sm-front/src/lib.rs` is **not** in `public_api_contracts.rs`'s `TARGETS` list at all (sm-front's public surface, including `types.rs`, is currently uncovered by this guard — a pre-existing gap, related in spirit to FA-03-031/#1700's "public API guard omits sm-sema" finding, but out of scope for this slice).
- `crates/sm-ir/src/lib.rs` **is** a target (`sm_ir_lib.txt`) and re-exports `Stmt`/`StmtId` by name (`pub use sm_front::{ ..., Stmt, StmtId, ... };`), but that snapshot captures only the flat re-export name list, not field-level shapes — a `default: Vec<StmtId>` → `Option<Vec<StmtId>>` change inside `Stmt::Match` is invisible to it.

`cargo test --test public_api_contracts` was run after the fix: **88 passed, 0 failed, zero snapshot drift** (`git status --short tests/golden_snapshots/` confirms no golden file changed). No snapshot was touched, deliberately or otherwise — there was nothing to update.

## Documentation

Inspected `docs/spec/foundation_source_profile_v1.md`, `docs/spec/source_semantics.md`, `docs/spec/syntax.md` for wildcard/default-arm wording. None make any claim that becomes false: they describe the *source-syntax* contract ("enum match may omit `_` only when unguarded variant coverage is exhaustive", "quad match still requires an explicit default arm `_`") — statements about whether `_` appears in the source at all, never about internal AST representation or body emptiness. That source-level contract is completely unaffected by this fix; only the previously-buggy internal implementation is corrected to actually match what these docs already promised. No documentation changes made.

## Pre-fix → post-fix proof

The fix spans multiple files (a field-type change threaded through 5 consumer files), so rather than neutralizing one line, the pre-fix defect was reproduced surgically at its single root cause — the parser's construction site — by temporarily re-inserting the exact collapse:

```rust
// TEMP-DISABLED-FOR-PREFIX-PROOF
let default = match default {
    Some(d) if d.is_empty() => None,
    other => other,
};
```

immediately before constructing `Stmt::Match`. Ran the central regressions: **3 sm-front tests failed** with concrete evidence matching the original pre-fix reproduction exactly — `rustlike_parser_distinguishes_absent_from_empty_present_default_arm` (`left: None, right: Some([])` collapsed back together), `statement_match_enum_present_empty_wildcard_admits_non_exhaustive_arms` (`Err("non-exhaustive match for enum 'Flag'; missing variants: B, C")`, the exact original bug), and `statement_match_empty_and_nonempty_wildcard_satisfy_identical_quad_presence_requirement` (`Err("match requires default arm '_'")`). Also confirmed the sm-ir lowering regression `lower_statement_match_present_empty_default_does_not_emit_trap` fails **transitively** through the same neutralized parser, with the identical error. Restored the fix, confirmed zero residual `TEMP-DISABLED` markers via grep, confirmed the restored diff was byte-identical to a pre-saved patch via `diff`.

## Fallback/bypass audit

`git diff | grep -E "^\+" | grep -viE "^\+\+\+" | grep -iE "unwrap_or_default|unwrap_or_else|unwrap_or\b|or_else|Default::default\(\)|\.ok\(\)|ignored|catch-all|truncate|clear\(\)|take\(0\)|dummy"` — one match, a comment string ("catch-all in the source"), not a code pattern. Separately confirmed zero remaining production uses of `default.is_empty()` as a presence proxy anywhere in the workspace (`grep -rn "default\.is_empty()"` across every touched crate returns only two historical/explanatory comments, one describing a prior, already-fixed, unrelated PR #1615 bug and one inside this PR's own new test comment).

## Qualification

- `cargo test -p sm-front --offline` — 578 passed, 0 failed (572 baseline + 6 new)
- `cargo check --workspace --all-targets --offline` — clean
- `cargo build --workspace --all-targets --offline` — clean (full build, not just check, to be certain every UI/example consumer compiles)
- `cargo test -p sm-ir --offline` — 133 passed, 0 failed (131 baseline + 2 new)
- `cargo test -p sm-vm --offline` — 116 passed, 0 failed (unaffected)
- `cargo test -p smc-cli --offline` — 13 passed, 0 failed (unaffected)
- `cargo test --test g1_benchmark_baseline --test g1_execution_integrity --test g1_frontend_trust --test g1_real_program_trial --offline` — 12 passed, 0 failed (the integration suites that exercise `tests/support/executable_bundle_support.rs`)
- `cargo test --test public_api_contracts` — 88 passed, 0 failed, zero snapshot drift
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed, 0 failed
- `cargo fmt -p sm-front --check` — clean
- `cargo fmt -p sm-ir --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` (workspace-wide) — reproduces the known pre-existing Windows path-length OS error (`os error 206`), confirmed unchanged, not a regression from this diff
- Targeted #1639/#1637/#1638 sweep (10 tests: A/B/C raw-AST + presence/exhaustiveness matrix + duplicate-wildcard siblings) — all pass

## Changed files

- `crates/sm-front/src/types.rs` — `Stmt::Match.default: Vec<StmtId>` → `Option<Vec<StmtId>>`
- `crates/sm-front/src/parser.rs` — construction site stops discarding presence; 3 tests updated/added
- `crates/sm-front/src/typecheck.rs` — both statement-match handlers switched to presence-based branching; 5 new regressions; 2 stale comments corrected
- `crates/sm-ir/src/legacy_lowering.rs` — both statement-match lowering handlers switched to presence-based branching; 2 new regressions
- `crates/smc-cli/src/executable_bundle.rs` — mechanical iteration fix
- `tests/support/executable_bundle_support.rs` — mechanical iteration fix

## Out of scope

This PR does **not**: touch `Expr::Match`/`MatchExpr` (already correct, used as the reference model); change what source syntax is admitted (bare `<T, U>`-style omission of `_` remains governed by the existing per-scrutinee exhaustiveness rules, untouched); make the wildcard mandatory anywhere it wasn't already; repair #1637/#1638 (already closed, only re-verified as unaffected); repair #1646 (`Self` outside trait/impl), #1861 (storage admission catch-all), or any SSF-08 ownership-state issue (explicitly out of scope per the task); or close #1578 (the SSF-07 parent umbrella).
