### PR TITLE
fix(front,ir): make ScopeEnv const lookup fail closed

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -521,29 +521,25 @@ impl ScopeEnv {
         self.binding(name).map(|binding| binding.ty.clone())
     }
 
-    /// SSF-08 Lane 1 (#1664): kept fail-open (`false` on a missing binding)
-    /// -- unlike every other #1664 API, this exact bool-returning shape has
-    /// live production call sites in `crates/sm-ir/src/legacy_lowering.rs`,
-    /// a Lane 2 crate this PR is not permitted to modify (SSF-08 Lane 1's
-    /// scope is `crates/sm-front` only). Changing this signature would
-    /// break that crate's build. Every in-crate (`sm-front`) production
-    /// call site now uses the fail-closed `is_const_checked` below instead;
-    /// this method is retained solely for that external, out-of-scope
-    /// dependency and must gain no new call sites within `sm-front`.
-    pub fn is_const(&self, name: SymbolId) -> bool {
-        self.binding(name)
-            .map(|binding| binding.is_const)
-            .unwrap_or(false)
-    }
-
-    /// SSF-08 Lane 1 (#1664): fail-closed counterpart of `is_const`, used by
-    /// every `sm-front`-internal call site. See `is_const`'s doc comment
-    /// for why that original bool-returning method could not simply be
-    /// changed in place.
-    pub(crate) fn is_const_checked(
-        &self,
-        name: SymbolId,
-    ) -> Result<bool, crate::types::FrontendError> {
+    /// SSF-08 (#1664 completion): REQUIRED_BINDING -- fails closed if
+    /// `name` is not a known binding, rather than treating "missing" as
+    /// "not const". This is a semantic property query against a binding
+    /// the caller has already established must exist -- every current
+    /// call site (`crates/sm-front/src/typecheck.rs`'s assignment/const-
+    /// initializer checks, and `crates/sm-ir/src/legacy_lowering.rs`'s
+    /// closure-capture/tuple-assignment/ordinary-assignment lowering)
+    /// resolves the binding via `env.get(name)` -- reporting the
+    /// canonical source-level "unknown ..." diagnostic on absence -- and
+    /// only queries constness once that has already succeeded, so this
+    /// `Err` path represents an internal invariant failure (the identity
+    /// disappeared after being proven to exist), never an ordinary source
+    /// mistake. This was the last of #1664's seven APIs to be converted;
+    /// it originally stayed fail-open because `crates/sm-ir` (Lane 2) had
+    /// live consumers of the old bool-returning shape and Lane 1's scope
+    /// was frontend-only -- SSF-08's #1664 completion slice explicitly
+    /// authorized migrating those three call sites so this contract
+    /// correction could land.
+    pub fn is_const(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
         Ok(self.require_binding(name)?.is_const)
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1648,7 +1648,7 @@ fn check_stmt(
                     resolve_symbol_name(arena, *name)?
                 ),
             })?;
