### PR TITLE
test(front): qualify projected-scrutinee fail-closed boundary

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -11940,12 +11940,116 @@ mod tests {
             .expect("sibling field of a projected-scrutinee move must remain usable");
     }
 
+    /// FA-02-040 (#1883): parse and typecheck as two explicit,
+    /// separately-observable steps, so a test using this can prove *which*
+    /// layer a rejection came from -- unlike `typecheck_source`, which
+    /// collapses both into one `Result` and cannot distinguish a parser
+    /// rejection from a semantic/ownership one. The internal `.expect()` on
+    /// the parse step is a deliberate guard: if a test using this helper
+    /// ever starts failing to parse, it panics with an explicit message
+    /// naming the parse failure, instead of silently "passing" for the
+    /// wrong reason against a weaker downstream assertion -- the exact
+    /// failure mode FA-02-040 found in the regression this helper now
+    /// backs.
+    fn parse_then_typecheck(src: &str) -> Result<(), FrontendError> {
+        let program = parse_program(src)
+            .expect("FA-02-040 test helper: source must parse for this test to prove anything about the ownership layer");
+        type_check_program(&program)
+    }
+
     #[test]
     fn ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects() {
-        // seq[i] with a non-literal index cannot be resolved to a static
-        // path by expr_access_path; since the pattern here captures a value
-        // from it, this must reject deterministically rather than silently
-        // skip ownership tracking.
+        // FA-02-040 (#1883) corrective round: the original form of this
+        // test used a bare-identifier match-arm pattern (`v => {...}`),
+        // which is not admitted syntax at all -- `MatchPattern` (types.rs)
+        // has no bind-by-name variant, only `Quad`/`Adt`/`Wildcard`/
+        // `IntRange`/`Or` -- so it failed at the *parser*, before the
+        // ownership layer ever ran. The old assertion
+        // (`!message.contains("unknown variable")`) could not distinguish
+        // a parser rejection from a semantic one, so this test reported
+        // green while proving nothing about the ownership invariant its
+        // name claims. Confirmed via temporary instrumentation (since
+        // reverted): `parse_program` itself returned
+        // `"expected '::' in enum match pattern"`; `apply_arm_pattern_capture`
+        // was never entered.
+        //
+        // Fixed to use a valid `Adt` match pattern (`Flag::A(x)`) instead,
+        // which parses and reaches `apply_arm_pattern_capture` with a
+        // genuine consuming `BindingPlan` and an unrepresentable
+        // (dynamically-indexed) scrutinee -- confirmed via the same
+        // temporary instrumentation to actually enter that function before
+        // this test's rejection fires -- proving the real semantic
+        // boundary #1663 claims to guarantee. See
+        // `fa02_040_lettuple_dynamically_indexed_sequence_scrutinee_with_capture_rejects`
+        // below for an independent proof via a different call site, and
+        // `fa02_040_bare_identifier_match_pattern_is_not_admitted_syntax`
+        // for honest coverage of the parser behavior this test used to
+        // (accidentally) rely on.
+        let src = r#"
+            enum Flag { A(i32), B }
+            fn main() {
+                let seq: Sequence(Flag) = [Flag::A(1), Flag::B];
+                let i: i32 = 0;
+                match seq[i] {
+                    Flag::A(x) => { let _ = x; }
+                    Flag::B => {}
+                }
+                return;
+            }
+        "#;
+        let err = parse_then_typecheck(src).expect_err(
+            "a capturing match against a dynamically-indexed sequence scrutinee must reject deterministically at the ownership layer",
+        );
+        assert!(
+            err.message.contains(
+                "pattern capture against a projected scrutinee that is not an admitted static path"
+            ),
+            "must be the canonical unrepresentable-scrutinee rejection, not a different error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn fa02_040_lettuple_dynamically_indexed_sequence_scrutinee_with_capture_rejects() {
+        // Complementary to the match-based regression above: proves the
+        // same canonical `apply_arm_pattern_capture` authority rejects an
+        // unrepresentable, dynamically-indexed scrutinee identically when
+        // reached via plain tuple-destructuring-let (a different one of
+        // `apply_arm_pattern_capture`'s five production call sites), not
+        // only via `match` -- one semantic authority, not a
+        // construct-specific special case.
+        let src = r#"
+            fn main() {
+                let seq: Sequence((i32, i32)) = [(1, 2), (3, 4)];
+                let i: i32 = 1;
+                let (a, b) = seq[i];
+                let _ = a;
+                let _ = b;
+                return;
+            }
+        "#;
+        let err = parse_then_typecheck(src).expect_err(
+            "tuple-destructuring a dynamically-indexed sequence scrutinee must reject deterministically at the ownership layer",
+        );
+        assert!(
+            err.message.contains(
+                "pattern capture against a projected scrutinee that is not an admitted static path"
+            ),
+            "must be the canonical unrepresentable-scrutinee rejection, not a different error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn fa02_040_bare_identifier_match_pattern_is_not_admitted_syntax() {
+        // Honest parser-surface coverage, NOT ownership evidence (see
+        // FA-02-040 / #1883). Pins that a bare identifier (no enum-variant
+        // `::` prefix) is not valid match-arm pattern syntax --
+        // `MatchPattern` has no bind-by-name variant at all, so this fails
+        // to parse regardless of scrutinee shape, static or dynamic. This
+        // is the parser behavior the original,
+        // misleadingly-named-as-ownership-proof regression above used to
+        // (accidentally) exercise before this corrective round.
         let src = r#"
             fn main() {
                 let seq: Sequence(i32) = [1, 2, 3];
@@ -11956,12 +12060,10 @@ mod tests {
                 return;
             }
         "#;
-        let err = typecheck_source(src).expect_err(
-            "a capturing match against a dynamically-indexed sequence scrutinee must reject deterministically",
-        );
+        let err = parse_program(src).expect_err("bare-identifier match pattern must fail to parse");
         assert!(
-            !err.message.contains("unknown variable"),
-            "must be an explicit unsupported-path rejection, not an unrelated unknown-variable error: {}",
+            err.message.contains("expected '::' in enum match pattern"),
+            "unexpected parser diagnostic: {}",
             err.message
         );
     }


### PR DESCRIPTION
FA-02-040: replace false-positive parser-gated ownership evidence with a regression that proves the actual projected-scrutinee semantic boundary.

**VERDICT A**: valid admitted source reaches the intended ownership boundary; the existing implementation fails closed correctly; the misleading regression is replaced. No production code change.

No language-surface expansion. No Sequence ownership promotion. No Lane 2 changes. Position A unchanged.

Closes #1883

## Baseline / HEAD

- Expected baseline: `0eccc1f0f0c9509b0d2206afb1e07fc8e05bb040` (confirmed exact match: `git fetch origin && git rev-parse origin/main`, working tree clean before branching).
- This branch: `fix/1883-projected-scrutinee-qualification`.

## Governing question

Can a valid admitted source program produce both (1) a consuming `BindingPlan`, and (2) a scrutinee for which `expr_access_path(...) == None`? If yes, does `apply_arm_pattern_capture` actually reject it? A rejection at layer N (the parser) cannot qualify behavior at layer N+1 (ownership) if execution never reaches layer N+1.

## Step 1 — reproduce the disputed test's actual behavior on baseline

`ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects`'s source is effectively `match seq[i] { v => { let _ = v; } }`. Its only assertion is `!err.message.contains("unknown variable")` — too weak to identify which subsystem produced the error.

Temporarily instrumented (since reverted): called `parse_program(src)` and `type_check_program(&program)` as two separate, directly observable steps, rather than trusting `typecheck_source`'s combined `Result`.

**Result on `origin/main @ 0eccc1f0`:**
```
parse_program(src) -> Err("expected '::' in enum match pattern")
```
`type_check_program` is never reached — the test's `.expect_err(...)` panics at the parse step itself. Confirmed: **pure parser failure**, not an ownership-layer rejection.

## Step 2 — audit the pattern grammar (section 6)

| Pattern surface | Backing type | Bind-by-name (`v`) admitted? |
|---|---|---|
| `match` arm | `MatchPattern` (`Quad`/`Adt`/`Wildcard`/`Or`/`IntRange`) | **No** — no such variant exists |
| `if let` | `MatchPattern` (same type, shared with `match`) | **No** |
| record destructuring (`let Record { .. } = ..;`) | `RecordPatternItem` / `RecordPatternTarget` | **Yes** — `RecordPatternTarget::Bind { name, capture }` |
| tuple destructuring (`let (a, b) = ..;`) | `TuplePatternItem` | **Yes** — `TuplePatternItem::Bind { name, capture }` |
| ADT payload capture (inside `MatchPattern::Adt`) | `AdtMatchPattern` / `AdtPatternItem` | **Yes** — `AdtPatternItem::Bind { name, capture }`, but only as a payload sub-item of an already-valid `Name::Variant(..)` pattern, never standalone |
| Quad pattern | `MatchPattern::Quad(QuadVal)` | No — matches a literal quad value |
| Wildcard | `MatchPattern::Wildcard` | No — discards |
| Int-range | `MatchPattern::IntRange` | No — matches a numeric range |
| Or-pattern | `MatchPattern::Or(Vec<MatchPattern>)` | No — combinator over other patterns |

`MatchPattern` (used by both `match` and `if let`) has **no bind-by-name variant at all**. A bare identifier like `v` is not valid syntax as a top-level match/if-let pattern against *any* scrutinee, static or dynamic — this explains the parse failure and rules out "just use `v` correctly" as a fix. Bind-by-name capture *is* admitted, but only nested inside record/tuple/ADT-payload patterns.

## Step 3 — audit every production call site of `apply_arm_pattern_capture` (section 7)

Five call sites, `crates/sm-front/src/typecheck.rs`:

| Caller | Scrutinee source | Constrained to `Expr::Var`? | Consuming plan possible? |
|---|---|---|---|
| `Stmt::LetTuple` | `value: ExprId`, checked via generic `infer_expr_type`/`infer_expr_type_with_expected` | No — any expression evaluating to `Type::Tuple` | Yes (`TuplePatternItem::Bind`, default `Move`) |
| `Stmt::LetRecord` | `value: ExprId`, same generic `infer_expr_type` | No — any expression evaluating to the named record type | Yes (`RecordPatternTarget::Bind`, default `Move`) |
| `Stmt::LetElseRecord` | same code shape as `LetRecord` (confirmed by inspection — identical "M9.10/#1663" comment at all four `let`-family call sites) | No | Yes |
| `Stmt::LetElseTuple` | same code shape as `LetTuple` | No | Yes |
| `build_pattern_arm_env` (shared by statement `match`, expression `match`, statement `if-let`, expression `if-let`) | `scrutinee: ExprId`, passed through from the construct's own scrutinee expression | No — confirmed empirically (below) that `seq[i]` is accepted as a `match` scrutinee | Yes (`AdtPatternItem::Bind`, `RecordPatternTarget::Bind` inside a valid outer pattern) |

None of the five callers restrict the scrutinee expression to `Expr::Var` — all accept any expression of the right type. This is the structural reason a dynamically-indexed scrutinee can reach the handler at all.

## Step 4 — falsification search (section 8-9): does valid source reach the boundary?

Constructed and empirically verified (temporary `eprintln!` in `apply_arm_pattern_capture`, since reverted) two independent, currently-admitted programs:

**A. `match` with a valid `Adt` pattern** (same construct family as the original test, fixed pattern syntax):
```rust
enum Flag { A(i32), B }
fn main() {
    let seq: Sequence(Flag) = [Flag::A(1), Flag::B];
    let i: i32 = 0;
    match seq[i] {
        Flag::A(x) => { let _ = x; }
        Flag::B => {}
    }
    return;
}
```
Observed: `apply_arm_pattern_capture ENTERED: plan.items.len()=1`, then `Err("pattern capture against a projected scrutinee that is not an admitted static path (e.g. a dynamically-computed index) cannot be tracked; bind the scrutinee to a local first or use a supported static path")`.

**B. Tuple-destructuring `let`** (a second, independent call site):
```rust
fn main() {
    let seq: Sequence((i32, i32)) = [(1, 2), (3, 4)];
    let i: i32 = 1;
    let (a, b) = seq[i];
    let _ = a;
    let _ = b;
    return;
}
```
Observed: `apply_arm_pattern_capture ENTERED: plan.items.len()=2`, then the identical canonical `Err(...)`.

Both parse successfully, both reach `apply_arm_pattern_capture` with a genuine consuming `BindingPlan` (`Move` capture) and a scrutinee for which `expr_access_path(seq[i]) == None` (dynamic index), and both are rejected with the exact canonical diagnostic — proving the semantic boundary #1663 claims to guarantee is real, reachable, and correctly enforced.

**Also checked, not pursued further**: `if let Flag::A(x) = seq[i] { .. }` hit a *different*, separate parser error (`"expected primary expression"`) — distinct from the bare-bind issue, not investigated further since (A) and (B) already conclusively establish Case A for `apply_arm_pattern_capture` itself, which is the shared authority behind `match`, expression-`match`, and both `if-let` forms.

## Verdict

**VERDICT A.** Valid admitted source reaches `apply_arm_pattern_capture` with a consuming plan and an unrepresentable scrutinee; the implementation fails closed correctly with the canonical diagnostic. #1663's implementation is **not** falsified — it is validated by this investigation. Per the governing task: do not reopen #1663.

## Repair (test-only)

`crates/sm-front/src/typecheck.rs` only. No production code changed.

- Added `parse_then_typecheck(src) -> Result<(), FrontendError>`: a tiny local test helper (justified per the task's own guidance — several new/reworked tests need the same "prove parse succeeded, then check the semantic result" shape) that runs `parse_program` and `type_check_program` as two explicit steps, `.expect()`-guarding the parse step so a *future* parser regression panics with an explicit "source must parse" message instead of silently satisfying a downstream assertion — the exact failure mode this whole investigation exists to prevent.
- **`ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects`** (fixed in place, same name, same intent): source changed from the invalid bare-bind `match` to the valid `Adt`-pattern `match` (reproduction A above); assertion changed from `!message.contains("unknown variable")` to `message.contains("pattern capture against a projected scrutinee that is not an admitted static path")` — the exact canonical diagnostic, not merely "any error."
- **`fa02_040_lettuple_dynamically_indexed_sequence_scrutinee_with_capture_rejects`** (new): independent proof via reproduction B, exercising a different one of the five call sites — proves this is one shared semantic authority, not a `match`-specific special case.
- **`fa02_040_bare_identifier_match_pattern_is_not_admitted_syntax`** (new): honest, correctly-labeled parser-surface coverage for the behavior the old regression was accidentally exercising — explicitly *not* framed as ownership evidence.

## Nearby-regression audit (section 26)

Searched the SSF-08 ownership test cluster (39 `ssf08_*`-prefixed tests plus the `fa02_03*`/`fa02_04*` tests from #1881/#1664) for the same pattern (`expect_err` with only a negative/weak assertion, no positive diagnostic check). Found three other `!message.contains(...)` uses in the file — all are *secondary*, defense-in-depth checks alongside a primary positive `.contains(specific_substring)` assertion, a structurally different and safe pattern. `ssf08_1663_dynamically_indexed_sequence_scrutinee_with_capture_rejects` was the **only** test in this cluster with solely a negative assertion and no positive one. No other false-positive candidates found; no separate FA finding filed.

## #1663 positive proofs preserved

`ssf08_1663_projected_record_field_scrutinee_move_is_tracked` and `ssf08_1663_projected_record_field_scrutinee_sibling_field_still_usable` — unmodified, still green.

## #1881 matrix preserved

All 9 `fa02_039_*` tests (the #1881 no-recheck-traversal fix and its positive/negative matrix) — unmodified, still green.

## Explicitly out of scope

- `#1664` (`is_const`, `sm-ir` migration) — not touched.
- Lane 2: `#1709`, `#1718`, `#1724`, `#1725`, `#1726` — not touched. No production changes under `crates/sm-ir`, `crates/sm-format`, `crates/sm-verify`, `crates/sm-vm`, `crates/sm-runtime-core`, `prom-abi`.
- Sequence ownership promotion — not attempted. Sequence runtime/indexing support remains distinct from a qualified Sequence ownership contract; nothing here changes that classification (`NOT PROVEN`). No new `MatchPattern` syntax, IR path component, or SemCode component introduced.
- The `if let ... = seq[i] { .. }` parser error found in passing — documented above, not investigated further, not filed as a separate finding (low confidence on root cause without further digging; flagging in this PR body is sufficient given it didn't block resolving #1883).

## Fallback / hidden-behavior audit

Production code is entirely untouched — no fallback audit applies to it. For the new/changed tests themselves: no `unwrap_or`/`unwrap_or_default`/silent `None => skip`/`Default::default()`-as-recovery/ignored `Result` introduced; the new `parse_then_typecheck` helper `.expect()`-fails loudly (not silently) if parsing ever regresses.

## Files changed

- `crates/sm-front/src/typecheck.rs` only (test code): 1 regression fixed in place, 2 new regressions, 1 small local test helper.

## Local qualification (all commands from workspace root)

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo test -p sm-front --lib` | **644 passed**, 0 failed |
| `cargo check -p sm-front --all-targets` | clean |
| `cargo clippy -p sm-front --all-targets -- -D warnings` | clean |
| `cargo test --test scalar_root_rebind_copy_semantics_e2e` | 6/6 passed |
| `cargo test --test runtime_ownership_e2e` | 32/32 passed |
| `cargo test --test match_surface_qualification` | 3/3 passed |
| `cargo test --test ssf_status_drift` | 3/3 passed |
| `cargo test --test public_api_contracts` | 88/88 passed |
| `cargo check --workspace --all-targets` | clean |
| `cargo test --workspace` | **4438 passed, 0 failed** — full pass, not INCOMPLETE |
| `git diff --check` | clean |

Do not merge. Draft PR pending review, matching the exact-head discipline established on #1879/#1880/#1882.

Closes #1883
