### PR TITLE
fix(front): reject Self outside trait and impl context (#1646)

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -2735,11 +2735,16 @@ impl<'a> Parser<'a> {
         } else if self.check(TokenKind::Ident) {
             let t = self.tokens[self.next_non_layout_idx()].text.clone();
             if t == "Self" {
+                let self_pos = self.peek().pos;
                 let _ = self.advance();
                 if let Some(self_ty) = &self.self_type_scope {
                     self_ty.clone()
                 } else {
-                    Type::Record(self.arena.intern_symbol("Self"))
+                    return Err(FrontendError {
+                        pos: self_pos,
+                        message: "'Self' is only admitted in trait or impl method type positions"
+                            .to_string(),
+                    });
                 }
             } else if t == "qvec" {
                 let _ = self.advance();
@@ -6904,6 +6909,66 @@ fn main() {
     }
 
     #[test]
+    fn self_type_rejects_at_parse_time_in_every_ordinary_type_position() {
+        // FA-02-014 / #1646, matrix items 1-4: `Self` is contextual syntax
+        // admitted only inside a trait/impl owner scope (`self_type_scope`).
+        // Every ordinary type position -- direct or nested, anywhere
+        // `parse_type` is reachable outside that scope -- must reject
+        // deterministically at parse time, never silently become
+        // `Type::Record("Self")`. Nesting must not bypass the rule: the
+        // recursive `parse_type` calls inside `Option`/`Sequence`/`Result`/
+        // tuple parsing reach the identical `Self` branch.
+        let cases = [
+            (
+                "A: function parameter",
+                "fn f(x: Self) -> i32 { return 0; }\n",
+            ),
+            (
+                "B: function return",
+                "record R { x: i32 }\nfn f() -> Self { return R { x: 0 }; }\n",
+            ),
+            (
+                "C: let annotation",
+                "fn f() -> i32 {\n    let x: Self = 0;\n    return 0;\n}\n",
+            ),
+            (
+                "D: record field",
+                "record R {\n    x: Self\n}\nfn main() { return; }\n",
+            ),
+            (
+                "E: ADT payload",
+                "enum E {\n    A(Self)\n}\nfn main() { return; }\n",
+            ),
+            (
+                "G: nested Option(Self)",
+                "fn f(x: Option(Self)) -> i32 { return 0; }\n",
+            ),
+            (
+                "G: nested Sequence(Self)",
+                "fn f(x: Sequence(Self)) -> i32 { return 0; }\n",
+            ),
+            (
+                "G: nested Result(Self, i32)",
+                "fn f(x: Result(Self, i32)) -> i32 { return 0; }\n",
+            ),
+            (
+                "G: nested tuple (Self, i32)",
+                "fn f(x: (Self, i32)) -> i32 { return 0; }\n",
+            ),
+        ];
+        for (label, src) in cases {
+            let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+                .expect_err(&format!("{label}: Self outside owner context must reject"));
+            assert!(
+                err.message
+                    .contains("'Self' is only admitted in trait or impl method type positions"),
+                "{label}: unexpected error: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
     fn trait_method_self_type_parses_as_owner_layer_marker() {
         let src = r#"
 trait Iterable {
@@ -7110,6 +7175,42 @@ fn apply<T: Eq, U>(x: T, y: U) -> i32 {
             "type_param_scope must be restored to exactly its pre-call depth \
              and contents -- only the entries this call pushed should be \
              popped, leaving the pre-existing outer entry untouched"
+        );
+    }
+
+    #[test]
+    fn with_self_type_scope_restores_previous_scope_when_the_closure_errors() {
+        // FA-02-014 / #1646, owner-state restoration audit: `with_self_type_scope`
+        // saves the previous `self_type_scope`, installs the owner type, runs
+        // the closure, and restores the previous value unconditionally --
+        // `let result = f(self);` does not use `?`, so the restoration line
+        // always runs whether the closure returned `Ok` or `Err`. This
+        // directly inspects a `Parser`'s `self_type_scope` after an error
+        // occurs *inside* a trait body (a malformed method signature after
+        // the return arrow) to prove the scope is genuinely restored, not
+        // merely argued to be safe by the surrounding architecture.
+        let src = "trait Contract {\n    fn a(x: Self) -> ;\n}\n";
+        let tokens = lex_tokens(src).expect("lex");
+        let profile = ParserProfile::foundation_default();
+        let mut p = Parser {
+            tokens,
+            idx: 0,
+            source: src.to_string(),
+            arena: AstArena::default(),
+            policy: CompilePolicyView::new(&profile),
+            type_param_scope: Vec::new(),
+            self_type_scope: None,
+        };
+        assert_eq!(p.self_type_scope, None, "scope before the call");
+        let result = p.parse_program();
+        assert!(
+            result.is_err(),
+            "malformed method signature inside the trait body must reject"
+        );
+        assert_eq!(
+            p.self_type_scope, None,
+            "self_type_scope must be restored to its pre-call value even when \
+             the closure that installed it returns Err"
         );
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -9150,6 +9150,15 @@ mod tests {
 
     #[test]
     fn self_type_outside_trait_or_impl_positions_is_not_admitted() {
+        // FA-02-014 / #1646: before this fix, this test passed only by
+        // coincidence -- `parse_type` silently rewrote out-of-context `Self`
+        // to `Type::Record("Self")`, and this specific source happened to
+        // reject downstream only because no record named "Self" exists, with
+        // the accidental message "unknown nominal type 'Self'". The parser
+        // now rejects `Self` deterministically the moment it is recognized
+        // outside a trait/impl owner scope, regardless of whether any
+        // declaration happens to be named "Self" -- see the companion test
+        // below, which proves the difference is not merely cosmetic.
         let src = r#"
             fn id(value: Self) -> Self {
                 return value;
@@ -9162,7 +9171,43 @@ mod tests {
         let err = typecheck_source(src)
             .expect_err("Self outside trait/impl method type positions must stay unsupported");
         assert!(
-            err.message.contains("unknown nominal type 'Self'"),
+            err.message
+                .contains("'Self' is only admitted in trait or impl method type positions"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn self_type_outside_owner_context_rejects_even_when_a_record_named_self_exists() {
+        // FA-02-014 / #1646, matrix item 12: the required invariant is that
+        // an ordinary type reference spelled `Self` must never resolve as a
+        // nominal record merely because a record happens to be named
+        // "Self". Before this fix, `record Self { x: i32 }` followed by an
+        // ordinary `fn f(x: Self) -> i32 { ... }` typechecked successfully
+        // end-to-end (`Ok(())`) -- `Self` silently resolved to that
+        // unrelated record, exactly the misresolution this issue exists to
+        // close. The parser-level rejection is unconditional: it never
+        // consults the record/ADT tables at all, so this now rejects
+        // deterministically regardless of what happens to be declared.
+        let src = r#"
+            record Self { x: i32 }
+
+            fn f(x: Self) -> i32 {
+                return 0;
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src).expect_err(
+            "an ordinary Self reference must reject even when a record literally named \
+             Self is declared, never silently resolve to it",
+        );
+        assert!(
+            err.message
+                .contains("'Self' is only admitted in trait or impl method type positions"),
             "unexpected error: {}",
             err.message
         );

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -280,6 +280,24 @@ never a guessed `Record` regardless of the target's actual family. Broader
 generic/blanket/dynamic impl forms remain outside this closed surface, as
 described above.
 
+`Self` is reserved contextual type syntax, not an ordinary nominal type
+name: the parser admits it only while `self_type_scope` is populated, which
+is true exactly while parsing a trait method signature or an impl method's
+type positions (`parse_trait_decl`/`parse_impl_decl`, via
+`with_self_type_scope`), direct or nested through any currently admitted
+structural type family. Before SSF-07 #1646, `Self` written anywhere else
+(an ordinary function parameter/return, a record field, an ADT payload, a
+`let` annotation) silently parsed as `Type::Record("Self")` — a genuine
+nominal type reference to whatever happens to be named `Self`, which
+existed if and only if some other declaration happened to share that name,
+and rejected with an unrelated "unknown nominal type" diagnostic otherwise.
+`parse_type` now rejects `Self` outside `self_type_scope` deterministically,
+at the exact point recognition occurs, before any record/ADT table lookup
+ever runs — this holds unconditionally, even when a record or enum is
+declared with the literal name `Self`, so an ordinary type reference
+spelled `Self` can never be silently resolved as that unrelated
+declaration.
+
 `TraitTable` (`build_trait_table`) is itself the admitted owner-layer trait
 contract, not an unchecked cache of raw parsed declarations: every non-`Self`
 parameter and return type in every trait method signature is canonicalized

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -476,10 +476,15 @@ Current v0 range-literal limits:
   first-wave iterable loop path on `main`
 - direct record `Iterable` impl dispatch now executes on current `main` when the
   impl exposes `fn next(self: Self, index: i32) -> Option(Item)`
-- `Self` is admitted only in trait method signatures and impl method type
-  positions on current `main`
-- `Self` outside trait/impl method type positions is not part of the stable
-  syntax contract
+- `Self` is reserved contextual type syntax, admitted only while parsing a
+  trait method signature or an impl method's type positions on current
+  `main` -- direct or nested (`Option(Self)`, `Sequence(Self)`,
+  `Result(Self, T)`, tuple positions, etc.), the parser tracks this owner
+  context explicitly rather than inferring it structurally
+- `Self` written anywhere outside that owner context is rejected
+  deterministically at parse time (FA-02-014 / #1646) and is never
+  reinterpreted as an ordinary nominal type name -- this holds even when a
+  record or enum happens to be declared with the literal name `Self`
 - ADT/schema iterable dispatch and indirect iterable projection are not part of
   the current syntax contract
 - descending/custom-step/general iterable range forms are not yet part of the


### PR DESCRIPTION
SSF-07 reconciliation: #1578
Fixes #1646

## Baseline

Fetched fresh `origin/main`; branched from `39989470c2c37998ac9e0ee2692d35bcc1c46297` (the exact baseline given for this slice) in an isolated `EnterWorktree` worktree.

## Reproduction matrix (empirical, on the exact baseline)

Ran a comprehensive probe suite against genuinely unmodified `crates/sm-front/src/parser.rs` (implementation was reverted, probes run, results recorded, probes removed, implementation reapplied — not just read):

| Item | Source | Pre-fix parse result |
|---|---|---|
| A. Function parameter | `fn f(x: Self) -> i32` | `Ok`, `Record(SymbolId)` |
| B. Function return | `fn f() -> Self` | `Ok`, `Record(SymbolId)` |
| C. `let` annotation | `let x: Self = 0;` | `Ok` |
| D. Record field | `record R { x: Self }` | `Ok`, `Record(SymbolId)` |
| E. ADT payload | `enum E { A(Self) }` | `Ok`, `Record(SymbolId)` |
| G. Nested — all 4 forms | `Option(Self)`, `Sequence(Self)`, `Result(Self, i32)`, `(Self, i32)` | `Ok`, `Self` → `Record(SymbolId)` in every nested position — **nesting provides no protection**, since the recursive `parse_type` calls all reach the identical buggy branch |

**Nominal `Self` collision, traced through the full pipeline** (not just AST inspection):

- No `record Self` declared: `fn id(value: Self) -> Self { ... }` — parses `Ok`; `type_check_program` rejects with `Err("unknown nominal type 'Self'")`. This is the **exact mechanism** the pre-existing test `self_type_outside_trait_or_impl_positions_is_not_admitted` relied on — it passed only because no record named "Self" happened to exist, an accidental, coincidental rejection, not a deliberate "Self is contextual syntax" one.
- `record Self { x: i32 }` declared, then an ordinary `fn f(x: Self) -> i32 { ... }`: parses `Ok`, `build_record_table` admits the record `Ok`, and **`type_check_program` returns `Ok(())`** — the whole pipeline succeeds, with the ordinary `Self` reference silently resolved to the unrelated declared record. This is the concrete, dangerous form of the defect: not a parser artifact, a full misresolution that a real program could hit.

## Positive controls (H, I — re-verified, not duplicated)

Trait-side and impl-side `Self` admission is already thoroughly covered by existing tests and was re-run, unmodified, to confirm this fix doesn't touch them:
- `trait_method_self_type_parses_as_owner_layer_marker`, `impl_method_self_type_is_anchored_to_impl_target` (`parser.rs`)
- `build_trait_table_admits_reserved_self_in_direct_and_nested_source_positions` (direct + `(Self, i32)` tuple + `Sequence(Self)` + `Option(Self)` + `Result(Self, i32)` + `Result(i32, Self)`), `canonicalize_declared_type_generic_admits_self_in_closure_positions`, `build_trait_table_does_not_treat_unrelated_nominal_type_as_self` (`lib.rs`)
- `trait_self_contract_allows_multiple_impl_targets`, `trait_self_contract_still_rejects_wrong_concrete_impl_parameter`, `substitute_trait_self_type_covers_nested_positions_for_both_nominal_families`, `impl_self_for_adt_target_typechecks_body_as_the_correct_adt_not_a_guessed_record`, `impl_self_conformance_mismatch_reports_the_correct_adt_type_not_record`, `impl_target_that_does_not_exist_rejects_even_without_any_self_reference`, `impl_target_ambiguous_between_record_and_enum_rejects_deterministically`, `impl_target_that_exists_without_self_reference_still_typechecks`, `impl_self_nested_in_option_typechecks_end_to_end_for_enum_target` (`typecheck.rs`, #1667/#1651 territory)

All 31 relevant tests re-run explicitly, all pass.

## Parser owner-boundary decision

`self_type_scope: Option<Type>` (populated only by `with_self_type_scope`, called from `parse_trait_decl`/`parse_impl_decl`) is the sole, narrow owner-context marker — unchanged, not widened or redesigned. `parse_type`'s `Self` branch now rejects deterministically the instant `self_type_scope` is `None`, at the exact recognition point, before any record/ADT table lookup can run:

```rust
if t == "Self" {
    let self_pos = self.peek().pos;
    let _ = self.advance();
    if let Some(self_ty) = &self.self_type_scope {
        self_ty.clone()
    } else {
        return Err(FrontendError {
            pos: self_pos,
            message: "'Self' is only admitted in trait or impl method type positions"
                .to_string(),
        });
    }
}
```

Position is captured via `self.peek().pos` (the next non-layout token's position) *before* `self.advance()` consumes it — `self.pos()` after advancing would point past the `Self` token, since `advance()` internally skips to `next_non_layout_idx()` before moving `self.idx`.

## `Self` occurrence inventory (workspace-wide)

Searched the entire workspace (`crates/`, `tests/`, `docs/`) for `self_type_scope`, `TypeVar(Self`, `Type::Record(...Self...)`, `substitute_trait_self_type`, and the literal string `"Self"`. Every production occurrence lives in `sm-front` (`parser.rs`/`typecheck.rs`/`lib.rs`) — confirmed zero occurrences anywhere in `sm-ir`, `sm-vm`, `smc-cli`, `sm-sema`, since `Self` is always resolved to a concrete `Type` before IR lowering ever runs. Classified:

- **Parser contextual syntax owner**: `self_type_scope` field + `with_self_type_scope` + `parse_type`'s `Self` branch (`parser.rs`) — the one and only admission rule, now fixed.
- **Trait placeholder**: `self_placeholder = Type::TypeVar(intern_symbol("Self"))` in `parse_trait_decl` (`parser.rs:365`) — untouched.
- **Impl target anchoring**: `Type::Record(for_type)` passed to `with_self_type_scope` in `parse_impl_decl` (`parser.rs:431`) — untouched.
- **Canonicalization/substitution**: the `"Self"` symbol lookups in `build_trait_table` (`lib.rs:659`) and `validate_impl_conformance` (`typecheck.rs:12117`), and `substitute_trait_self_type` itself (`typecheck.rs:12294`) — all downstream, owner-context-only, operate strictly on `Self` occurrences the parser already admitted. None of these is a second admission path; none can recreate `Record("Self")` from an out-of-context reference.
- **Diagnostic/test/docs**: the remaining `"Self"`/`.get("Self")` occurrences inside test bodies.
- **Unrelated nominal string**: none found — every quoted `"Self"` in the workspace refers to this one contextual-syntax mechanism.

This proves exactly one contextual parser admission rule exists, with no second fallback anywhere that could recreate `Record("Self")` after this fix.

## Nominal `record Self` collision — final characterization

`record Self { ... }` remains syntactically representable (declaration names are not reserved by this slice) and remains a perfectly ordinary record in every way *except* that it can no longer be referenced through the bare `Self` type-syntax token — writing `Self` anywhere outside a trait/impl owner scope now always means "the contextual placeholder is missing," never "look up whatever happens to be named Self." Reaching that record from ordinary code still works through its own separate identity (e.g. as a payload/field type written in a context where an unrelated declaration named "Self" is intended, which remains representable through any *other* spelling — there is none for "Self" specifically, since "Self" the token is now always contextual). This is intentional and matches the required invariant precisely: it is not a declaration-name reservation policy (no rejection at `record Self { ... }`'s own declaration site), it is a type-*reference* rule. No evidence was found that a broader declaration-name reservation policy is warranted or expected by any current contract; not attempted here.

## Owner-state restoration audit

`with_self_type_scope` (`parser.rs:78-87`) was already correct: `let result = f(self);` does not use `?`, so `self.self_type_scope = previous;` runs unconditionally after the closure regardless of `Ok`/`Err`. Not refactored — proven instead, via a new regression that constructs a `Parser` directly, runs a trait body whose method signature is malformed *after* the return arrow (so the error occurs while `self_type_scope` is `Some(...)`), and directly asserts `self_type_scope == None` afterward.

## Regressions

- `self_type_rejects_at_parse_time_in_every_ordinary_type_position` (`parser.rs`) — table-driven, covers A/B/C/D/E and all 4 nested-G forms in one pass (matrix items 1-4).
- `with_self_type_scope_restores_previous_scope_when_the_closure_errors` (`parser.rs`) — direct-Parser-construction proof of owner-state restoration on error.
- `self_type_outside_trait_or_impl_positions_is_not_admitted` (`typecheck.rs`) — updated: was passing on the old accidental "unknown nominal type 'Self'" message; now asserts the new deterministic message, with a comment explaining exactly what changed and why the old pass was coincidental.
- `self_type_outside_owner_context_rejects_even_when_a_record_named_self_exists` (`typecheck.rs`) — new: the `record Self { ... }` collision, matrix item 12, proving the fix is unconditional rather than merely downstream-lookup-shaped.
- Items 5-11 (trait/impl positive controls, #1651/#1667 impl-target regressions) — all pre-existing, re-verified unmodified (see Positive controls above), not duplicated.

## Pre-fix → post-fix proof

Saved `git diff -- crates/sm-front/src/parser.rs` to a local patch file. Temporarily restored the historical fallback (`Type::Record(self.arena.intern_symbol("Self"))`) behind an `if true` / `TEMP-DISABLED-FOR-PREFIX-PROOF` marker. Ran the 3 central regressions — **all 3 failed** with concrete evidence: the table-driven test failed on case A with a full `Program` dump showing `Record(SymbolId(2))` for the `Self` parameter; `self_type_outside_trait_or_impl_positions_is_not_admitted` failed reproducing the exact old message `"unknown nominal type 'Self'"`; and `self_type_outside_owner_context_rejects_even_when_a_record_named_self_exists` failed with `expect_err` panicking on `Ok(())` — the collision silently succeeding again, reproducing the dangerous case exactly. The owner-state-restoration test (unrelated to the `Self`-rejection branch) correctly kept passing throughout, confirming it tests an orthogonal invariant. Restored the fix, confirmed zero residual `TEMP-DISABLED` markers via grep, confirmed the restored diff was byte-identical to the saved patch via `diff`. Deleted the patch files.

## Sibling audit

- **#1667** (impl `Self` concrete nominal family) / **#1651** (impl target existence) — unaffected; `validate_impl_conformance`/impl-target resolution not touched; all their regressions re-run and pass (see Positive controls).
- **#1669/#1647** (trait signature canonical/executable admission) — unaffected; `build_trait_table`/`ensure_executable_type_supported` not touched.
- **#1635** (generic traits) / **#1668** (generic impls) — unaffected; not touched, unrelated to `Self` admission.
- **#1861** (storage type admission catch-all) — unaffected; different function entirely, not touched.
- **#1648/#1649/#1650/#1717** (generic frontend/IR boundaries) — unaffected; this slice is parser contextual admission for `Self`, not a generic-type-parameter concern; no interaction.

This PR stays exactly parser-level contextual admission — it does not become a typechecker nominal-resolution repair. The one typecheck.rs test file change is a *test* update (the pre-existing test's assertion), not a change to any typecheck production logic.

## Fallback/bypass audit

`git diff | grep -E "^\+" | grep -viE "^\+\+\+" | grep -iE "unwrap_or|unwrap_or_default|unwrap_or_else|or_else|Default::default\(\)|catch-all|ignored|synthetic default"` — zero matches. Separately confirmed zero remaining production occurrences of `Type::Record(...intern_symbol("Self")...)` or any equivalent fallback anywhere in `sm-front` — the only remaining `intern_symbol("Self")`/`Type::TypeVar(...Self...)` sites are the legitimate trait placeholder (`parser.rs:365`) and a test helper (`typecheck.rs:9269`), both already classified above.

## Documentation

- `docs/spec/syntax.md` — strengthened the existing "`Self` outside trait/impl method type positions is not part of the stable syntax contract" line, which was ambiguous about *how* out-of-context `Self` was handled (and, pre-fix, was actually misleading — the parser silently admitted it with different semantics rather than treating it as unsupported). Now states explicitly: rejected deterministically at parse time, never reinterpreted as an ordinary nominal type, holds even when a record/enum is declared with the literal name `Self`.
- `docs/spec/foundation_source_profile_v1.md` — added a new paragraph immediately before the `TraitTable` discussion, stating the contextual-admission rule and the pre-fix defect/collision precisely, matching this file's established role as the detailed normative boundary spec (mirrors the pattern used for #1633/#1650/#1717's additions here).
- `docs/spec/source_semantics.md` — inspected; its existing wording ("trait-side `Self` now denotes the impl-anchored receiver contract only inside trait method signatures and impl method type positions", "`Self` does not widen the general executable type surface beyond that narrow trait/impl contract") describes the *admitted* scope accurately and makes no claim about out-of-context handling either way — not false, not changed.

Does not claim Rust-equivalent `Self` semantics more broadly than implemented anywhere.

## Qualification

- `cargo test -p sm-front --offline` — 581 passed, 0 failed (578 baseline + 3 new)
- `cargo check --workspace --all-targets --offline` — clean
- `cargo build --workspace --all-targets --offline` — clean (ran as part of the `frontend_parser_qualification`/`frontend_lexer_qualification` build, full workspace including UI crates)
- `cargo test -p sm-ir -p sm-vm --offline` — 133 + 116 passed, 0 failed (unaffected)
- `cargo test --test public_api_contracts` — 88 passed, 0 failed, zero snapshot drift
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed, 0 failed
- `cargo test --test frontend_parser_qualification --test frontend_lexer_qualification` — 9 + 8 passed, 0 failed
- `cargo fmt -p sm-front --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` (workspace-wide) — reproduces the known pre-existing Windows path-length OS error (`os error 206`), confirmed unchanged, not a regression from this diff
- Targeted #1667/#1651/#1669/#1647 + all `Self`-related regression sweep (31 tests) — all pass

## Changed files

- `crates/sm-front/src/parser.rs` — `parse_type`'s `Self` branch rejects deterministically outside `self_type_scope`; 2 new regressions
- `crates/sm-front/src/typecheck.rs` — 1 existing test's assertion updated to the new message; 1 new regression (the `record Self` collision)
- `docs/spec/foundation_source_profile_v1.md` — new normative paragraph on the contextual-admission boundary
- `docs/spec/syntax.md` — strengthened the out-of-context `Self` wording to state deterministic rejection explicitly

## Out of scope

This PR does **not**: reserve `Self` (or any other name) as a forbidden declaration name — `record Self { ... }` remains representable, only ordinary *references* spelled `Self` are affected; widen or redesign `self_type_scope`/`with_self_type_scope`; touch `substitute_trait_self_type`, `build_trait_table`, or `validate_impl_conformance`; repair #1667/#1651/#1669/#1647/#1635/#1668/#1861 (all re-verified unaffected, not touched); touch anything in #1648/#1649/#1650/#1717's generic frontend/IR territory; or close #1578 (the SSF-07 parent umbrella). It closes exactly one gap: an ordinary type reference spelled `Self` can no longer be silently reinterpreted as a nominal record — it is now rejected deterministically the moment the parser recognizes it outside a trait/impl owner scope, regardless of what happens to be declared elsewhere.