-            if env.is_const_checked(*name)? {
+            if env.is_const(*name)? {
                 return Err(FrontendError {
                     pos: 0,
                     message: format!(
@@ -1716,7 +1716,7 @@ fn check_stmt(
                         resolve_symbol_name(arena, *name)?
                     ),
                 })?;
-                if env.is_const_checked(*name)? {
+                if env.is_const(*name)? {
                     return Err(FrontendError {
                         pos: 0,
                         message: format!(
@@ -12168,16 +12168,16 @@ mod tests {
     }
 
     #[test]
-    fn ssf08_1664_is_const_checked_fails_closed_on_missing_binding() {
-        // is_const_checked is the fail-closed sibling used by every
-        // sm-front-internal call site (see is_const's own doc comment and
-        // the next test for why the original is_const symbol itself could
-        // not be changed in place).
+    fn ssf08_1664_is_const_fails_closed_on_missing_binding() {
+        // #1664 completion: is_const is now the single, canonical
+        // fail-closed authority (the is_const_checked/is_const split has
+        // been retired -- see is_const's own doc comment for why the old
+        // bool-returning shape could finally be changed in place).
         let env = ScopeEnv::new();
         let unknown = SymbolId(993);
         let err = env
-            .is_const_checked(unknown)
-            .expect_err("is_const_checked on a genuinely missing binding must fail closed");
+            .is_const(unknown)
+            .expect_err("is_const on a genuinely missing binding must fail closed");
         assert!(
             err.message.contains("internal ownership state"),
             "unexpected: {}",
@@ -12186,22 +12186,38 @@ mod tests {
     }
 
     #[test]
-    fn ssf08_1664_is_const_legacy_bool_api_remains_fail_open_for_lane2_compat() {
-        // Deliberate, evidenced exception: `is_const`'s bool-returning shape
-        // has live production call sites in crates/sm-ir/src/
-        // legacy_lowering.rs (Lane 2), which SSF-08 Lane 1 is not permitted
-        // to modify. This pins that the old symbol still returns `false` on
-        // a missing binding -- not because it is correct, but because
-        // changing it would require editing a Lane 2 crate. Every
-        // sm-front-internal decision now goes through is_const_checked
-        // instead (see the prior test); this method must gain no new
-        // sm-front call sites.
-        let env = ScopeEnv::new();
-        let unknown = SymbolId(992);
-        assert!(
-            !env.is_const(unknown),
-            "legacy is_const must still fail open (false) on a missing binding -- this is the \
-             documented Lane 2 compatibility exception, not new behavior"
+    fn ssf08_1664_is_const_known_const_binding_is_ok_true() {
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(991);
+        env.insert_const(sym, Type::I32);
+        assert_eq!(
+            env.is_const(sym),
+            Ok(true),
+            "a known const binding must report Ok(true)"
+        );
+    }
+
+    #[test]
+    fn ssf08_1664_is_const_known_ordinary_binding_is_ok_false() {
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(990);
+        env.insert(sym, Type::I32);
+        assert_eq!(
+            env.is_const(sym),
+            Ok(false),
+            "a known ordinary (non-const, non-mutable) binding must report Ok(false)"
+        );
+    }
+
+    #[test]
+    fn ssf08_1664_is_const_known_mutable_binding_is_ok_false() {
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(989);
+        env.insert_mut(sym, Type::I32);
+        assert_eq!(
+            env.is_const(sym),
+            Ok(false),
+            "a known mutable binding must report Ok(false) -- mutable and const are exclusive"
         );
     }
 
@@ -16504,7 +16520,7 @@ fn ensure_const_initializer_safe(
                     message: format!("unknown variable '{}'", resolve_symbol_name(arena, *name)?),
                 });
             }
-            if env.is_const_checked(*name)? {
+            if env.is_const(*name)? {
                 Ok(())
             } else {
                 Err(FrontendError {

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -11305,13 +11305,36 @@ mod opt_tests {
     }
 
     #[test]
-    fn lowering_preserves_const_capture_in_closure() {
-        // #1664 completion: proves the closure-capture call site's
-        // is_const(*capture)? migration still lowers a const capture
-        // successfully -- this is the one of the three migrated call
-        // sites with no sm-front-level equivalent check (capture
-        // constness preservation into the lifted helper's own
-        // environment is purely an sm-ir lowering concern).
+    fn lowering_succeeds_for_closure_capturing_const_binding() {
+        // #1664 completion. What this proves: the closure-capture call
+        // site's is_const(*capture)? migration (bool -> Result) does not
+        // regress the ordinary case -- a closure capturing a const
+        // binding still lowers successfully and emits its lifted helper.
+        //
+        // What this does NOT prove: that the captured binding was
+        // actually inserted into the lifted helper's own environment via
+        // lifted_env.insert_const(...) rather than lifted_env.insert(...)
+        // -- i.e. this does not independently verify constness
+        // preservation *within* the lifted environment.
+        //
+        // That could not be observed directly without architectural
+        // distortion. The only operation whose outcome differs between
+        // insert_const and insert is an assignment to the captured name
+        // rejecting as const -- and a closure body is a value-producing
+        // block (`infer_value_block_type` in
+        // crates/sm-front/src/typecheck.rs), which admits only
+        // `Stmt::Const | Let | LetTuple | Discard | Expr(_)`; `Stmt::Assign`
+        // is categorically not admitted inside any value-producing block,
+        // closure bodies included (confirmed by direct inspection, and
+        // empirically: `(x => { offset = 2.0; x })` fails to parse with
+        // "expected '}' after value-producing block", independent of
+        // constness). No admitted source can place a reassignment inside
+        // a closure body at all, so no admitted source can make lowering
+        // outcome differ based on which of the two `lifted_env` calls
+        // fired. Exposing `lifted_env` itself from
+        // `lower_closure_literal_expr` for direct inspection would be a
+        // production hook added solely for this test, which is exactly
+        // what this migration must not do.
         let src = r#"
             fn main() {
                 const offset: f64 = 1.0;

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -2464,7 +2464,7 @@ fn lower_closure_literal_expr(
             ),
         })?;
         lifted_signature_params.push(callable_family_for_type(&capture_ty)?);
-        if env.is_const(*capture) {
+        if env.is_const(*capture)? {
             lifted_env.insert_const(*capture, capture_ty.clone());
         } else {
             lifted_env.insert(*capture, capture_ty.clone());
@@ -5008,7 +5008,7 @@ fn assign_tuple_items(
                 resolve_symbol_name(arena, *name)?
             ),
         })?;
-        if env.is_const(*name) {
+        if env.is_const(*name)? {
             return Err(FrontendError {
                 pos: 0,
                 message: format!(
@@ -6104,7 +6104,7 @@ fn lower_stmt(
                     resolve_symbol_name(arena, *name)?
                 ),
             })?;
-            if env.is_const(*name) {
+            if env.is_const(*name)? {
                 return Err(FrontendError {
                     pos: 0,
                     message: format!(
@@ -11279,6 +11279,53 @@ mod opt_tests {
         assert!(err
             .message
             .contains("cannot assign to const binding 'total'"));
+    }
+
+    #[test]
+    fn lowering_rejects_tuple_assignment_to_const_binding() {
+        // #1664 completion: is_const's fail-closed migration (bool -> ?)
+        // must not disturb this rejection for the tuple-destructuring
+        // assignment call site.
+        let src = r#"
+            fn pair(flag: bool) -> (i32, bool) = (1, flag);
+
+            fn main() {
+                const count: i32 = 0;
+                let ready: bool = false;
+                (count, ready) = pair(true);
+                return;
+            }
+        "#;
+
+        let err =
+            compile_program_to_ir(src).expect_err("tuple assignment to const target must reject");
+        assert!(err
+            .message
+            .contains("cannot assign to const binding 'count'"));
+    }
+
+    #[test]
+    fn lowering_preserves_const_capture_in_closure() {
+        // #1664 completion: proves the closure-capture call site's
+        // is_const(*capture)? migration still lowers a const capture
+        // successfully -- this is the one of the three migrated call
+        // sites with no sm-front-level equivalent check (capture
+        // constness preservation into the lifted helper's own
+        // environment is purely an sm-ir lowering concern).
+        let src = r#"
+            fn main() {
+                const offset: f64 = 1.0;
+                let add: Closure(f64 -> f64) = (x => x + offset);
+                let total: f64 = add(2.0);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src)
+            .expect("closure capturing a const binding should lower successfully");
+        assert!(ir
+            .iter()
+            .any(|func| func.name.starts_with("__closure_main_")));
     }
 
     #[test]

--- a/tests/golden_snapshots/public_api/sm_front_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_front_lib.txt
@@ -1,16 +1,20 @@
 source: crates/sm-front/src/lib.rs
 #[cfg(any(feature = "alloc", feature = "std"))]
+pub mod hello_parser;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub mod hello_sema;
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub mod types;
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use types::{
-#[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub use types::{ AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg, ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId, FrontendError, FrontendErrorKind, Function, IfExpr, ImplDecl, IterableLoopDesugaring, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MapType, MatchArm, MatchExpr, MatchExprArm, PathAvailability, PatternPath, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr, SequenceLiteral, SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind, TraitBound, TraitDecl, TraitMethodSig, TuplePatternItem, Type, UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan, ValidationVariantPlan, };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod lexer;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod parser;
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use typecheck::{
+pub use typecheck::{ derive_validation_plan_table, type_check_function, type_check_function_with_table, type_check_program, };
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FnSig {
@@ -50,14 +54,15 @@ pub fn pop_scope(&mut self) {
 pub fn insert(&mut self, name: SymbolId, ty: Type) {
 pub fn insert_mut(&mut self, name: SymbolId, ty: Type) {
 pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
-pub fn mark_consumed(&mut self, name: SymbolId) {
-pub fn is_consumed(&self, name: SymbolId) -> bool {
-pub fn mark_path_state(
-pub fn check_path_available(
-pub fn check_capture_allowed(
+pub fn mark_consumed(&mut self, name: SymbolId) -> Result<(), crate::types::FrontendError> {
+pub fn is_consumed(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
+pub fn mark_path_state( &mut self, name: SymbolId, path: crate::types::PatternPath, state: crate::types::PathAvailability, ) -> Result<(), crate::types::FrontendError> {
+pub fn check_path_available( &self, name: SymbolId, access_path: &crate::types::PatternPath, ) -> Result<(), crate::types::FrontendError> {
+pub fn check_capture_allowed( &self, name: SymbolId, path: &crate::types::PatternPath, capture: crate::types::CaptureMode, ) -> Result<(), crate::types::FrontendError> {
 pub fn get(&self, name: SymbolId) -> Option<Type> {
-pub fn is_const(&self, name: SymbolId) -> bool {
-pub fn is_mutable(&self, name: SymbolId) -> bool {
+pub fn is_const(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
+pub fn is_mutable(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
+pub(crate) fn join_ownership_from( &mut self, successors: &[ScopeEnv], ) -> Result<(), crate::types::FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -69,18 +74,25 @@ pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError>
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_schema_table(program: &Program) -> Result<SchemaTable, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn canonicalize_declared_type(
+pub fn canonicalize_declared_type( ty: &Type, record_table: &RecordTable, adt_table: &AdtTable, arena: &AstArena, ) -> Result<Type, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn canonicalize_declared_type_generic(
+pub fn canonicalize_declared_type_generic( ty: &Type, record_table: &RecordTable, adt_table: &AdtTable, arena: &AstArena, type_params: &[SymbolId], ) -> Result<Type, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn builtin_sig(name: &str) -> Option<FnSig> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn reorder_call_args(
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrderedCallArgs {
+pub slots: Vec<ExprId>,
+pub eval_order: Vec<usize>,
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn resolve_symbol_name<'a>(arena: &'a AstArena, id: SymbolId) -> Result<&'a str, FrontendError> {
+pub fn reorder_call_args( call_name: SymbolId, args: &[CallArg], sig: &FnSig, arena: &AstArena, ) -> Result<OrderedCallArgs, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn resolve_symbol_name<'a>( arena: &'a AstArena, id: SymbolId, ) -> Result<&'a str, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq)]
 pub enum AstBundle {
+RustLike(Program),
+Logos(LogosProgram),
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, Copy)]
 pub struct CompilePolicyView<'a> {
@@ -89,24 +101,29 @@ pub const fn new(profile: &'a ParserProfile) -> Self {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_rustlike(input: &str) -> Result<AstBundle, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_rustlike_with_profile(
+pub fn parse_rustlike_with_profile( input: &str, profile: &ParserProfile, ) -> Result<AstBundle, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_logos(input: &str) -> Result<AstBundle, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_logos_with_profile(
+pub fn parse_logos_with_profile( input: &str, profile: &ParserProfile, ) -> Result<AstBundle, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_program(input: &str) -> Result<Program, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_program_with_profile(
+pub fn parse_program_with_profile( input: &str, profile: &ParserProfile, ) -> Result<Program, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_logos_program(input: &str) -> Result<LogosProgram, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_logos_program_with_profile(
+pub fn parse_logos_program_with_profile( input: &str, profile: &ParserProfile, ) -> Result<LogosProgram, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn lex(input: &str) -> Result<Vec<Token>, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompileProfile {
+Auto,
+RustLike,
+Logos,
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OptLevel {
+O0,
+O1,

--- a/tests/golden_snapshots/public_api/sm_front_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_front_lib.txt
@@ -1,20 +1,16 @@
 source: crates/sm-front/src/lib.rs
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub mod hello_parser;
-#[cfg(any(feature = "alloc", feature = "std"))]
-pub mod hello_sema;
-#[cfg(any(feature = "alloc", feature = "std"))]
 pub mod types;
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use sm_profile::{CompatibilityMode, ParserProfile};
+pub use types::{
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use types::{ AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg, ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId, FrontendError, FrontendErrorKind, Function, IfExpr, ImplDecl, IterableLoopDesugaring, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MapType, MatchArm, MatchExpr, MatchExprArm, PathAvailability, PatternPath, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr, SequenceLiteral, SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind, TraitBound, TraitDecl, TraitMethodSig, TuplePatternItem, Type, UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan, ValidationVariantPlan, };
+pub use sm_profile::{CompatibilityMode, ParserProfile};
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod lexer;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod parser;
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use typecheck::{ derive_validation_plan_table, type_check_function, type_check_function_with_table, type_check_program, };
+pub use typecheck::{
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FnSig {
@@ -54,15 +50,14 @@ pub fn pop_scope(&mut self) {
 pub fn insert(&mut self, name: SymbolId, ty: Type) {
 pub fn insert_mut(&mut self, name: SymbolId, ty: Type) {
 pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
-pub fn mark_consumed(&mut self, name: SymbolId) -> Result<(), crate::types::FrontendError> {
-pub fn is_consumed(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
-pub fn mark_path_state( &mut self, name: SymbolId, path: crate::types::PatternPath, state: crate::types::PathAvailability, ) -> Result<(), crate::types::FrontendError> {
-pub fn check_path_available( &self, name: SymbolId, access_path: &crate::types::PatternPath, ) -> Result<(), crate::types::FrontendError> {
-pub fn check_capture_allowed( &self, name: SymbolId, path: &crate::types::PatternPath, capture: crate::types::CaptureMode, ) -> Result<(), crate::types::FrontendError> {
+pub fn mark_consumed(&mut self, name: SymbolId) {
+pub fn is_consumed(&self, name: SymbolId) -> bool {
+pub fn mark_path_state(
+pub fn check_path_available(
+pub fn check_capture_allowed(
 pub fn get(&self, name: SymbolId) -> Option<Type> {
-pub fn is_const(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
-pub fn is_mutable(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
-pub(crate) fn join_ownership_from( &mut self, successors: &[ScopeEnv], ) -> Result<(), crate::types::FrontendError> {
+pub fn is_const(&self, name: SymbolId) -> bool {
+pub fn is_mutable(&self, name: SymbolId) -> bool {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -74,25 +69,18 @@ pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError>
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_schema_table(program: &Program) -> Result<SchemaTable, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn canonicalize_declared_type( ty: &Type, record_table: &RecordTable, adt_table: &AdtTable, arena: &AstArena, ) -> Result<Type, FrontendError> {
+pub fn canonicalize_declared_type(
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn canonicalize_declared_type_generic( ty: &Type, record_table: &RecordTable, adt_table: &AdtTable, arena: &AstArena, type_params: &[SymbolId], ) -> Result<Type, FrontendError> {
+pub fn canonicalize_declared_type_generic(
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn builtin_sig(name: &str) -> Option<FnSig> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OrderedCallArgs {
-pub slots: Vec<ExprId>,
-pub eval_order: Vec<usize>,
+pub fn reorder_call_args(
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn reorder_call_args( call_name: SymbolId, args: &[CallArg], sig: &FnSig, arena: &AstArena, ) -> Result<OrderedCallArgs, FrontendError> {
-#[cfg(any(feature = "alloc", feature = "std"))]
-pub fn resolve_symbol_name<'a>( arena: &'a AstArena, id: SymbolId, ) -> Result<&'a str, FrontendError> {
+pub fn resolve_symbol_name<'a>(arena: &'a AstArena, id: SymbolId) -> Result<&'a str, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq)]
 pub enum AstBundle {
-RustLike(Program),
-Logos(LogosProgram),
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, Copy)]
 pub struct CompilePolicyView<'a> {
@@ -101,29 +89,24 @@ pub const fn new(profile: &'a ParserProfile) -> Self {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_rustlike(input: &str) -> Result<AstBundle, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_rustlike_with_profile( input: &str, profile: &ParserProfile, ) -> Result<AstBundle, FrontendError> {
+pub fn parse_rustlike_with_profile(
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_logos(input: &str) -> Result<AstBundle, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_logos_with_profile( input: &str, profile: &ParserProfile, ) -> Result<AstBundle, FrontendError> {
+pub fn parse_logos_with_profile(
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_program(input: &str) -> Result<Program, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_program_with_profile( input: &str, profile: &ParserProfile, ) -> Result<Program, FrontendError> {
+pub fn parse_program_with_profile(
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn parse_logos_program(input: &str) -> Result<LogosProgram, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn parse_logos_program_with_profile( input: &str, profile: &ParserProfile, ) -> Result<LogosProgram, FrontendError> {
+pub fn parse_logos_program_with_profile(
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn lex(input: &str) -> Result<Vec<Token>, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompileProfile {
-Auto,
-RustLike,
-Logos,
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OptLevel {
-O0,
-O1,


### PR DESCRIPTION
SSF-08 #1664 completion slice.

This PR deliberately opens the `sm-front → sm-ir` boundary only to migrate the three existing `legacy_lowering` consumers of `ScopeEnv::is_const` after the final fail-open bool-returning API is replaced by the canonical `Result`-returning contract.

No Lane 2 ownership/lowering semantics are changed.

## Baseline / HEAD

- Expected baseline: `528ba2a4b4973c6495f56627047aefab8a0bc27a` (confirmed exact match: `git fetch origin && git rev-parse origin/main`, working tree clean before branching).
- This branch: `fix/1664-is-const-fail-closed`.

## Public API change (intentional, pre-stable contract correction)

```
ScopeEnv::is_const
bool
→ Result<bool, FrontendError>
```

This is not a cosmetic refactor. The `bool` contract was semantically unsound because a missing binding collapsed into a legitimate non-const result — the exact defect #1664 (FA-02-032) exists to eliminate, and the last of its seven named APIs to still have it.

## Confirmed residual architecture, then workspace-wide call-site audit

Confirmed on exact baseline before editing: `is_const`'s bool-returning shape and the `is_const_checked` split matched the expected pre-slice shape exactly (section 5 of the governing spec).

`rg -n "\.is_const\(" .` / `rg -n "is_const_checked\(" .` across the entire workspace found:

| Consumer | Kind |
|---|---|
| `crates/sm-front/src/typecheck.rs:1651` (`Stmt::Assign`) | internal, via `is_const_checked` |
| `crates/sm-front/src/typecheck.rs:1719` (`Stmt::AssignTuple`) | internal, via `is_const_checked` |
| `crates/sm-front/src/typecheck.rs:16507` (`ensure_const_initializer_safe`) | internal, via `is_const_checked` |
| `crates/sm-ir/src/legacy_lowering.rs:2467` (closure capture) | external, via `is_const` |
| `crates/sm-ir/src/legacy_lowering.rs:5011` (tuple-assignment target) | external, via `is_const` |
| `crates/sm-ir/src/legacy_lowering.rs:6107` (ordinary-assignment target) | external, via `is_const` |

Exactly the three logical `sm-ir` uses the governing spec expected, confirmed by search rather than assumed. Zero consumers found outside `sm-front`/`sm-ir`.

## Call-site ordering audit (no race between lookup and const query)

All three `sm-ir` call sites, and all three `sm-front` internal call sites, follow the identical, pre-existing pattern:

```rust
let target_ty = env.get(*name).ok_or(FrontendError { ...canonical diagnostic... })?;
if env.is_const(*name)? { ...reject... }
```

Existence is resolved first (producing the canonical source-facing diagnostic on absence); constness is queried only once that has already succeeded. No scope pop, rebinding, or environment replacement occurs between the two calls at any of the six sites — confirmed by direct inspection of each enclosing function, not assumed. No race exists; the migration is a pure `?`-propagation change at each site.

## Repair

**`crates/sm-front/src/lib.rs`**:
```rust
pub fn is_const(&self, name: SymbolId) -> Result<bool, crate::types::FrontendError> {
    Ok(self.require_binding(name)?.is_const)
}
```
via the existing canonical `require_binding` authority — the same shape as every other #1664 API. `is_const_checked` deleted entirely; zero production or test callers remain (one historical-documentation comment reference only, per the governing spec's own allowance).

**`crates/sm-front/src/typecheck.rs`**: the three internal call sites migrated from `is_const_checked(...)?` to the now-canonical `is_const(...)?`. Test module: the missing-binding regression renamed from `ssf08_1664_is_const_checked_fails_closed_on_missing_binding` to `ssf08_1664_is_const_fails_closed_on_missing_binding` (same assertion, canonical API); the now-obsolete `ssf08_1664_is_const_legacy_bool_api_remains_fail_open_for_lane2_compat` test **removed** (it documented behavior that no longer exists); three new direct unit tests added for known const/non-const/mutable bindings (see regression matrix below).

**`crates/sm-ir/src/legacy_lowering.rs`**: exactly three one-character diffs (`is_const(*x)` → `is_const(*x)?`) at the three call sites above. All three enclosing functions (`lower_closure_literal_expr`, `assign_tuple_items`, `lower_stmt`) already return `Result<_, FrontendError>`-compatible types — no signature widening needed anywhere. Two new tests added (see below). No other line in this file changed.

## All seven #1664 APIs — final audit

| API | Old missing-binding behavior | Final contract | Direct regression |
|---|---|---|---|
| `mark_consumed` | no-op | `Result<(), FrontendError>` / fail closed | `ssf08_1664_mark_consumed_fails_closed_on_missing_binding` |
| `is_consumed` | implicit `false` | `Result<bool, FrontendError>` / fail closed | `ssf08_1664_is_consumed_fails_closed_on_missing_binding` |
| `mark_path_state` | no-op | `Result<(), FrontendError>` / fail closed | `ssf08_1664_mark_path_state_fails_closed_on_missing_binding` |
| `check_path_available` | `Ok(())` | `Result<(), FrontendError>` / fail closed | `ssf08_1664_check_path_available_fails_closed_on_missing_binding` |
| `check_capture_allowed` | `Ok(())` | `Result<(), FrontendError>` / fail closed | `ssf08_1664_check_capture_allowed_fails_closed_on_missing_binding` |
| `is_const` | `false` | `Result<bool, FrontendError>` / fail closed | `ssf08_1664_is_const_fails_closed_on_missing_binding` (**this PR**) |
| `is_mutable` | `false` | `Result<bool, FrontendError>` / fail closed | `ssf08_1664_is_mutable_fails_closed_on_missing_binding` |

All seven satisfy the issue contract. `ScopeEnv::get` remains the deliberately-untouched optional-existence lookup (`Option<Type>`) — the architecture's intentional second authority, not a residual.

## `sm-front` regression matrix (new/renamed, `crates/sm-front/src/typecheck.rs`)

| Case | Test | Result |
|---|---|---|
| Missing binding | `ssf08_1664_is_const_fails_closed_on_missing_binding` | `Err(internal ownership state: required binding ... is missing)` |
| Known const binding | `ssf08_1664_is_const_known_const_binding_is_ok_true` | `Ok(true)` |
| Known ordinary binding | `ssf08_1664_is_const_known_ordinary_binding_is_ok_false` | `Ok(false)` |
| Known mutable binding | `ssf08_1664_is_const_known_mutable_binding_is_ok_false` | `Ok(false)` |
| Source-level: assignment to unknown target | `ssf08_1664_unknown_variable_diagnostic_remains_canonical` (pre-existing, still green) | canonical diagnostic, not internal error |
| Source-level: const initializer referencing unknown variable | `ssf08_1664_const_initializer_unknown_variable_diagnostic_remains_canonical` (pre-existing, still green) | canonical diagnostic, not internal error |

## `sm-ir` regression matrix (new, `crates/sm-ir/src/legacy_lowering.rs`)

| Family | Case | Test | Result |
|---|---|---|---|
| Ordinary assignment | known const target | `lowering_rejects_assignment_to_const_binding` (pre-existing, still green) | canonical `"cannot assign to const binding 'total'"` |
| Ordinary assignment | known non-const target | covered by the large existing assignment-lowering test corpus (unmodified, still green) | existing lowering behavior |
| Tuple assignment | known const target | `lowering_rejects_tuple_assignment_to_const_binding` (**new**) | canonical `"cannot assign to const binding 'count' in tuple destructuring assignment"` |
| Tuple assignment | known non-const target | `lower_tuple_destructuring_assignment_to_tuple_get_ir`, `lower_tuple_assignment_records_write_path_events` (pre-existing, still green) | existing lowering behavior |
| Closure capture | known const capture | `lowering_succeeds_for_closure_capturing_const_binding` (**new**; see note below) | lowers successfully, lifted helper emitted |
| Closure capture | known non-const capture | `first_class_closures_lower_to_runtime_carrier_and_semcod19` (pre-existing, still green) | existing lowering behavior |

### On the "missing target" diagnostics specifically

Investigated whether `"unknown captured value ..."` / `"unknown tuple assignment target ..."` / `"unknown assignment target ..."` are reachable at the `sm-ir` layer via `compile_program_to_ir`. Confirmed empirically (temporary instrumentation, since reverted) that `compile_program_to_ir_with_options_and_profile` calls `type_check_program(&program)?` **before** lowering — so any genuinely-unknown identifier is already rejected by `sm-front`'s own gate (which has its own, separately-checked equivalent diagnostics) before `sm-ir`'s own copies of these checks are ever reached. These three `sm-ir`-level messages are therefore defensive, internal-consistency assertions (guarding against `sm-ir`'s independently-constructed lowering-time `ScopeEnv` ever drifting from what `sm-front`'s typecheck-time `ScopeEnv` already proved), not end-user-reachable diagnostics — consistent with the governing spec's explicit instruction not to manufacture artificial states to force coverage of genuinely production-unreachable paths. Not pursued further; this does not affect the migration's correctness, since it only changes how a missing-identity result propagates *after* this (already-proven-safe) resolve step, not whether it can occur.

### On the closure-capture regression's actual scope

`lowering_succeeds_for_closure_capturing_const_binding` proves the closure-capture call site's `is_const(*capture)?` migration does not regress the ordinary case: a closure capturing a const binding still lowers successfully. It does **not** independently prove that `lifted_env.insert_const(...)` (rather than `lifted_env.insert(...)`) actually fired inside the lifted helper's own environment.

Investigated whether that could be observed directly. The only operation whose outcome differs between the two is an assignment to the captured name rejecting as const — and a closure body is a value-producing block (`infer_value_block_type` in `crates/sm-front/src/typecheck.rs`), which admits only `Stmt::Const | Let | LetTuple | Discard | Expr(_)`. `Stmt::Assign` is categorically not admitted inside any value-producing block, closure bodies included — confirmed both by reading `infer_value_block_type`'s match arms directly and empirically: `(x => { offset = 2.0; x })` fails to parse with `"expected '}' after value-producing block"`, independent of `offset`'s constness. No admitted source can place a reassignment inside a closure body at all, so no admitted source can make the lowering outcome differ based on which `lifted_env` call fired. The only way to observe it directly would be exposing `lifted_env` from `lower_closure_literal_expr` for test inspection — a production hook added solely for testing, which the governing spec explicitly forbids. The test and its own doc comment state this limitation explicitly; the PR does not claim more than what it proves.

## Public API snapshot — deliberately untouched

`tests/golden_snapshots/public_api/sm_front_lib.txt` is **not** modified by this PR. An earlier draft of this PR regenerated it to reflect the `is_const` signature change; that regeneration has been removed.

**Why:** investigating the expected snapshot delta (`cargo test --test public_api_contracts` passed all 88 tests with the snapshot *unmodified* even after the `is_const` signature change landed in source) revealed `tests/public_api_contracts.rs::TARGETS` does not include `crates/sm-front/src/lib.rs` at all — the file is completely orphaned, never read or validated by any test. Regenerating it locally (via the test's own `update_mode()` write path, `sm-front` temporarily wired into `TARGETS` for that one regeneration only, then reverted) showed the checked-in snapshot predates not just this PR's `is_const` change but the *already-merged* SSF-08 Lane 1 corrective round (PR #1880) entirely, plus several unrelated modules/types added since.

Filed as **#1885 (FA-02-041)**, the same class of finding as the already-tracked #1700 (FA-03-031, `sm-sema` omitted from the same guard). Per that finding: this snapshot is not currently owned by `public-api-guard`, and its regeneration would incorporate substantial historical drift unrelated to #1664 — #1886 must not establish that accumulated drift as a new baseline as a side effect of unrelated work. The orphaned file, `TARGETS` wiring, canonical regeneration, and review of the accumulated drift all belong to #1885's own, separately-scoped repair. `tests/public_api_contracts.rs` has zero diff in this PR.

## Determinism

`is_const`'s fail-closed path routes through the same `require_binding` authority every other #1664 API already uses — no `BTreeMap`-iteration-order sensitivity introduced; `ScopeEnv`'s scope storage is unchanged.

## Fallback audit

`rg -n "unwrap_or\(false\)|unwrap_or_default|map_or\(false|is_const_checked|is_const_legacy" crates/sm-front crates/sm-ir` — all matches are pre-existing, unrelated parser/lexer code (`TokenKind` lookahead, Logos-profile auto-detection) and one historical-documentation comment referencing the now-retired `is_const_checked` split; none touch the const-state path. `rg -n "\.is_const\(" crates` — all 10 occurrences (6 production, 4 test) handle the `Result` explicitly; zero `.unwrap_or(false)`, zero `.ok().unwrap_or(...)`, zero ignored `Result`.

## Explicitly out of scope

- `#1579` — not closed. #1664 completion means the Lane 1 API residual is closed, not that SSF-08 is complete.
- `#1709`, `#1718`, `#1724`, `#1725`, `#1726` — not touched. Diff-audited `legacy_lowering.rs`'s full changeset (above) and confirmed zero changes to nested-expression lowering, value-block lowering, ownership-event collection, `SymbolId`/root-identity handling, or loop lowering — exactly the three `?` insertions plus two new tests, nothing else.
- No new lifetimes, regions, borrow graphs, escape analysis, or move semantics. Plain root rebinding stays copy-by-value (unaffected — `scalar_root_rebind_copy_semantics_e2e.rs` still 6/6).
- `#1885` (FA-02-041, the orphaned public-api-guard gap found during this slice) — filed, not repaired here. `tests/golden_snapshots/public_api/sm_front_lib.txt` is deliberately left byte-for-byte identical to `origin/main`; this PR does not update it.

## Local qualification

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo check -p sm-front --all-targets` | clean |
| `cargo test -p sm-front --lib` | **646 passed**, 0 failed |
| `cargo clippy -p sm-front --all-targets -- -D warnings` | clean |
| `cargo check -p sm-ir --all-targets` | clean |
| `cargo test -p sm-ir` | **138 passed**, 0 failed |
| `cargo clippy -p sm-ir --all-targets -- -D warnings` | clean |
| `cargo test --test scalar_root_rebind_copy_semantics_e2e` | 6/6 passed |
| `cargo test --test runtime_ownership_e2e` | 32/32 passed |
| `cargo test --test match_surface_qualification` | 3/3 passed |
| `cargo test --test ssf_status_drift` | 3/3 passed |
| `cargo test --test public_api_contracts` | 88/88 passed |
| `cargo check --workspace --all-targets` | clean |
| `cargo test --workspace` | **4442 passed, 0 failed** — full pass, not INCOMPLETE (confirmed identical count after the corrective round, as expected: one test renamed/reframed, none added or removed) |
| `git diff --check` | clean |

Do not merge. Draft PR pending review, matching the exact-head discipline established on #1879/#1880/#1882/#1884.

Closes #1664
