### PR TITLE
fix(front): preserve exact ownership path for nested projection reads

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -11095,31 +11095,24 @@ mod tests {
     }
 
     #[test]
-    fn fa02_039_known_defect_nested_projection_rereads_intermediate_base_as_whole_value() {
-        // Tracked as FA-02-039 (skulmakov-oss/Semantic#1881). NOT part of
-        // #1656-#1664, NOT fixed by this PR. Documents a pre-existing
-        // frontend defect found while writing the #1663 regression suite
-        // (SSF-08 Lane 1): reading a two-level-nested field projection
-        // (`c.pair.b`) spuriously rejects if a *sibling* field of the
-        // intermediate base was moved (`c.pair.a`), because the
-        // intermediate base (`c.pair`) is independently re-checked as if it
-        // were being read as a whole value, not merely projected through.
-        // Isolated to a straight-line program with zero if/loop/match and
-        // zero Lane 1 join-model code involved at all -- the root cause is
-        // in `infer_expr_type_no_check`, which only skips its own
-        // path-availability re-check when the base expression is a bare
-        // `Expr::Var`; a `RecordField` base (as in `c.pair.b`, whose base
-        // `c.pair` is itself a `RecordField` access, not a `Var`) falls
-        // through to a second, independent, shorter-path check that the
-        // outer expression's own top-level check has already correctly
-        // subsumed. This is a read-path-checking gap orthogonal to
-        // control-flow/branch-joining (Lane 1's actual scope) -- it would
-        // misfire in a single straight-line function with no
-        // `if`/`loop`/`match` anywhere. This test pins the *current*
-        // (buggy) behavior so it does not regress silently; when FA-02-039
-        // is repaired, this test must be replaced or inverted to assert
-        // success, not preserved as-is -- its continued `expect_err` after
-        // a fix would itself be a stale, incorrect assertion.
+    fn fa02_039_nested_projection_sibling_read_remains_available() {
+        // Fixes FA-02-039 (skulmakov-oss/Semantic#1881). Not part of
+        // #1656-#1664 (SSF-08 Lane 1's own scope); this is a follow-up
+        // frontend read-path repair. Reading a two-level-nested field
+        // projection (`c.pair.b`) must succeed after only a *sibling*
+        // field of the intermediate base was moved (`c.pair.a`): `pair.a`
+        // and `pair.b` are sibling paths under `pair`, and neither is a
+        // prefix of the other. Root cause was `infer_expr_type_no_check`
+        // only preserving its no-ownership-recheck contract for a bare
+        // `Expr::Var` base; a `RecordField` base (as in `c.pair.b`, whose
+        // own base `c.pair` is itself a `RecordField` access) fell through
+        // to the fully-checked `infer_expr_type`, re-deriving and
+        // re-checking a shorter, synthetic `[pair]` path that the outer
+        // expression's own top-level `[pair, b]` check had already
+        // correctly subsumed. `infer_expr_type_no_check` now recurses
+        // through the same no-check-preserving field/index resolvers for
+        // any base `expr_access_path` itself recognizes as part of the
+        // admitted static path family, not only `Expr::Var`.
         let src = r#"
             record Pair { a: i32, b: i32 }
             record Container { pair: Pair, other: i32 }
@@ -11132,14 +11125,203 @@ mod tests {
                 return;
             }
         "#;
-        let err = typecheck_source(src).expect_err(
-            "known pre-existing defect: reading a sibling field two levels deep spuriously rejects; see comment above",
-        );
+        typecheck_source(src)
+            .expect("sibling field two levels deep must remain readable after the fix");
+    }
+
+    #[test]
+    fn fa02_039_three_level_chain_sibling_read_remains_available() {
+        // Positive, deeper chain: move root.a.b.x, read root.a.b.y. The read
+        // expression's base chain is root.a.b (two levels of RecordField
+        // nesting below the outermost .y), exercising genuine multi-level
+        // recursion through infer_expr_type_no_check, not just one level.
+        let src = r#"
+            record Inner { x: i32, y: i32 }
+            record Middle { b: Inner, z: i32 }
+            record Outer { a: Middle, w: i32 }
+            fn main() {
+                let root: Outer = Outer { a: Middle { b: Inner { x: 1, y: 2 }, z: 3 }, w: 4 };
+                let Inner { x: moved, y: _ } = root.a.b;
+                let _ = moved;
+                let val: i32 = root.a.b.y;
+                let _ = val;
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("sibling read three levels deep must remain available after the fix");
+    }
+
+    #[test]
+    fn fa02_039_disjoint_branch_under_common_ancestor_remains_available() {
+        // Positive: move root.a.x, read root.b.y -- entirely disjoint
+        // branches under a shared root, not even overlapping ancestors.
+        let src = r#"
+            record BranchA { x: i32 }
+            record BranchB { y: i32 }
+            record Root { a: BranchA, b: BranchB }
+            fn main() {
+                let root: Root = Root { a: BranchA { x: 1 }, b: BranchB { y: 2 } };
+                let BranchA { x: moved } = root.a;
+                let _ = moved;
+                let val: i32 = root.b.y;
+                let _ = val;
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("disjoint branch under a common ancestor must remain readable");
+    }
+
+    #[test]
+    fn fa02_039_moved_ancestor_field_blocks_descendant_read() {
+        // Negative: move the whole c.pair field, then read c.pair.b -- the
+        // moved path IS an ancestor of the read path, so this must still
+        // reject. Proves the fix removed only the spurious *intermediate*
+        // re-check, not the genuine ancestor/descendant overlap rule.
+        let src = r#"
+            record Pair { a: i32, b: i32 }
+            record Container { pair: Pair, other: i32 }
+            fn main() {
+                let c: Container = Container { pair: Pair { a: 1, b: 2 }, other: 9 };
+                let Container { pair: moved, other: _ } = c;
+                let _ = moved;
+                let z: i32 = c.pair.b;
+                let _ = z;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("reading through a moved ancestor field must still reject");
+        assert!(err.message.contains("moved"), "unexpected: {}", err.message);
+    }
+
+    #[test]
+    fn fa02_039_move_then_reread_exact_path_still_rejects() {
+        // Negative: move c.pair.b, then read c.pair.b again (identical
+        // path) -- must still reject.
+        let src = r#"
+            record Pair { a: i32, b: i32 }
+            record Container { pair: Pair, other: i32 }
+            fn main() {
+                let c: Container = Container { pair: Pair { a: 1, b: 2 }, other: 9 };
+                let Pair { a: _, b: moved } = c.pair;
+                let _ = moved;
+                let z: i32 = c.pair.b;
+                let _ = z;
+                return;
+            }
+        "#;
+        let err =
+            typecheck_source(src).expect_err("re-reading the exact moved path must still reject");
+        assert!(err.message.contains("moved"), "unexpected: {}", err.message);
+    }
+
+    #[test]
+    fn fa02_039_moved_child_still_blocks_genuine_whole_parent_read() {
+        // Negative, the critical boundary case: move c.pair.a, then read
+        // c.pair as an actual *whole-value* read (not merely an
+        // intermediate type-resolution step on the way to a sibling
+        // field). This is the exact partial-move rejection the fix must
+        // NOT weaken -- unlike `c.pair.b`, this expression's own top-level
+        // access path genuinely IS `[pair]`, evaluated directly (via
+        // infer_expr_type_with_expected's catch-all -> the real, checked
+        // infer_expr_type), never through infer_expr_type_no_check at all.
+        let src = r#"
+            record Pair { a: i32, b: i32 }
+            record Container { pair: Pair, other: i32 }
+            fn main() {
+                let c: Container = Container { pair: Pair { a: 1, b: 2 }, other: 9 };
+                let Pair { a: moved, b: _ } = c.pair;
+                let _ = moved;
+                let whole: Pair = c.pair;
+                let _ = whole;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("reading c.pair as a genuine whole value after .a was moved must reject");
         assert!(
             err.message.contains("partially moved"),
             "unexpected: {}",
             err.message
         );
+    }
+
+    #[test]
+    fn fa02_039_moved_mid_level_ancestor_blocks_deep_descendant_read() {
+        // Negative, deeper ancestor/descendant overlap: move the whole
+        // root.a field (a Middle), then read the deep descendant
+        // root.a.b.x -- must still reject, stress-testing the ancestor
+        // rule at the same recursion depth the positive three-level test
+        // above proves succeeds for a non-overlapping sibling.
+        let src = r#"
+            record Inner { x: i32, y: i32 }
+            record Middle { b: Inner, z: i32 }
+            record Outer { a: Middle, w: i32 }
+            fn main() {
+                let root: Outer = Outer { a: Middle { b: Inner { x: 1, y: 2 }, z: 3 }, w: 4 };
+                let Outer { a: moved, w: _ } = root;
+                let _ = moved;
+                let val: i32 = root.a.b.x;
+                let _ = val;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("reading a deep descendant of a moved mid-level ancestor must reject");
+        assert!(err.message.contains("moved"), "unexpected: {}", err.message);
+    }
+
+    #[test]
+    fn fa02_039_mixed_record_sequence_record_chain_type_resolves() {
+        // Positive, mixed projection families: record.field[literal_index].child
+        // must type-check via the same recursive no-check traversal,
+        // proving it is not special-cased to RecordField-only chains.
+        // Sequence-element ownership tracking has no admitted move syntax
+        // under the current language surface (match/if-let patterns admit
+        // only Quad/enum/wildcard/int-range forms, never a bare bind
+        // against a non-enum scrutinee -- confirmed empirically while
+        // auditing this issue, reported separately, not fixed here), so
+        // this is a type-resolution-only proof with no move involved.
+        let src = r#"
+            record Item { value: i32, label: i32 }
+            record Holder { items: Sequence(Item) }
+            fn main() {
+                let holder: Holder = Holder { items: [Item { value: 1, label: 2 }] };
+                let z: i32 = holder.items[0].label;
+                let _ = z;
+                return;
+            }
+        "#;
+        typecheck_source(src)
+            .expect("mixed record/sequence/record projection chain must type-check");
+    }
+
+    #[test]
+    fn fa02_039_dynamic_sequence_index_base_still_type_checks() {
+        // Positive: a dynamic (non-literal) index base inside a larger
+        // read chain is structurally excluded from the new no-check
+        // routing by construction -- expr_access_path returns None for a
+        // non-literal index, so the guard condition
+        // `expr_access_path(expr_id, arena).is_some()` is always false
+        // here and this always falls through to the normal, fully-checked
+        // infer_expr_type, exactly as before the fix. This proves that
+        // fallthrough still produces a correct, successful type for the
+        // ordinary case (no regression), complementing
+        // ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects's
+        // coverage of the rejecting case.
+        let src = r#"
+            record Item { value: i32 }
+            fn main() {
+                let items: Sequence(Item) = [Item { value: 1 }, Item { value: 2 }];
+                let i: i32 = 1;
+                let z: i32 = items[i].value;
+                let _ = z;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("dynamically-indexed base read must still type-check");
     }
 
     // #1656 -- statement `if`
@@ -11734,13 +11916,14 @@ mod tests {
     fn ssf08_1663_projected_record_field_scrutinee_sibling_field_still_usable() {
         // Proves the tracked path is `c.pair.a` specifically, not a coarser
         // `c` root -- a sibling field one level up, `c.other`, must remain
-        // usable after only `c.pair.a` was moved. (Deliberately uses a
-        // one-level-nested sibling, not `c.pair.b`: reading a two-level
-        // projection through an intermediate record-field base hits an
-        // unrelated, pre-existing defect tracked as FA-02-039
-        // (skulmakov-oss/Semantic#1881) -- see
-        // `fa02_039_known_defect_nested_projection_rereads_intermediate_base_as_whole_value`
-        // -- which this test must not exercise.)
+        // usable after only `c.pair.a` was moved. (Originally used a
+        // one-level-nested sibling rather than `c.pair.b` specifically to
+        // avoid FA-02-039 (skulmakov-oss/Semantic#1881), a since-fixed
+        // unrelated defect in reading a two-level projection through an
+        // intermediate record-field base -- see
+        // `fa02_039_nested_projection_sibling_read_remains_available`. Left
+        // as-is here since it independently proves path-precision at a
+        // different nesting depth, not because `c.pair.b` is unsafe now.)
         let src = r#"
             record Pair { a: i32, b: i32 }
             record Container { pair: Pair, other: i32 }
@@ -16632,8 +16815,24 @@ pub(crate) fn expr_access_path(
 /// check from M9.9.  Used internally when `expr_id` is the *base* of a field or
 /// index access whose **caller** has already verified the full access path.
 ///
-/// Only skips the path check for `Expr::Var`; all other expressions fall through
-/// to the normal `infer_expr_type` (which includes their own path check).
+/// SSF-08 (#1881 / FA-02-039): recursively preserves this no-check contract
+/// across any expression `expr_access_path` itself recognizes as part of an
+/// admitted static path chain (`Expr::Var`, `Expr::RecordField`,
+/// `Expr::SequenceIndex` with a literal non-negative index) -- not only a
+/// bare `Expr::Var` base. A multi-level projection base (e.g. the `c.pair`
+/// in `c.pair.b`) is itself such a chain segment: its own full path was
+/// already validated by the true top-level caller (the outermost
+/// `expr_access_path`/`check_path_available` pair in `infer_expr_type`), so
+/// re-deriving and re-checking *its own*, shorter, synthetic path here would
+/// incorrectly treat an intermediate type-resolution step as an independent
+/// whole-value read of a path the program never actually reads as such.
+///
+/// Anything **not** recognized by `expr_access_path` -- i.e. not provably
+/// part of the same checked static chain -- still falls through to the
+/// normal, fully-checked `infer_expr_type` below. This must never become
+/// "skip the check when unsure": an unprovable or dynamic path shape (e.g.
+/// a non-literal sequence index) stays fail-closed via the ordinary checked
+/// path, exactly as before.
 fn infer_expr_type_no_check(
     expr_id: ExprId,
     arena: &AstArena,
@@ -16653,6 +16852,35 @@ fn infer_expr_type_no_check(
                 pos: 0,
                 message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
             })
+        }
+        Expr::RecordField(field_expr) if expr_access_path(expr_id, arena).is_some() => {
+            // Same no-check contract as the Var case above, recursed one
+            // level: reuse the existing field-resolution logic, which
+            // itself calls infer_expr_type_no_check on *its* base.
+            infer_record_field_access_type(
+                field_expr,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty,
+                loop_stack,
+                impl_list,
+            )
+        }
+        Expr::SequenceIndex(index_expr) if expr_access_path(expr_id, arena).is_some() => {
+            infer_sequence_index_type(
+                index_expr,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty,
+                loop_stack,
+                impl_list,
+            )
         }
         _ => infer_expr_type(
             expr_id,


### PR DESCRIPTION
SSF-08 frontend ownership/read-path follow-up.

Closes #1881.

Fixes a false rejection in nested projection reads where type resolution re-checked an intermediate base as a standalone whole-value access even though the caller had already validated the complete ownership path.

Position A unchanged. No Lane 2 changes. No #1664 changes.

## Baseline / HEAD

- Expected baseline: `ff3e65972adacf19c101207b27ad9d59f8c62001` (confirmed exact match: `git fetch origin && git rev-parse origin/main`, working tree clean before branching).
- This branch: `fix/1881-nested-projection-read`.

## Reproduction

```rust
record Pair { a: i32, b: i32 }
record Container { pair: Pair, other: i32 }

fn main() {
    let c: Container = Container { pair: Pair { a: 1, b: 2 }, other: 9 };
    let Pair { a: moved, b: _ } = c.pair;
    let _ = moved;
    let z: i32 = c.pair.b;
    let _ = z;
    return;
}
```

- `origin/main @ ff3e6597` (via the pre-fix `fa02_039_known_defect_...` test, which asserted `expect_err`): **FAILS incorrectly** — `use of partially moved value: cannot use whole variable because child path ["pair", "a"] was moved`, even though `c.pair.a` and `c.pair.b` are sibling paths.
- This branch's HEAD (via the same test, inverted to `fa02_039_nested_projection_sibling_read_remains_available`, now `.expect(...)`): **PASSES correctly**.

## Root cause (verified against this exact baseline before editing, per the issue's own checklist)

1. Confirmed the call path still exists exactly as #1881 describes: `infer_record_field_access_type` (`crates/sm-front/src/typecheck.rs`) resolves a field access's base via `infer_expr_type_no_check(field_expr.base, ...)`, whose comment claimed "no path check needed; the outer `infer_expr_type` call for the full field/index expression already checked the correct sub-path" — but `infer_expr_type_no_check` only actually honored that for a bare `Expr::Var` base; any other kind (including another `RecordField`) fell through to the fully-checked `infer_expr_type`.
2. Reproduced #1881 on this exact baseline (confirmed above).
3. Confirmed the *outer* full-path check for `c.pair.b` (`check_path_available(c, [pair, b])`) correctly finds no overlap with the stored `[pair, a] = Moved` restriction (true siblings, neither a prefix of the other) — traced by hand through `check_path_available`'s prefix/overlap logic, and confirmed empirically with temporary instrumentation (see below).
4. Confirmed the false rejection comes *only* from the second, intermediate call: resolving `c.pair`'s own type (as the base of `c.pair.b`) re-invokes the full, checked `infer_expr_type(c.pair)`, whose own top-of-function check re-derives and re-checks the shorter path `[pair]`, which *does* overlap `[pair, a]` as an ancestor — producing the spurious rejection.

None of the checklist's "if false, STOP" conditions were triggered; proceeded to the fix.

## Repair mechanism

`infer_expr_type_no_check` now recursively preserves its no-ownership-recheck contract for **any** base expression `expr_access_path` itself recognizes as part of the admitted static path family (`Expr::Var`, `Expr::RecordField`, `Expr::SequenceIndex` with a literal non-negative index) — not only a bare `Expr::Var`. For `RecordField`/`SequenceIndex` bases whose own `expr_access_path` resolves (proving they are themselves a segment of a chain whose full path the true top-level caller already validated), it now calls the existing `infer_record_field_access_type`/`infer_sequence_index_type` resolvers directly — the exact same functions the checked path already used, which themselves recurse into `infer_expr_type_no_check` for *their* base. This is **one canonical no-check traversal**, not a special case per expression kind: no new field/index-resolution logic was written; the fix is entirely in which function `infer_expr_type_no_check` dispatches to.

Anything **not** recognized by `expr_access_path` (a dynamic sequence index, a call expression, etc.) still falls through to the normal, fully-checked `infer_expr_type`, unchanged from before — this is not "skip the check when unsure." An unprovable/dynamic path stays fail-closed via the ordinary checked path exactly as it did pre-fix.

`ScopeEnv::check_path_available` and its prefix/overlap semantics in `crates/sm-front/src/lib.rs` are **untouched** — the issue's own evidence said the bug was not there, and empirical proof (below) confirms it. `lib.rs` has zero diff in this PR.

### Empirical proof of "single ownership check authority" (section 19)

Temporarily instrumented `check_path_available` with an `eprintln!` logging `(name, path)` on every call, ran the primary reproduction, and removed the instrumentation before this commit. Observed exactly two calls for the whole program: one for `[pair]` (the *separate*, legitimate destructuring-scrutinee check on `let Pair { .. } = c.pair;`), and one for `[pair, b]` (the `c.pair.b` read itself). Zero synthetic re-checks on the intermediate `[pair]` base for the read — confirming the fix produces exactly the desired control flow (`derive canonical full path → check once → resolve remaining type without re-checking shorter synthetic bases`), not the old `check [pair,b], check [pair]` double-check.

## Positive / negative regression matrix (`crates/sm-front/src/typecheck.rs`)

| Case | Test | Result |
|---|---|---|
| Two-level sibling: move `c.pair.a`, read `c.pair.b` | `fa02_039_nested_projection_sibling_read_remains_available` (inverted from the pre-existing known-defect test) | PASS |
| Three-level chain sibling: move `root.a.b.x`, read `root.a.b.y` | `fa02_039_three_level_chain_sibling_read_remains_available` | PASS |
| Disjoint branches under a common ancestor: move `root.a.x`, read `root.b.y` | `fa02_039_disjoint_branch_under_common_ancestor_remains_available` | PASS |
| Moved ancestor field blocks descendant read: move whole `c.pair`, read `c.pair.b` | `fa02_039_moved_ancestor_field_blocks_descendant_read` | REJECT (unchanged) |
| Exact-path re-read: move `c.pair.b`, read `c.pair.b` | `fa02_039_move_then_reread_exact_path_still_rejects` | REJECT (unchanged) |
| **Critical boundary case** — moved child still blocks a *genuine* whole-parent read: move `c.pair.a`, then `let whole: Pair = c.pair;` (a real whole-value read, reached via the checked path directly, never through `infer_expr_type_no_check`) | `fa02_039_moved_child_still_blocks_genuine_whole_parent_read` | REJECT (unchanged — proves the fix is bounded to intermediate-base resolution only) |
| Deeper ancestor/descendant overlap: move whole `root.a`, read deep descendant `root.a.b.x` | `fa02_039_moved_mid_level_ancestor_blocks_deep_descendant_read` | REJECT (unchanged) |
| Mixed projection families, type-resolution only: `holder.items[0].label` (`RecordField → SequenceIndex(literal) → RecordField`) | `fa02_039_mixed_record_sequence_record_chain_type_resolves` | PASS |
| Dynamic index base structurally excluded from the new routing: `items[i].value` with non-literal `i` | `fa02_039_dynamic_sequence_index_base_still_type_checks` | PASS (still routes through the fully-checked path, unchanged) |
| Dynamic/unrepresentable sequence-index scrutinee (pre-existing #1663 coverage) | `ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects` | kept green, unmodified |
| #1663 projected-scrutinee tracking (pre-existing) | `ssf08_1663_projected_record_field_scrutinee_move_is_tracked`, `ssf08_1663_projected_record_field_scrutinee_sibling_field_still_usable` | kept green, unmodified (only a stale comment referencing the old FA-02-039 test name was corrected) |

## A finding surfaced during this audit — filed separately, not fixed here

While constructing the mixed-projection matrix (section 17), I needed a way to move a specific `Sequence` element via pattern capture to build meaningful negative cases. Investigating this surfaced that **`ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects` (merged in #1880) does not test what its name and comment claim.**

Its assertion is only `!err.message.contains("unknown variable")`. Empirically (temporary instrumentation, since reverted), the program `match seq[i] { v => { let _ = v; } }` — with `i` dynamic — actually fails to **parse** at all: `"expected '::' in enum match pattern"`. This is because `MatchPattern` (`crates/sm-front/src/types.rs`) has no "bind by plain name" variant at all — only `Quad`, `Adt` (enum, requires `Name::Variant`), `Wildcard`, `IntRange`, `Or`. A bare identifier like `v` as a match arm pattern is not valid syntax against *any* scrutinee type, regardless of whether the underlying path is static or dynamic. The test's weak assertion happens to also hold for this parse error, so it reports green while proving nothing about ownership-path rejection specifically.

Filed as **#1883 (FA-02-040: "projected-scrutinee negative regression passes at parser layer and does not exercise ownership rejection")**, umbrella #1617, Module 02 (`sm-front`), Classification TEST-INTEGRITY · FALSE-READY · QUALIFICATION-GAP. Explicitly does **not** reopen #1663 (this finding proves one of its qualifying regressions is invalid evidence, not that its implementation is wrong) and explicitly does **not** belong in this PR. I did not fix or touch the test — it's out of #1881's scope, and #1880's own boundary explicitly required keeping it green and unmodified. It also means: there is currently no admitted source syntax to move a specific `Sequence` element via pattern capture at all (record/tuple destructuring support bind-by-name via a different, separate pattern representation; `match`/`if-let` do not) — which is why the mixed-projection matrix above is positive/type-resolution-only for sequence chains, not move/reject, and why I did not attempt a `sequence[index].field`-with-a-move negative case.

## Explicitly out of scope (not touched, not opportunistically repaired)

- `#1664` remainder (`is_const`, `sm-ir` migration) — not touched.
- Lane 2: `#1709`, `#1718`, `#1724`, `#1725`, `#1726` — not touched. No production changes under `crates/sm-ir`, `crates/sm-format`, `crates/sm-verify`, `crates/sm-vm`, `crates/sm-runtime-core`.
- `#1883` (FA-02-040, the `ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects` test-integrity finding above) — filed, not fixed here.
- Position A unchanged; plain root rebinding (`let y = x;`) stays copy-by-value (`scalar_root_rebind_copy_semantics_e2e.rs`, still 6/6).

## Fallback / hidden-behavior audit

Searched the diff for `unwrap_or`, `unwrap_or_default`, `Ok(())` on an unresolved path, silent `None => continue`, a fallback to full `infer_expr_type` used as an uncertainty-recovery mechanism, `Default::default()` as recovery, and ignored `Result` — none introduced. The `_ => infer_expr_type(...)` fallthrough arm is the pre-existing, intentional fail-closed default for anything `expr_access_path` doesn't recognize, unchanged in shape from before this PR (only the two new guarded arms sit above it).

## Files changed

- `crates/sm-front/src/typecheck.rs` only (+265/-37): `infer_expr_type_no_check`'s recursive fix, its updated doc comment, the inverted/renamed `fa02_039_*` test plus 8 new regression tests, and a corrected stale comment in one pre-existing #1663 test.
- `crates/sm-front/src/lib.rs`: **zero diff.** No `ScopeEnv` semantic change was needed or made.

## Local qualification (all commands from workspace root)

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo test -p sm-front --lib` | **642 passed**, 0 failed (634 baseline + 8 net-new) |
| `cargo check -p sm-front --all-targets` | clean |
| `cargo clippy -p sm-front --all-targets -- -D warnings` | clean |
| `cargo test --test scalar_root_rebind_copy_semantics_e2e` | 6/6 passed |
| `cargo test --test runtime_ownership_e2e` | 32/32 passed |
| `cargo test --test match_surface_qualification` | 3/3 passed |
| `cargo test --test ssf_status_drift` | 3/3 passed |
| `cargo test --test public_api_contracts` | 88/88 passed |
| `cargo check --workspace --all-targets` | clean |
| `cargo test --workspace` | **4436 passed, 0 failed** — full pass, not INCOMPLETE |
| `git diff --check` | clean |

Do not merge. Draft PR pending review, matching the exact-head discipline established on #1879/#1880.

Closes #1881
