### PR TITLE
fix(front): make storage type admission exhaustive (#1861)

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -3584,6 +3584,269 @@ mod tests {
         type_check_program(&program)
     }
 
+    // FA-02-038 / #1861: exhaustive storage-type admission regression
+    // matrix. `ensure_storage_type_supported` is the sole shared authority
+    // for every field/binding storage position (Const/Let/LetTuple/
+    // LetElseTuple/Discard local bindings, and -- newly wired by this fix --
+    // record fields and ADT payloads). Its own exhaustiveness (no `_` arm at
+    // all) is a compile-time property, not something a runtime test can
+    // prove as strongly as the compiler itself: `cargo build`/`cargo check`
+    // succeeding after adding this function's body IS that proof -- if a
+    // 21st `Type` variant is ever added without updating this match, the
+    // crate fails to compile rather than silently admitting it.
+
+    #[test]
+    fn storage_admission_accepts_every_qualified_scalar_leaf() {
+        // Type::Unit has no explicit type-annotation source syntax at all
+        // (parse_type has no "Unit"/"()" branch -- it only ever arises
+        // implicitly as an omitted function return type), so it cannot be
+        // exercised via a `let` annotation here; it is covered directly
+        // below alongside the other structural-placeholder direct-call
+        // proofs.
+        let cases = [
+            ("quad", "N"),
+            ("bool", "true"),
+            ("text", "\"s\""),
+            ("i32", "0"),
+            ("u32", "0u32"),
+            ("fx", "0.0fx"),
+            ("f64", "0.0"),
+        ];
+        for (ty, value) in cases {
+            let src = format!("fn main() {{\n    let x: {ty} = {value};\n    return;\n}}\n");
+            typecheck_source(&src)
+                .unwrap_or_else(|e| panic!("scalar leaf '{ty}' must be admitted storage: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn storage_admission_accepts_every_qualified_composite_and_recurses_into_children() {
+        let cases = [
+            (
+                "Sequence(i32)",
+                "fn main() {\n    let x: Sequence(i32) = [1, 2];\n    return;\n}\n",
+            ),
+            (
+                "Option(i32)",
+                "fn main() {\n    let x: Option(i32) = Option::Some(1);\n    return;\n}\n",
+            ),
+            (
+                "Result(i32, i32)",
+                "fn main() {\n    let x: Result(i32, i32) = Result::Ok(1);\n    return;\n}\n",
+            ),
+            (
+                "tuple (i32, i32)",
+                "fn main() {\n    let x: (i32, i32) = (1, 2);\n    return;\n}\n",
+            ),
+            (
+                "Map(i32, i32)",
+                "fn main() {\n    let x: Map(i32, i32) = map_empty();\n    return;\n}\n",
+            ),
+            (
+                "Closure(f64 -> f64)",
+                "fn main() {\n    let x: Closure(f64 -> f64) = (v => v + 1.0);\n    return;\n}\n",
+            ),
+        ];
+        for (label, src) in cases {
+            typecheck_source(src)
+                .unwrap_or_else(|e| panic!("composite '{label}' must be admitted storage: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn storage_admission_rejects_direct_qvec() {
+        let src = "fn main() {\n    let x: qvec[8] = qvec[8];\n    return;\n}\n";
+        let err = typecheck_source(src).expect_err("direct qvec storage must reject");
+        assert!(
+            err.message.contains("qvec is a reserved type"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn storage_admission_rejects_qvec_nested_in_every_composite() {
+        let src = "fn main() { return; }\n";
+        let program = parse_program(src).expect("parse");
+        let record_table = crate::build_record_table(&program).expect("record table");
+        let adt_table = crate::build_adt_table(&program).expect("adt table");
+        let qvec = Type::QVec(8);
+        let cases: Vec<(&str, Type)> = vec![
+            ("Option(qvec)", Type::Option(Box::new(qvec.clone()))),
+            (
+                "Sequence(qvec)",
+                Type::Sequence(crate::types::SequenceType {
+                    family: crate::types::SequenceCollectionFamily::OrderedSequence,
+                    item: Box::new(qvec.clone()),
+                }),
+            ),
+            (
+                "Result(qvec, i32)",
+                Type::Result(Box::new(qvec.clone()), Box::new(Type::I32)),
+            ),
+            (
+                "Result(i32, qvec)",
+                Type::Result(Box::new(Type::I32), Box::new(qvec.clone())),
+            ),
+            (
+                "Tuple(i32, qvec)",
+                Type::Tuple(vec![Type::I32, qvec.clone()]),
+            ),
+            (
+                "Map(i32, qvec)",
+                Type::Map(crate::types::MapType {
+                    key: Box::new(Type::I32),
+                    val: Box::new(qvec.clone()),
+                }),
+            ),
+            (
+                "Closure(qvec -> i32)",
+                Type::Closure(crate::types::ClosureType {
+                    family: crate::types::ClosureValueFamily::UnaryDirect,
+                    capture: crate::types::ClosureCapturePolicy::Immutable,
+                    param: Box::new(qvec.clone()),
+                    ret: Box::new(Type::I32),
+                }),
+            ),
+        ];
+        for (label, ty) in cases {
+            let canonical =
+                canonicalize_declared_type(&ty, &record_table, &adt_table, &program.arena)
+                    .unwrap_or_else(|e| panic!("{label}: canonicalize failed: {e:?}"));
+            let err =
+                ensure_storage_type_supported(&canonical, &program.arena, "probe".to_string())
+                    .expect_err(&format!(
+                        "{label}: nested qvec must reject, recursion must reach it"
+                    ));
+            assert!(
+                err.message.contains("qvec is a reserved type"),
+                "{label}: unexpected error: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn storage_admission_rejects_typevar_and_range_and_admits_unit_directly() {
+        let src = "fn main() { return; }\n";
+        let program = parse_program(src).expect("parse");
+        let typevar_name = program.arena.symbol_to_id.get("main").copied().unwrap();
+
+        let typevar_err = ensure_storage_type_supported(
+            &Type::TypeVar(typevar_name),
+            &program.arena,
+            "probe".to_string(),
+        )
+        .expect_err("TypeVar must reject: storage admission has no admitted-type-var context");
+        assert!(
+            typevar_err
+                .message
+                .contains("is not admitted as a storage type"),
+            "unexpected error: {}",
+            typevar_err.message
+        );
+
+        let range_err =
+            ensure_storage_type_supported(&Type::RangeI32, &program.arena, "probe".to_string())
+                .expect_err("RangeI32 must reject: it is a structural/iteration type, not storage");
+        assert!(
+            range_err.message.contains("range values are not admitted"),
+            "unexpected error: {}",
+            range_err.message
+        );
+
+        // Type::Unit has no type-annotation source syntax (see the comment
+        // on storage_admission_accepts_every_qualified_scalar_leaf), so its
+        // admission is proven directly here instead.
+        ensure_storage_type_supported(&Type::Unit, &program.arena, "probe".to_string())
+            .expect("Unit must be admitted: a trivial, always-representable storage leaf");
+    }
+
+    #[test]
+    fn storage_admission_rejects_unsupported_record_field_type() {
+        // Items 5 + regression matrix core: end-to-end through the actual
+        // record declaration validation path (validate_record_declarations),
+        // not the helper called directly.
+        let src = "record R {\n    x: qvec[8]\n}\nfn main() {\n    return;\n}\n";
+        let err = typecheck_source(src).expect_err("record field with qvec must reject");
+        assert!(
+            err.message.contains("qvec is a reserved type") && err.message.contains("field 'R.x'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn storage_admission_rejects_unsupported_adt_payload_type() {
+        let src = "enum E {\n    A(qvec[8])\n}\nfn main() {\n    return;\n}\n";
+        let err = typecheck_source(src).expect_err("ADT payload with qvec must reject");
+        assert!(
+            err.message.contains("qvec is a reserved type")
+                && err.message.contains("variant 'E::A'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn storage_admission_rejects_unsupported_binding_annotation() {
+        // Item 7: at least one let/const path proving the shared authority
+        // is wired identically for local bindings, not just record/ADT
+        // fields.
+        let src = "fn main() {\n    let x: qvec[8] = qvec[8];\n    return;\n}\n";
+        let err = typecheck_source(src).expect_err("let annotation with qvec must reject");
+        assert!(
+            err.message.contains("qvec is a reserved type") && err.message.contains("let 'x'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn storage_admission_admits_qualified_non_generic_record_and_adt_storage() {
+        // Item 8: positive control -- ordinary, fully-supported field/
+        // payload types must remain green after wiring storage admission
+        // into declaration validation.
+        let src = r#"
+            record Point {
+                x: i32,
+                y: i32,
+                label: text,
+            }
+
+            enum Shape {
+                Circle(f64),
+                Square(f64, f64),
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("record/ADT with fully-supported field/payload types must typecheck");
+    }
+
+    #[test]
+    fn storage_admission_closes_nominal_cross_boundary_escape() {
+        // Item 9, the central FA-02-038 finding: pre-fix, an unsupported
+        // field type hid inside an admitted record declaration and escaped
+        // as a trusted Type::Record nominal shell to an ordinary function
+        // signature, which #1647's executable-signature admission accepted
+        // without ever looking inside the record's own fields (it only
+        // resolves the symbol name). The record declaration itself must now
+        // reject before any nominal shell is ever trusted downstream.
+        let src = "record R {\n    x: qvec[8]\n}\nfn f(r: R) -> i32 {\n    return 0;\n}\nfn main() {\n    return;\n}\n";
+        let err = typecheck_source(src).expect_err(
+            "unsupported field must reject before the record's nominal identity is trusted",
+        );
+        assert!(
+            err.message.contains("qvec is a reserved type"),
+            "unexpected error (possible authority inversion or cross-boundary escape): {}",
+            err.message
+        );
+    }
+
     // FA-02-018 / #1650: generic record/ADT declarations are rejected at
     // the canonical owner boundary (build_record_table/build_adt_table),
     // never merely tolerated until an unrelated later error happens to
@@ -7993,9 +8256,18 @@ mod tests {
 
     #[test]
     fn record_equality_rejects_unsupported_field_subset() {
+        // FA-02-038 / #1861: this test previously used a `qvec` field to
+        // reach a field type equality never supports. That relied on
+        // `qvec`-typed record fields being admitted at declaration time at
+        // all -- itself the exact fail-open storage-admission gap #1861
+        // closes (record fields now reject `qvec` before equality is ever
+        // considered). `Map(i32, i32)` is a storage-admitted field type
+        // (declares successfully) that `supports_stable_equality_type_inner`
+        // still unconditionally reports as not equality-supporting, so it
+        // isolates the equality-specific rejection this test targets.
         let src = r#"
             record SensorFrame {
-                mask: qvec,
+                mask: Map(i32, i32),
             }
 
             fn compare(left: SensorFrame, right: SensorFrame) {
@@ -12515,6 +12787,23 @@ fn validate_record_declarations(
                     resolve_symbol_name(&program.arena, field.name)?
                 ),
             )?;
+            // FA-02-038 / #1861: ensure_type_resolved above proves nominal
+            // references resolve, not that the field's type is one this
+            // Foundation actually admits as storage -- a reserved/
+            // structural/contextual type (e.g. qvec, a closure, an
+            // unresolved generic) could previously hide inside an admitted
+            // record declaration and escape as a trusted Type::Record
+            // nominal shell everywhere downstream, since no earlier phase
+            // ever looked inside the field.
+            ensure_storage_type_supported(
+                &field.ty,
+                &program.arena,
+                format!(
+                    "field '{}.{}'",
+                    resolve_symbol_name(&program.arena, record.name)?,
+                    resolve_symbol_name(&program.arena, field.name)?
+                ),
+            )?;
         }
     }
 
@@ -12565,6 +12854,19 @@ fn validate_adt_declarations(
                     item_ty,
                     record_table,
                     adt_table,
+                    &program.arena,
+                    format!(
+                        "variant '{}::{}' payload item {}",
+                        resolve_symbol_name(&program.arena, adt.name)?,
+                        resolve_symbol_name(&program.arena, variant.name)?,
+                        index
+                    ),
+                )?;
+                // FA-02-038 / #1861: see the matching comment in
+                // validate_record_declarations -- ensure_type_resolved alone
+                // does not prove a payload's type is admitted storage.
+                ensure_storage_type_supported(
+                    item_ty,
                     &program.arena,
                     format!(
                         "variant '{}::{}' payload item {}",
@@ -13103,12 +13405,58 @@ pub(crate) fn ensure_executable_type_supported(
     }
 }
 
+/// FA-02-038 / #1861: exhaustive (no catch-all) storage-type admission.
+///
+/// Every `Type` variant is matched explicitly, so adding a new variant to
+/// the `Type` enum without updating this function is a compile error rather
+/// than a silent "falls through to `Ok(())`" admission -- the same
+/// exhaustiveness discipline `ensure_executable_type_supported` established
+/// for #1647, applied to a genuinely different question. Storage admission
+/// answers "may this type be the type of a field, binding, or annotated
+/// value", not "may this type appear in an executable function
+/// signature" -- the two contracts happen to agree on every variant here,
+/// but are decided independently rather than by reuse, since nothing
+/// guarantees they always will (e.g. a future closure-capture storage
+/// model could diverge from closure's executable-parameter admission).
+///
+/// `Type::Closure` is an admitted storage composite: `let f: Closure(f64 ->
+/// f64) = (x => x + offset);` is genuinely qualified, tested first-class
+/// closure storage (see `first_class_closure_literal_typechecks_with_declared_signature_and_capture`
+/// / `direct_first_class_closure_invocation_typechecks_in_wave3`), so this
+/// recurses into the closure's parameter/return types exactly as
+/// `ensure_executable_type_supported` does, rather than rejecting it -- an
+/// earlier revision of this fix rejected `Closure` outright on the
+/// assumption that persistent/stored closures are unproven, until these two
+/// pre-existing tests demonstrated the opposite for local `let` storage,
+/// and no evidence was found distinguishing record-field storage as a
+/// stricter sub-contract.
+///
+/// `Type::RangeI32` and `Type::TypeVar` reject unconditionally: no current
+/// Foundation source-profile evidence, test, or lowering path shows a range
+/// value or an unresolved generic parameter is ever storable, and unlike
+/// `canonicalize_declared_type_generic`/`ensure_executable_type_supported`
+/// this helper has no caller-scoped `admitted_type_vars` list through which
+/// a `TypeVar` could ever be proven legitimate here -- there is also no
+/// parser-level annotation syntax that ever constructs `Type::RangeI32` in
+/// the first place (it only ever arises as an inferred range-*expression*
+/// type), so this arm is believed unreachable via any current call path;
+/// it is included because exhaustiveness requires a decision for every
+/// variant regardless of reachability. `Type::QVec` remains reserved and
+/// not yet promoted, as it is for executable admission.
 fn ensure_storage_type_supported(
     ty: &Type,
     arena: &AstArena,
     context: String,
 ) -> Result<(), FrontendError> {
     match ty {
+        Type::Quad
+        | Type::Bool
+        | Type::Text
+        | Type::I32
+        | Type::U32
+        | Type::Fx
+        | Type::F64
+        | Type::Unit => Ok(()),
         Type::Tuple(items) => {
             for item in items {
                 ensure_storage_type_supported(item, arena, context.clone())?;
@@ -13121,6 +13469,10 @@ fn ensure_storage_type_supported(
         Type::Map(map) => {
             ensure_storage_type_supported(map.key.as_ref(), arena, context.clone())?;
             ensure_storage_type_supported(map.val.as_ref(), arena, context)
+        }
+        Type::Closure(closure) => {
+            ensure_storage_type_supported(closure.param.as_ref(), arena, context.clone())?;
+            ensure_storage_type_supported(closure.ret.as_ref(), arena, context)
         }
         Type::Measured(base, _) => ensure_storage_type_supported(base, arena, context),
         Type::Option(item) => ensure_storage_type_supported(item, arena, context),
@@ -13136,7 +13488,24 @@ fn ensure_storage_type_supported(
             let _ = resolve_symbol_name(arena, *name)?;
             Ok(())
         }
-        _ => Ok(()),
+        Type::TypeVar(name) => Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "type variable '{}' is not admitted as a storage type in {}",
+                resolve_symbol_name(arena, *name)?,
+                context
+            ),
+        }),
+        Type::RangeI32 => Err(FrontendError {
+            pos: 0,
+            message: format!("range values are not admitted as a storage type in {context}"),
+        }),
+        Type::QVec(_) => Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "qvec is a reserved type and is not admitted as a storage type in {context}"
+            ),
+        }),
     }
 }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -3584,6 +3584,153 @@ mod tests {
         type_check_program(&program)
     }
 
+    #[test]
+    fn storage_admission_aggregate_composite_matrix_typechecks_for_record_and_adt() {
+        // Corrective round (review on PR #1877): wiring
+        // ensure_storage_type_supported into record/ADT declaration
+        // validation changed this authority's semantic scope from
+        // "local binding storage" to "local binding storage, record field
+        // storage, and ADT payload storage" -- the original PR treated the
+        // 20-variant classification as automatically valid for all three
+        // positions without proving that. This table proves, per composite,
+        // that a value can be constructed with the composite in a record
+        // field / ADT payload position, read back out, and used -- not
+        // merely that the declaration alone typechecks.
+        //
+        // Tuple/Measured/Option/Result: `docs/spec/types.md` already states
+        // "measured numeric types may appear in ... tuple elements, record
+        // fields, Option(T), and Result(T, E) payload positions" -- direct
+        // normative evidence, corroborated here.
+        // Sequence/Map: no prior normative record-field statement found;
+        // admitted only after this empirical proof (also lowered to IR
+        // successfully, see legacy_lowering.rs's matching regression).
+        // Record/Adt nesting: architecturally proven independently by
+        // `validate_record_acyclic`/`validate_adt_acyclic`, which exist
+        // specifically to walk nested nominal fields -- that machinery has
+        // no purpose if nominal nesting were not an intended, supported
+        // pattern.
+        let cases = [
+            (
+                "record Tuple",
+                "record R { x: (i32, i32) } fn main() { let r: R = R { x: (1, 2) }; let (a, b): (i32, i32) = r.x; let _ = a; let _ = b; return; }",
+            ),
+            (
+                "adt Tuple",
+                "enum E { V((i32, i32)) } fn main() { let e: E = E::V((1, 2)); match e { E::V(t) => { let (a, b): (i32, i32) = t; let _ = a; let _ = b; } } return; }",
+            ),
+            (
+                "record Sequence",
+                "record R { x: Sequence(i32) } fn main() { let r: R = R { x: [1, 2] }; let s: Sequence(i32) = r.x; let _ = s; return; }",
+            ),
+            (
+                "adt Sequence",
+                "enum E { V(Sequence(i32)) } fn main() { let e: E = E::V([1, 2]); match e { E::V(s) => { let _ = s; } } return; }",
+            ),
+            (
+                "record Map",
+                "record R { x: Map(i32, i32) } fn main() { let r: R = R { x: map_empty() }; let m: Map(i32, i32) = r.x; let _ = m; return; }",
+            ),
+            (
+                "adt Map",
+                "enum E { V(Map(i32, i32)) } fn main() { let e: E = E::V(map_empty()); match e { E::V(m) => { let _ = m; } } return; }",
+            ),
+            (
+                "record Measured",
+                "record R { x: f64[m] } fn main() { let r: R = R { x: 1.0 }; let v: f64[m] = r.x; let _ = v; return; }",
+            ),
+            (
+                "adt Measured",
+                "enum E { V(f64[m]) } fn main() { let e: E = E::V(1.0); match e { E::V(v) => { let _ = v; } } return; }",
+            ),
+            (
+                "record Option",
+                "record R { x: Option(i32) } fn main() { let r: R = R { x: Option::Some(1) }; let o: Option(i32) = r.x; let _ = o; return; }",
+            ),
+            (
+                "adt Option",
+                "enum E { V(Option(i32)) } fn main() { let e: E = E::V(Option::Some(1)); match e { E::V(o) => { let _ = o; } } return; }",
+            ),
+            (
+                "record Result",
+                "record R { x: Result(i32, i32) } fn main() { let r: R = R { x: Result::Ok(1) }; let v: Result(i32, i32) = r.x; let _ = v; return; }",
+            ),
+            (
+                "adt Result",
+                "enum E { V(Result(i32, i32)) } fn main() { let e: E = E::V(Result::Ok(1)); match e { E::V(v) => { let _ = v; } } return; }",
+            ),
+            (
+                "record nested Record",
+                "record Inner { n: i32 } record Outer { x: Inner } fn main() { let o: Outer = Outer { x: Inner { n: 1 } }; let _ = o.x; return; }",
+            ),
+            (
+                "adt nested Record",
+                "record Inner { n: i32 } enum E { V(Inner) } fn main() { let e: E = E::V(Inner { n: 1 }); match e { E::V(i) => { let _ = i; } } return; }",
+            ),
+            (
+                "record nested Adt",
+                "enum Inner { A, B } record Outer { x: Inner } fn main() { let o: Outer = Outer { x: Inner::A }; let _ = o.x; return; }",
+            ),
+            (
+                "adt nested Adt",
+                "enum Inner { A, B } enum E { V(Inner) } fn main() { let e: E = E::V(Inner::A); match e { E::V(i) => { let _ = i; } } return; }",
+            ),
+        ];
+        for (label, src) in cases {
+            typecheck_source(src).unwrap_or_else(|e| {
+                panic!("{label}: aggregate composite storage must typecheck: {e:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn storage_admission_record_closure_field_typechecks_end_to_end() {
+        // Corrective round: the original PR admitted Type::Closure for
+        // storage on the strength of *local-binding* evidence only (two
+        // pre-existing tests proving `let`-bound closures work), which does
+        // not by itself prove record-field closure storage -- the
+        // historical `first_class_closures_full_scope.md` scope explicitly
+        // named "local binding, parameter, and return transport" only, not
+        // aggregate storage. This constructs a record with a closure field,
+        // reads the field back out, and invokes the extracted closure --
+        // full frontend proof; VM execution is proven separately in
+        // sm-vm's test suite (see `docs/spec/foundation_source_profile_v1.md`
+        // for the reconciled normative statement and the SSF-07 #1861
+        // addendum in `first_class_closures_full_scope.md`).
+        let src = r#"
+            record Holder {
+                f: Closure(f64 -> f64),
+            }
+
+            fn main() {
+                let h: Holder = Holder { f: (x => x + 1.0) };
+                let g: Closure(f64 -> f64) = h.f;
+                let total: f64 = g(2.0);
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("record field closure storage: construct, extract, and invoke must typecheck");
+    }
+
+    #[test]
+    fn storage_admission_adt_closure_payload_typechecks_end_to_end() {
+        let src = r#"
+            enum Holder {
+                Wrap(Closure(f64 -> f64)),
+            }
+
+            fn main() {
+                let h: Holder = Holder::Wrap((x => x + 1.0));
+                let total: f64 = match h {
+                    Holder::Wrap(g) => { g(2.0) }
+                };
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("ADT payload closure storage: construct and invoke via match must typecheck");
+    }
+
     // FA-02-038 / #1861: exhaustive storage-type admission regression
     // matrix. `ensure_storage_type_supported` is the sole shared authority
     // for every field/binding storage position (Const/Let/LetTuple/
@@ -13419,17 +13566,47 @@ pub(crate) fn ensure_executable_type_supported(
 /// guarantees they always will (e.g. a future closure-capture storage
 /// model could diverge from closure's executable-parameter admission).
 ///
-/// `Type::Closure` is an admitted storage composite: `let f: Closure(f64 ->
-/// f64) = (x => x + offset);` is genuinely qualified, tested first-class
-/// closure storage (see `first_class_closure_literal_typechecks_with_declared_signature_and_capture`
-/// / `direct_first_class_closure_invocation_typechecks_in_wave3`), so this
-/// recurses into the closure's parameter/return types exactly as
-/// `ensure_executable_type_supported` does, rather than rejecting it -- an
-/// earlier revision of this fix rejected `Closure` outright on the
-/// assumption that persistent/stored closures are unproven, until these two
-/// pre-existing tests demonstrated the opposite for local `let` storage,
-/// and no evidence was found distinguishing record-field storage as a
-/// stricter sub-contract.
+/// `Type::Closure` is an admitted storage composite, and this admission is
+/// position-independent (local binding, record field, ADT payload) by
+/// direct proof rather than by assumption. Local `let` storage was already
+/// covered (see `first_class_closure_literal_typechecks_with_declared_signature_and_capture`
+/// / `direct_first_class_closure_invocation_typechecks_in_wave3`), but an
+/// earlier revision of this fix generalized that to record/ADT storage on
+/// the weaker claim that "no evidence distinguishes record-field storage as
+/// stricter". Wiring this function into `validate_record_declarations`/
+/// `validate_adt_declarations` genuinely widened its scope beyond local
+/// bindings, so that generalization needed its own proof, not an absence of
+/// counter-evidence. That proof now exists at every pipeline stage for both
+/// aggregate positions: typecheck (`storage_admission_record_closure_field_typechecks_end_to_end`
+/// / `storage_admission_adt_closure_payload_typechecks_end_to_end`), IR
+/// lowering to the correct `MakeClosure`/`MakeRecord`/`MakeAdt`/`RecordGet`/
+/// `ClosureCall` opcode sequence (`storage_admission_record_closure_field_lowers_to_working_ir`
+/// / `storage_admission_adt_closure_payload_lowers_to_working_ir` in
+/// `sm-ir`), and full frontend-to-VM execution producing the correct result
+/// (`storage_admission_record_closure_field_vm_executes_correctly` /
+/// `storage_admission_adt_closure_payload_vm_executes_correctly` in
+/// `sm-vm`). This is documented as a deliberate SSF-07 #1861 widening of
+/// closure storage scope beyond the M8.4 local-binding-only baseline; see
+/// the addendum in `docs/roadmap/language_maturity/first_class_closures_full_scope.md`.
+/// Recursing into the closure's parameter/return types mirrors
+/// `ensure_executable_type_supported`, but the two remain independently
+/// decided contracts, not a shared implementation.
+///
+/// The other admitted composites are backed the same way, evidence first:
+/// `Sequence`/`Map` have no prior normative statement admitting them in
+/// aggregate position, so `storage_admission_sequence_and_map_aggregate_storage_lowers`
+/// (`sm-ir`) is their sole but sufficient lowering proof for both record
+/// and ADT storage. `Tuple`/`Measured`/`Option`/`Result` are directly named
+/// in aggregate position by `docs/spec/types.md` ("measured numeric types
+/// may appear in ... tuple elements, record fields ... `Option(T)`, and
+/// `Result(T, E)` payload positions"), confirmed end-to-end by
+/// `storage_admission_aggregate_composite_matrix_typechecks_for_record_and_adt`,
+/// which exercises all eight admitted composites in both record-field and
+/// ADT-payload position. `Record`/`Adt` nominal nesting inside other
+/// records/ADTs is proven intended by the pre-existing
+/// `validate_record_acyclic`/`validate_adt_acyclic` cycle-detection
+/// machinery, which would be pointless if nominal aggregate nesting were
+/// not a supported storage pattern.
 ///
 /// `Type::RangeI32` and `Type::TypeVar` reject unconditionally: no current
 /// Foundation source-profile evidence, test, or lowering path shows a range

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -10166,6 +10166,120 @@ mod opt_tests {
     use sm_format::semcode_decode::{decode_semcode_envelope, DecodedAccessPathComponent};
     use sm_front::parse_program;
 
+    #[test]
+    fn storage_admission_sequence_and_map_aggregate_storage_lowers() {
+        // FA-02-038 / #1861 corrective round: Sequence/Map have no prior
+        // normative record-field statement (unlike Tuple/Measured/Option/
+        // Result, documented in docs/spec/types.md); this is their sole
+        // aggregate-storage lowering evidence.
+        let cases = [
+            (
+                "record Sequence",
+                "record R { x: Sequence(i32) } fn main() { let r: R = R { x: [1, 2] }; let s: Sequence(i32) = r.x; let _ = s; return; }",
+            ),
+            (
+                "adt Sequence",
+                "enum E { V(Sequence(i32)) } fn main() { let e: E = E::V([1, 2]); match e { E::V(s) => { let _ = s; } } return; }",
+            ),
+            (
+                "record Map",
+                "record R { x: Map(i32, i32) } fn main() { let r: R = R { x: map_empty() }; let m: Map(i32, i32) = r.x; let _ = m; return; }",
+            ),
+            (
+                "adt Map",
+                "enum E { V(Map(i32, i32)) } fn main() { let e: E = E::V(map_empty()); match e { E::V(m) => { let _ = m; } } return; }",
+            ),
+        ];
+        for (label, src) in cases {
+            compile_program_to_ir(src)
+                .unwrap_or_else(|e| panic!("{label}: aggregate storage must lower: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn storage_admission_record_closure_field_lowers_to_working_ir() {
+        // FA-02-038 / #1861 corrective round: proves the record-closure
+        // path lowers to real, composing opcodes (MakeClosure -> MakeRecord
+        // -> RecordGet -> ClosureCall), not merely that the frontend admits
+        // the declaration. Full VM execution is proven in sm-vm's test
+        // suite (crates/sm-vm/src/lib.rs).
+        let src = r#"
+            record Holder {
+                f: Closure(f64 -> f64),
+            }
+
+            fn main() {
+                let h: Holder = Holder { f: (x => x + 1.0) };
+                let g: Closure(f64 -> f64) = h.f;
+                let total: f64 = g(2.0);
+                return;
+            }
+        "#;
+        let ir = compile_program_to_ir(src).expect("record closure field storage must lower");
+        let main = &ir[0];
+        assert!(
+            main.instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::MakeClosure { .. })),
+            "expected a MakeClosure instruction"
+        );
+        assert!(
+            main.instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::MakeRecord { .. })),
+            "expected the closure to be stored via MakeRecord"
+        );
+        assert!(
+            main.instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::RecordGet { .. })),
+            "expected the closure to be read back out via RecordGet"
+        );
+        assert!(
+            main.instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::ClosureCall { .. })),
+            "expected the extracted closure to be invoked via ClosureCall"
+        );
+    }
+
+    #[test]
+    fn storage_admission_adt_closure_payload_lowers_to_working_ir() {
+        let src = r#"
+            enum Holder {
+                Wrap(Closure(f64 -> f64)),
+            }
+
+            fn main() {
+                let h: Holder = Holder::Wrap((x => x + 1.0));
+                let total: f64 = match h {
+                    Holder::Wrap(g) => { g(2.0) }
+                };
+                return;
+            }
+        "#;
+        let ir = compile_program_to_ir(src).expect("ADT closure payload storage must lower");
+        let main = &ir[0];
+        assert!(
+            main.instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::MakeClosure { .. })),
+            "expected a MakeClosure instruction"
+        );
+        assert!(
+            main.instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::MakeAdt { .. })),
+            "expected the closure to be stored via MakeAdt"
+        );
+        assert!(
+            main.instrs
+                .iter()
+                .any(|instr| matches!(instr, IrInstr::ClosureCall { .. })),
+            "expected the extracted closure to be invoked via ClosureCall"
+        );
+    }
+
     // FA-04-011 / #1717: sm-ir's executable boundary has no monomorphisation
     // pass, so a generic function's declaration (Function.type_params
     // non-empty) is rejected deterministically at IR lowering -- used or

--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -126,6 +126,67 @@ mod tests {
         );
     }
 
+    /// FA-02-038 / #1861 corrective round: category-3 (full pipeline) proof
+    /// that a record-field-stored closure is not merely admitted by the
+    /// frontend but genuinely executes correctly end to end -- typecheck ->
+    /// IR lowering (see `storage_admission_record_closure_field_lowers_to_working_ir`
+    /// in crates/sm-ir) -> SemCode -> verification -> VM execution. The
+    /// original PR justified `Type::Closure`'s storage admission only via
+    /// local-binding closure tests; this closes that evidentiary gap for
+    /// record-field position specifically.
+    #[test]
+    fn storage_admission_record_closure_field_vm_executes_correctly() {
+        let src = r#"
+            record Holder {
+                f: Closure(f64 -> f64),
+            }
+
+            fn compute() -> f64 {
+                let h: Holder = Holder { f: (x => x + 1.0) };
+                let g: Closure(f64 -> f64) = h.f;
+                return g(2.0);
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("compute").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
+        assert_eq!(res, Value::F64(3.0));
+    }
+
+    /// FA-02-038 / #1861 corrective round: same category-3 proof as
+    /// `storage_admission_record_closure_field_vm_executes_correctly`, for
+    /// ADT payload position.
+    #[test]
+    fn storage_admission_adt_closure_payload_vm_executes_correctly() {
+        let src = r#"
+            enum Holder {
+                Wrap(Closure(f64 -> f64)),
+            }
+
+            fn compute() -> f64 {
+                let h: Holder = Holder::Wrap((x => x + 1.0));
+                let result: f64 = match h {
+                    Holder::Wrap(g) => { g(2.0) }
+                };
+                return result;
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("verify");
+        let entry = token.require_entry("compute").expect("entry");
+        let res = run_verified_function_semcode_with_args(&entry, vec![]).expect("run");
+        assert_eq!(res, Value::F64(3.0));
+    }
+
     /// #1774 (FA-09-006): the original `test_6_reject_wrong_argument_count`
     /// ended with `assert!(res.is_ok() || res.is_err())`, which is true for
     /// every possible `Result` and therefore proves nothing about whether

--- a/docs/roadmap/language_maturity/first_class_closures_full_scope.md
+++ b/docs/roadmap/language_maturity/first_class_closures_full_scope.md
@@ -149,3 +149,46 @@ Even after this first wave lands, the repository still does not claim:
 
 The next language-facing candidate inside the `M8` package is `M9.1
 Generics`.
+
+## Post-Close-Out Addendum (SSF-07 #1861)
+
+This track's "Included In This Track" list (above) named "local binding,
+parameter, and return transport for admitted closures" as the M8.4
+first-wave closure-transport surface. It did not name record fields or ADT
+payloads — neither as included nor as an explicit non-goal — because
+whether an admitted closure could be stored inside a record or ADT was
+never independently investigated at the time. That silence is not itself an
+error in this document; the M8.4 historical text above is left unedited as
+the accurate record of what M8.4 actually scoped and proved.
+
+SSF-07 #1861 ("storage type admission has a fail-open catch-all for
+unsupported type families") separately discovered that `validate_record_declarations`/
+`validate_adt_declarations` never routed field/payload types through the
+frontend's storage-admission authority (`ensure_storage_type_supported`) at
+all — only through `ensure_type_resolved`, which proves a nominal reference
+resolves, not that the referenced type is itself storage-admitted. Closing
+that gap genuinely widened `ensure_storage_type_supported`'s scope from
+local bindings to also cover record fields and ADT payloads, which meant
+`Type::Closure`'s admission for those two positions needed its own proof
+rather than inheriting M8.4's local-binding evidence by assumption. That
+proof was produced directly: record-field and ADT-payload closure storage
+now has dedicated end-to-end coverage across the full pipeline — frontend
+typecheck (`storage_admission_record_closure_field_typechecks_end_to_end`,
+`storage_admission_adt_closure_payload_typechecks_end_to_end` in
+`crates/sm-front/src/typecheck.rs`), IR lowering to the expected
+`MakeClosure`/`MakeRecord`/`MakeAdt`/`RecordGet`/`ClosureCall` opcode
+sequence (`storage_admission_record_closure_field_lowers_to_working_ir`,
+`storage_admission_adt_closure_payload_lowers_to_working_ir` in
+`crates/sm-ir/src/legacy_lowering.rs`), and full VM execution producing the
+mathematically correct result (`storage_admission_record_closure_field_vm_executes_correctly`,
+`storage_admission_adt_closure_payload_vm_executes_correctly` in
+`crates/sm-vm/src/lib.rs`).
+
+Record-field and ADT-payload closure transport is therefore now a
+deliberately proven and admitted SSF-07 widening of closure storage scope
+beyond the M8.4 first-wave baseline, not a silent extension. See
+`docs/spec/foundation_source_profile_v1.md` for the current normative
+storage-admission contract, which documents this alongside the same
+evidence-first treatment applied to every other admitted composite
+(`Tuple`, `Sequence`, `Map`, `Measured`, `Option`, `Result`, `Record`,
+`Adt`).

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -420,6 +420,42 @@ inference* remain frontend-admitted and closed (#1634, #1648, #1649), but
 executing one is deterministically rejected, not silently erased, until a
 real specialization pass exists.
 
+Storage-type admission — the question of whether a `Type` may be the type of
+a field, an ADT payload item, or an annotated `const`/`let`/tuple-destructure/
+discard binding — is exhaustive over the current `Type` enum:
+`ensure_storage_type_supported` matches every variant explicitly, with no
+`_` arm, so adding a new `Type` variant without updating this function is a
+compile error rather than a silent "falls through to admission." Before
+SSF-07 #1861, this function ended in `_ => Ok(())`, silently admitting
+every variant it did not explicitly reject (`QVec`, `Closure`, `RangeI32`,
+`TypeVar`, and any future addition), and record/ADT field types were never
+routed through it at all — `validate_record_declarations`/
+`validate_adt_declarations` only proved a field's nominal references
+resolve (`ensure_type_resolved`), never that the field's own type was
+storage-admitted. A reserved type (e.g. `qvec`) could therefore hide inside
+an admitted record field, and that record's nominal identity — a bare
+`Type::Record(name)`, unrelated to the record's own field shapes — was then
+trusted everywhere downstream, including by an ordinary function's own
+executable-signature admission (#1647), which resolves a `Type::Record`
+argument's symbol name without ever inspecting its fields. Both gaps are
+now closed: the match is exhaustive (admitted leaves: `quad`, `bool`,
+`text`, `i32`, `u32`, `fx`, `f64`, `()`; admitted composites, recursing
+into every child: tuples, `Sequence`, `Map`, `Closure`, unit-annotated
+values, `Option`, `Result`; admitted nominal identities: declared records
+and ADTs; rejected: `qvec` as reserved and not yet promoted, and `RangeI32`
+and an unresolved `TypeVar` as having no legitimate storage context this
+helper can prove), and `validate_record_declarations`/
+`validate_adt_declarations` now call it for every field/payload type, so
+storage admission is proven once, before a record or ADT's own nominal
+identity is trusted by anything downstream, not merely for local bindings.
+Storage admission and executable-signature admission (#1647) are decided
+independently, as separate contracts that currently agree on every variant
+by evidence rather than by construction — `Closure` in particular is
+admitted for storage specifically because pre-existing, already-qualified
+tests prove first-class closures are legitimately `let`-bound (see
+`first_class_closure_literal_typechecks_with_declared_signature_and_capture`),
+not merely because closures are executable elsewhere.
+
 ## Deterministically unsupported forms
 
 Forms with no admitted current implementation must fail before execution with a

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -450,11 +450,28 @@ storage admission is proven once, before a record or ADT's own nominal
 identity is trusted by anything downstream, not merely for local bindings.
 Storage admission and executable-signature admission (#1647) are decided
 independently, as separate contracts that currently agree on every variant
-by evidence rather than by construction — `Closure` in particular is
-admitted for storage specifically because pre-existing, already-qualified
-tests prove first-class closures are legitimately `let`-bound (see
-`first_class_closure_literal_typechecks_with_declared_signature_and_capture`),
-not merely because closures are executable elsewhere.
+by evidence rather than by construction. Because wiring this function into
+`validate_record_declarations`/`validate_adt_declarations` genuinely widened
+its scope from local bindings to also cover record fields and ADT payloads,
+each admitted composite's aggregate-position legitimacy was independently
+proven rather than assumed to follow from its local-binding admission.
+`Closure` is the sharpest case: local `let`-bound closure storage was
+already proven (`first_class_closure_literal_typechecks_with_declared_signature_and_capture`),
+but record-field and ADT-payload closure storage additionally now has
+direct end-to-end proof — typecheck, IR lowering to the expected
+`MakeClosure`/`MakeRecord`/`MakeAdt`/`RecordGet`/`ClosureCall` opcode
+sequence, and full VM execution producing the mathematically correct result
+— documented as a deliberate SSF-07 #1861 widening beyond the M8.4
+local-binding-only baseline (see the addendum in
+`docs/roadmap/language_maturity/first_class_closures_full_scope.md`).
+`Sequence`/`Map` have no prior normative statement admitting aggregate
+storage and rely on that same IR-lowering proof as their sole evidence;
+`Tuple`/`Measured`/`Option`/`Result` are directly named in record-field
+position by `docs/spec/types.md`, confirmed end to end for both record and
+ADT position by a dedicated regression matrix; and `Record`/`Adt` nominal
+nesting is proven intended by the pre-existing acyclic cycle-detection
+machinery (`validate_record_acyclic`/`validate_adt_acyclic`), which
+presupposes nominal aggregate nesting is a supported pattern.
 
 ## Deterministically unsupported forms
 


### PR DESCRIPTION
SSF-07 reconciliation: #1578
Fixes #1861

**Corrective round.** A review of the first round (commit `111d50ab`, reviewed clean by Codex) found a genuine evidentiary gap and requested correction before merge. This body has been rewritten to reflect the correction; see "## Corrective round" below for what changed and why. The original round's investigation (call-site inventory, 20-variant classification, pre-fix reproduction, architecture decision, sibling/catch-all/fallback audits) remains accurate and is kept below unedited except where noted.

## Baseline

Fetched fresh `origin/main`; branched from `5fe9bdb1c3112f4259b4d8b055eafdd1451afd7e` (the exact baseline given for this slice) in an isolated `EnterWorktree` worktree.

## Call-site / authority inventory

`ensure_storage_type_supported` (`crates/sm-front/src/typecheck.rs`) was called from exactly 5 production sites, all within `check_stmt` — `check_loop_expr_stmt` has no `Const`/`Let`/`LetTuple`/`Discard` arms of its own and falls through to `check_stmt` via its catch-all, so no 6th path exists:

| Caller | Surface | Why storage validation runs here |
|---|---|---|
| `Stmt::Const` | `const` annotation | binding storage for a compile-time value |
| `Stmt::Let` | `let` annotation | binding storage for a local value |
| `Stmt::LetTuple` | tuple destructuring bind annotation | binding storage per destructured element |
| `Stmt::LetElseTuple` | let-else tuple destructuring bind annotation | same, with fallible-match else-branch |
| `Stmt::Discard` | `let _: T = ...` discard binding annotation | binding storage even though the value is discarded |

**Critical finding — record/ADT declarations were *not* among these 5 callers.** `validate_record_declarations`/`validate_adt_declarations` (`typecheck.rs`) call only `ensure_type_resolved` on each field/payload type — a *different* function that proves nominal references resolve (record/ADT exists in the table) and validates unit-annotation legality, but never asks whether the type itself is storage-admitted. `build_record_table`/`build_adt_table` (`lib.rs`) don't touch field types at all (only duplicate-name and #1650's zero-arity checks). So this helper was the canonical authority for the 5 local-binding forms, but record/ADT field storage had **no admission check running at all** — not even the leaky one. This is strengthened once, not duplicated: `ensure_storage_type_supported` is now also called from both declaration-validation sites, immediately after the pre-existing `ensure_type_resolved` call, using the same per-field/per-payload-item context string.

**This is exactly the change that widened this authority's scope beyond local bindings** — see "## Corrective round" for why that widening needed independent proof per admitted composite, not an assumption that local-binding evidence carries over.

## Full 20-variant storage classification

| Category | Variants | Evidence |
|---|---|---|
| **A — admitted leaf** | `Quad`, `Bool`, `Text`, `I32`, `U32`, `Fx`, `F64`, `Unit` | Used pervasively as record/binding storage throughout docs (`record_data_model.md`, `record_scenarios.md`) and tests; corroborated by #1647's identical leaf admission for the first 7 (executable and storage semantics coincide for scalars — a scalar *is* its own storage). `Unit` has no explicit type-annotation source syntax (`parse_type` has no `"Unit"`/`()` branch — it only arises as an omitted function return type), so its admission is proven by direct `ensure_storage_type_supported(&Type::Unit, ...)` call rather than end-to-end source. |
| **B — admitted composite, recurse** | `Tuple`, `Sequence`, `Map`, `Closure`, `Measured`, `Option`, `Result` | See "## Corrective round" — every one of these now has direct, position-specific (record field *and* ADT payload) evidence, not just local-binding evidence generalized by assumption. |
| **C — admitted nominal identity** | `Record`, `Adt` | Symbol resolved for diagnostics; existence is proven separately, once, by `build_record_table`/`build_adt_table` before any field validation runs. Nominal nesting inside other records/ADTs is proven intended by the pre-existing `validate_record_acyclic`/`validate_adt_acyclic` cycle-detection machinery, which would be pointless if nominal aggregate nesting were not a supported storage pattern. |
| **D — reject, no proof of storage legitimacy** | `RangeI32`, `TypeVar` | See below. |
| **E — reserved, not promoted** | `QVec` | Matches #1647's own "reserved, not-yet-promoted-to-executable" classification; no doc, test, or lowering evidence carves out a storage-specific exception. |

**`RangeI32` — decided as structural, not storable.** No parser branch ever constructs `Type::RangeI32` from type-annotation syntax (confirmed via `grep -n "Type::RangeI32" crates/sm-front/src/parser.rs` — zero matches); it is only ever produced by range-*expression* type inference (`typecheck.rs:2236`, inside `for ... in range`). It cannot currently be written as a `let`/`const`/field type annotation at all, so this arm is believed structurally unreachable via any current call path. It is included because exhaustiveness requires a decision for every variant regardless of reachability — matching the codebase's existing precedent for "known unreachable but required for exhaustiveness" arms (e.g. `callable_family_for_type`'s `TypeVar` arm from #1717).

**`TypeVar` — fails closed, deliberately.** Unlike `ensure_executable_type_supported`/`canonicalize_declared_type_generic`, this helper has no caller-scoped `admitted_type_vars` list. Generic record/ADT declarations are already rejected at the owner boundary (#1650), and the 5 binding-annotation call sites all pass an already-canonicalized type (`canonicalize_declared_type`, which unconditionally rejects `TypeVar` itself, so `TypeVar` can never reach this helper via those 5 sites in practice) — but the new record/ADT field callers pass the *raw* `field.ty`/`item_ty`, not a canonicalized type, so a `TypeVar` is not provably unreachable there the same way. Per the task's explicit instruction, the helper has no context to prove a `TypeVar` legitimate, so it fails closed rather than guessing.

## Pre-fix reproduction (empirical, on the exact baseline)

All results captured via temporary probe tests (constructed, run, recorded, then removed before implementation):

| Case | Result |
|---|---|
| A. Direct `qvec[8]`, via the helper directly | `Ok(())` |
| B. Nested — `Option`/`Sequence`/`Result`/`Tuple`/`Map` all wrapping `qvec` | `Ok(())` in every position — recursion reaches the catch-all uniformly |
| C. Record field `x: qvec[8]` | `Ok(())` — record declaration itself never routed through storage admission at all |
| D. ADT payload `A(qvec[8])` | `Ok(())` — same gap |
| E. `let`/`const` binding annotation `qvec[8]` | annotation silently admitted (proven by the downstream error naming the *value expression*, `"const initializer currently supports only pure literal/const expression forms"`, never the annotation) |
| F. Cross-boundary escape | `Ok(())` — see below |

**Cross-boundary nominal escape (section 4F), reproduced exactly as described:**

```rust
record R { x: qvec[8] }
fn f(r: R) -> i32 { return 0; }
fn main() { return; }
```

`type_check_program` returned `Ok(())` on the exact baseline. The unsupported field never surfaced: the record declaration admitted it (no storage check ran), and `f`'s parameter `r: R` reached #1647's `ensure_executable_type_supported`, whose `Type::Record(name)` arm only resolves the symbol name — it never looks inside `R`'s own fields. No other independent guard stopped this; the storage boundary itself was the entire gap.

## Architecture decision

`ensure_storage_type_supported` remains the single shared authority — strengthened once (made exhaustive, with no `_` arm) and wired into two new callers (record/ADT declaration validation), not duplicated into a second whitelist. It stays a **separate contract** from `ensure_executable_type_supported` (#1647): both are decided independently, evaluated variant-by-variant on their own evidence, and happen to agree on every variant *except* nothing currently — but the decision process, not a shared implementation, is what's identical. `ensure_executable_type_supported` is not called from storage admission, and vice versa.

**No `StoragePosition` split was needed.** The corrective round explicitly considered splitting admission by position (local binding vs. record field vs. ADT payload) via a `StoragePosition` enum parameter, as the review required if position-dependent behavior were genuinely load-bearing. It is not: direct end-to-end proof (below) shows every admitted composite behaves identically in all three positions. The uniform, position-independent architecture from the first round is therefore correct — it was the *evidence* for that uniformity that was missing, not the architecture itself.

## Corrective round

The first round's admission of `Type::Closure` for storage cited only two pre-existing **local-binding** closure tests (`first_class_closure_literal_typechecks_with_declared_signature_and_capture`, `direct_first_class_closure_invocation_typechecks_in_wave3`) and reasoned "no evidence distinguishes record-field storage as a stricter sub-contract" — i.e. admitted record/ADT closure storage by absence of counter-evidence, not by positive proof. Because wiring `ensure_storage_type_supported` into `validate_record_declarations`/`validate_adt_declarations` is exactly what widened this authority's scope from local bindings to also cover record fields and ADT payloads, that generalization needed its own proof: **for a fail-closed Stable Foundation boundary, absence of proof must not widen the contract.**

**Closure, investigated end to end for both aggregate positions.** Record field:

```rust
record Holder { f: Closure(f64 -> f64) }
fn compute() -> f64 {
    let h: Holder = Holder { f: (x => x + 1.0) };
    let g: Closure(f64 -> f64) = h.f;
    return g(2.0);
}
```

and the equivalent ADT payload (`enum Holder { Wrap(Closure(f64 -> f64)) }`, extracted via `match`) were each traced through every pipeline stage:

- **Typecheck**: `storage_admission_record_closure_field_typechecks_end_to_end` / `storage_admission_adt_closure_payload_typechecks_end_to_end` (`crates/sm-front/src/typecheck.rs`) — construct, extract, and invoke, asserted to typecheck.
- **IR lowering**: `storage_admission_record_closure_field_lowers_to_working_ir` / `storage_admission_adt_closure_payload_lowers_to_working_ir` (`crates/sm-ir/src/legacy_lowering.rs`) — assert the lowered `IrFunction` actually contains the expected opcode sequence: `MakeClosure` (the closure literal) → `MakeRecord`/`MakeAdt` (storing it) → `RecordGet` (record only — ADT extraction is via `match`) → `ClosureCall` (invoking the extracted closure). Not just "compiles" — the specific opcodes that make storage-then-invoke actually work are present.
- **Full VM execution**: `storage_admission_record_closure_field_vm_executes_correctly` / `storage_admission_adt_closure_payload_vm_executes_correctly` (`crates/sm-vm/src/lib.rs`) — compile → verify → run through the real VM, asserting `Value::F64(3.0)` — the mathematically correct result of `2.0 + 1.0`. This is category-3 proof: not "it typechecks" or "it lowers," but "it actually runs and produces the right answer."

All six tests pass on the corrected code. This is documented as a deliberate SSF-07 #1861 widening of closure storage scope beyond the M8.4 first-wave local-binding-only baseline — see the new addendum in `docs/roadmap/language_maturity/first_class_closures_full_scope.md`, which leaves the original M8.4 "Included In This Track" text unedited (it was never wrong, just silent on aggregate positions) and appends the new evidence instead of rewriting history.

**The other seven admitted composites, audited the same way, evidence first, not assumption first:**

- `Tuple`, `Measured`, `Option`, `Result` are directly named in record-field position by `docs/spec/types.md` ("measured numeric types may appear in locals, parameters, returns, tuple elements, record fields, `Option(T)`, and `Result(T, E)` payload positions") — the strongest prior evidence of any composite.
- `Sequence`, `Map` have **no** prior normative statement placing them in aggregate position; `storage_admission_sequence_and_map_aggregate_storage_lowers` (`sm-ir`) is their sole but sufficient IR-lowering proof, covering both record and ADT position.
- `Record`, `Adt` nominal nesting inside other records/ADTs is proven intended by the pre-existing `validate_record_acyclic`/`validate_adt_acyclic` cycle-detection machinery (unrelated to this fix, already in the codebase) — that machinery would be pointless if nominal aggregate nesting were not a supported pattern.

All eight are exercised together, both record-field and ADT-payload position, by one new table-driven test: `storage_admission_aggregate_composite_matrix_typechecks_for_record_and_adt` (`sm-front`, 16 cases: 8 composites × 2 positions).

## Corrective-round pre-fix → post-fix proof

To prove the new aggregate regressions are load-bearing (not vacuously passing), rather than assuming a `StoragePosition` split was the right target (it isn't — see Architecture decision), the two composites with the weakest/no prior normative evidence — `Closure` (the review's specific concern) and `Sequence` (no prior doc statement at all) — were temporarily neutralized in `ensure_storage_type_supported`, changing their arms from admitting/recursing to an `Err` with a distinguishing `TEMP-PREFIX-PROOF-1861` message. Re-running the affected suites produced exactly the expected failures, all bearing that message:

- `sm-front`: 7 failures — both new Closure end-to-end tests, the new 16-case aggregate matrix (on its Sequence cases), the pre-existing local-binding `Closure`/`Sequence` coverage (`first_class_closure_literal_typechecks_with_declared_signature_and_capture`, `direct_first_class_closure_invocation_typechecks_in_wave3`, `storage_admission_accepts_every_qualified_composite_and_recurses_into_children`), and one collateral failure in `storage_admission_rejects_qvec_nested_in_every_composite` (its `Sequence(qvec)` case now fails on the outer `Sequence` rejection instead of the inner `qvec` — expected, not a regression).
- `sm-ir`: all 3 new lowering tests fail.
- `sm-vm`: both new VM-execution tests fail.

12 failures total, all carrying the `TEMP-PREFIX-PROOF-1861` marker, confirming every one of these tests actually depends on the code path it claims to prove. The file was then restored from a pre-edit backup and verified byte-identical via `diff` before re-running the same suites, which passed clean (19/19 in `sm-front`, 3/3 in `sm-ir`, 2/2 in `sm-vm`).

## Regressions

Original round (10, retained unchanged):
- `storage_admission_accepts_every_qualified_scalar_leaf` — table-driven, 7 scalars via source; `Unit` covered separately (no annotation syntax exists).
- `storage_admission_accepts_every_qualified_composite_and_recurses_into_children` — `Sequence`/`Option`/`Result`/tuple/`Map`/`Closure`, each via a real source annotation + matching value.
- `storage_admission_rejects_direct_qvec` — item 3.
- `storage_admission_rejects_qvec_nested_in_every_composite` — `Option`/`Sequence`/`Result` (both positions)/`Tuple`/`Map`/`Closure`, all wrapping `qvec`, item 4.
- `storage_admission_rejects_typevar_and_range_and_admits_unit_directly` — direct-call proof for the 3 variants with no reachable source-annotation path.
- `storage_admission_rejects_unsupported_record_field_type` — item 5, end-to-end through `validate_record_declarations`.
- `storage_admission_rejects_unsupported_adt_payload_type` — item 6, end-to-end through `validate_adt_declarations`.
- `storage_admission_rejects_unsupported_binding_annotation` — item 7, end-to-end `let` path.
- `storage_admission_admits_qualified_non_generic_record_and_adt_storage` — item 8, positive control.
- `storage_admission_closes_nominal_cross_boundary_escape` — item 9, the exact section-4F reproduction, now asserted to reject.
- **Item 10 (exhaustiveness compile guard)**: `ensure_storage_type_supported`'s `match` has no `_` arm at all — this is a compile-time property no runtime test can prove as strongly as the compiler itself. `cargo build`/`cargo check` succeeding after this change *is* that proof: a 21st `Type` variant added without a new arm here fails the build. Documented explicitly in the function's own doc comment.

Corrective round (8 new):
- `storage_admission_aggregate_composite_matrix_typechecks_for_record_and_adt` (`sm-front`) — 16-case table-driven matrix, Tuple/Sequence/Map/Measured/Option/Result/nested-Record/nested-Adt × record-field/ADT-payload.
- `storage_admission_record_closure_field_typechecks_end_to_end` / `storage_admission_adt_closure_payload_typechecks_end_to_end` (`sm-front`) — construct/extract/invoke through the frontend.
- `storage_admission_sequence_and_map_aggregate_storage_lowers` (`sm-ir`) — 4-case, record/ADT × Sequence/Map, IR lowering succeeds.
- `storage_admission_record_closure_field_lowers_to_working_ir` / `storage_admission_adt_closure_payload_lowers_to_working_ir` (`sm-ir`) — asserts the exact `MakeClosure`/`MakeRecord`/`MakeAdt`/`RecordGet`/`ClosureCall` opcode sequence is present.
- `storage_admission_record_closure_field_vm_executes_correctly` / `storage_admission_adt_closure_payload_vm_executes_correctly` (`sm-vm`) — full compile → verify → run, asserts `Value::F64(3.0)`.

**One pre-existing test updated (original round)**: `record_equality_rejects_unsupported_field_subset` used a `qvec` field to reach a field type equality doesn't support — but that relied on `qvec`-typed record fields being admitted at declaration time at all, which was itself the exact gap this fix closes. Replaced with `Map(i32, i32)` — storage-admitted (declares successfully) but still unconditionally equality-unsupported (`supports_stable_equality_type_inner`'s own `Type::Map(_) => Ok(false)` arm), isolating the equality-specific rejection this test actually targets.

## Sibling audit

- **#1647** (executable-signature admission) — unaffected, not touched; `ensure_executable_type_supported_admits_ordinary_families`/`ensure_executable_type_supported_rejects_qvec_directly_and_when_nested` re-run and pass, confirming no authority inversion (unsupported *direct executable signature* still rejected by the executable authority; unsupported *field/storage type* now rejected by the storage authority — independently).
- **#1669** (trait signature admission) — unaffected; `build_trait_table`'s own canonicalizer not touched.
- **#1650** (non-generic record/ADT boundary) — unaffected; `build_record_table`/`build_adt_table`'s zero-arity checks not touched, re-run and pass.
- **#1646** (`Self` contextual admission) — unaffected; parser-level, not touched, re-run and pass.
- **#1648/#1649** (generic function frontend) — unaffected; not touched.
- **#1717** (executable generic/IR boundary) — unaffected; `crates/sm-ir`'s pre-existing test suite re-run clean alongside the 3 new tests added there this round.

32 sibling regressions re-run explicitly, all pass.

## Adjacent catch-all audit

Two other `_ => Ok(())` matches exist in the immediate neighborhood of this fix — both inspected and classified as legitimate, deliberately left untouched:
- `validate_nominal_type_acyclic` (`typecheck.rs`) — a pure cycle-detection structural walker over `Record`/`Adt`/`Tuple` nesting; its catch-all correctly answers "does this type participate in a nominal cycle," an orthogonal question from storage admission. A `qvec`/`Closure`/`TypeVar` field simply never participates in a cycle, so `Ok(())` is correct there. (This round additionally uses this machinery's existence as positive evidence that nominal aggregate nesting is an intended pattern — see "## Corrective round".)
- `ensure_type_resolved` (`typecheck.rs`) — proves nominal *references* resolve (record/ADT exists in the table) and validates unit-annotation legality; its catch-all is correct because most variants trivially "resolve" (there's nothing to look up). This function remains the first check at every one of the 5 + 2 call sites, unchanged, running before the new/existing `ensure_storage_type_supported` call.

No other fail-open admission boundary was discovered in the area read for this fix; none folded into #1861.

## Fallback / bypass audit

`git diff | grep -E "^\+" | grep -viE "^\+\+\+" | grep -iE "_ => Ok\(\(\)\)|_ => default|unwrap_or_default|unwrap_or_else|or_else|Default::default\(\)|ignored Result|silent TypeVar|qvec normalization"` — the only matches are `.unwrap_or_else(|e| panic!(...))`/`.expect(...)` inside test assertions (standard "fail loudly with context" test idiom, not a production fallback) and doc-comment prose describing the historical bug. Zero production fallback patterns. `ensure_storage_type_supported` itself contains no `_` arm anywhere in the final diff, in either round.

## Pre-fix → post-fix proof (original round)

Saved `git diff -- crates/sm-front/src/typecheck.rs` to a local patch file. Temporarily restored the historical fail-open behavior by replacing the 3 rejecting arms' bodies (`TypeVar`/`RangeI32`/`QVec`) with `Ok(())`, marked `TEMP-DISABLED-FOR-PREFIX-PROOF`, keeping the match exhaustive (no literal `_` reintroduced). Ran the 10 new regressions — **7 negative regressions failed** with concrete evidence exactly matching the original pre-fix reproduction (direct/nested `qvec` admitted, `TypeVar`/`RangeI32` admitted, record field and ADT payload with `qvec` both admitted, the `let` annotation silently admitted again, and the cross-boundary escape test's `expect_err` panicking on `()` — the exact dangerous case reproduced). The 3 positive-control regressions correctly kept passing throughout, confirming they exercise an orthogonal path. Restored the fix, confirmed zero residual `TEMP-DISABLED` markers via grep, confirmed the restored diff was byte-identical to the saved patch via `diff`. Deleted the patch files.

(See "## Corrective-round pre-fix → post-fix proof" above for the second, corrective-round-specific proof cycle.)

## Documentation

- `docs/spec/foundation_source_profile_v1.md` — paragraph on the exhaustive storage-admission contract (added in the original round); this round replaced its closing sentence, which cited only local-binding closure evidence for the uniform-classification decision, with the position-independence proof summary (typecheck + IR-lowering opcode evidence + VM-execution result for Closure; `docs/spec/types.md` citation for Tuple/Measured/Option/Result; IR-lowering-only evidence for Sequence/Map; acyclic-validation-machinery citation for Record/Adt nesting).
- `docs/roadmap/language_maturity/first_class_closures_full_scope.md` — new "Post-Close-Out Addendum (SSF-07 #1861)" section appended after "## Close-Out Reading". Documents record/ADT aggregate closure storage as a newly-proven, deliberately-included SSF-07 widening beyond the M8.4 "local binding, parameter, and return transport" baseline — without editing the original M8.4 historical text, which was accurate as written and simply silent on aggregate positions.
- `docs/spec/source_semantics.md` / `docs/spec/syntax.md` — inspected for any storage-admission claim; found none (the one "storage" mention is unrelated — "record values currently participate only in local storage and internal verified execution"). No changes made; nothing to correct.

## Qualification

- `cargo test -p sm-front --offline` — 594 passed, 0 failed (581 original baseline + 10 original-round + 3 corrective-round `sm-front` regressions)
- `cargo test -p sm-ir -p sm-vm --offline` — 133 + 118 passed, 0 failed (includes 3 new `sm-ir` and 2 new `sm-vm` corrective-round regressions)
- `cargo check --workspace --all-targets --offline` — clean
- `cargo build --workspace --all-targets --offline` — clean (full workspace, including the heavy `naga`/`wgpu`/`iced` UI-stack dependency chain pulled in by unrelated `prom-ui-*` crates; confirmed exit 0 on a cold worktree cache)
- `cargo test --test public_api_contracts` — 88 passed, 0 failed, zero snapshot drift
- `cargo test --test ssf_language_contract_drift --test canonical_source_style` — 21 passed, 0 failed
- `cargo test --test frontend_parser_qualification --test frontend_lexer_qualification` — 9 + 8 passed, 0 failed
- `cargo fmt -p sm-front --check` — clean (one formatting drift from a corrective-round test addition was caught and fixed via `cargo fmt -p sm-front`); `cargo fmt -p sm-ir --check` / `-p sm-vm --check` — clean
- `cargo clippy -p sm-front --all-targets -- -D warnings` — clean
- `cargo clippy -p sm-ir --all-targets -- -D warnings` — clean
- `cargo clippy -p sm-vm --all-targets -- -D warnings` — **fails**, but only on one pre-existing, unrelated finding: `field \`header\` is never read` in `crates/sm-vm/src/semcode_vm.rs:1017` (`VmProgramView`). Confirmed via `git show origin/main:crates/sm-vm/src/semcode_vm.rs` that this exact field exists unchanged on `origin/main` — not introduced by this PR in either round. `cargo clippy -p sm-vm --all-targets` (without `-D warnings`) confirms this is the *only* finding in `sm-vm` — zero new clippy findings from this PR's changes. Flagged separately as its own out-of-scope follow-up rather than fixed inline here (touching `semcode_vm.rs` is unrelated to storage-type admission).
- `cargo fmt --check` (workspace-wide) — reproduces the known pre-existing Windows path-length OS error (`os error 206`), confirmed unchanged, not a regression from this diff
- Targeted #1647/#1669/#1650/#1646 sibling sweep (32 tests) — all pass

**Deviation from the standing workspace-wide-clippy qualification step**: the fixed qualification command list calls for `cargo clippy --workspace --all-targets -- -D warnings`. On this cold worktree, that pulls the full `naga`/`wgpu`/`iced` dependency chain through clippy's own separate build profile on top of the multi-hour `cargo build --workspace --all-targets` already run — a large, open-ended time cost for a check that cannot find anything in crates this PR doesn't touch, given `cargo check --workspace --all-targets` already proved workspace-wide type-correctness. Per explicit user direction mid-session, this was scoped down to `-p sm-front -p sm-ir -p sm-vm` (the three touched crates) instead of the full workspace. The one finding that surfaced (`sm-vm`'s pre-existing `header` field) was verified pre-existing on `origin/main` and flagged as a separate follow-up rather than absorbed into this PR's scope.

## Changed files

- `crates/sm-front/src/typecheck.rs` — `ensure_storage_type_supported` rewritten exhaustive (no `_` arm); wired into `validate_record_declarations`/`validate_adt_declarations`; doc comment rewritten with position-independence evidence citations; 13 regressions total (10 original + 3 new); 1 pre-existing test's field type corrected
- `crates/sm-ir/src/legacy_lowering.rs` — 3 new regressions proving aggregate Sequence/Map/Closure storage lowers to correct IR opcodes
- `crates/sm-vm/src/lib.rs` — 2 new regressions proving aggregate Closure storage executes correctly end to end through the real VM
- `docs/spec/foundation_source_profile_v1.md` — normative paragraph on the exhaustive storage-admission boundary; closing sentence rewritten with position-independence evidence
- `docs/roadmap/language_maturity/first_class_closures_full_scope.md` — new Post-Close-Out Addendum documenting aggregate closure storage as a deliberate SSF-07 #1861 widening

## Out of scope

This PR does **not**: merge storage admission with executable-signature admission (#1647) — they remain independently decided, separate contracts; touch `ensure_type_resolved` or `validate_nominal_type_acyclic` (both audited, both legitimate, both untouched); reserve any declaration name; widen the `Self` contextual mechanism (#1646); repair #1669/#1650/#1648/#1649/#1717 (all re-verified unaffected, not touched); repair any other adjacent catch-all discovered but not classified as this same storage-admission authority; fix the pre-existing unrelated `sm-vm` dead-code clippy finding (flagged separately); or close #1578 (the SSF-07 parent umbrella — this closes the *last* SSF-07 residual FA, but does not itself declare SSF-07 or the reconciliation effort complete). It closes exactly one gap: every current `Type` variant now has an explicit, evidenced storage-admission decision, enforced identically for local bindings and for record/ADT declarations, with no wildcard admission path anywhere, a compile-time guarantee that a future 21st variant cannot silently inherit one, and — as of this corrective round — direct end-to-end proof (not assumption) that every admitted composite behaves identically across all three storage positions.

**Do not merge.** Waiting for fresh CI and a fresh `@codex review` on the new exact HEAD before any further action.
