### PR TITLE
fix(ir,vm): resolve OWN0 ownership-path roots through the function's own string table (#1725)

### DIFF
--- a/crates/sm-emit/src/lib.rs
+++ b/crates/sm-emit/src/lib.rs
@@ -47,6 +47,25 @@ mod tests {
         cursor
     }
 
+    // #1725 (FA-04-019): OWN0's wire `root` field is now the *index* of the
+    // lowered-local key in this same table, not a raw frontend SymbolId, so
+    // asserting its value requires decoding the actual strings to find that
+    // index - unlike `skip_string_table`, which only needs their lengths.
+    fn read_string_table(code: &[u8]) -> (Vec<String>, usize) {
+        let mut cursor = 0usize;
+        let count = read_u16_le(code, &mut cursor).expect("string count") as usize;
+        let mut strings = Vec::with_capacity(count);
+        for _ in 0..count {
+            let len = read_u16_le(code, &mut cursor).expect("string length") as usize;
+            let s = std::str::from_utf8(&code[cursor..cursor + len])
+                .expect("utf8 string")
+                .to_string();
+            cursor += len;
+            strings.push(s);
+        }
+        (strings, cursor)
+    }
+
     fn skip_optional_ownership_section(code: &[u8], mut cursor: usize) -> usize {
         if !code[cursor..].starts_with(&OWNERSHIP_SECTION_TAG) {
             return cursor;
@@ -175,7 +194,12 @@ mod tests {
         assert_ne!(spec.capabilities & CAP_OWNERSHIP_FIELD_PATHS, 0);
 
         let code = function_code(&bytes, "main");
-        let mut cursor = skip_string_table(code);
+        let (strings, mut cursor) = read_string_table(code);
+        let root_index = strings
+            .iter()
+            .position(|s| s == &borrow.path.root)
+            .expect("lowered-local root key interned in this function's string table")
+            as u32;
         assert_eq!(&code[cursor..cursor + 4], &OWNERSHIP_SECTION_TAG);
         cursor += 4;
         assert_eq!(read_u16_le(code, &mut cursor).expect("event count"), 1);
@@ -183,10 +207,7 @@ mod tests {
             read_u8(code, &mut cursor).expect("event kind"),
             OWNERSHIP_EVENT_KIND_BORROW
         );
-        assert_eq!(
-            read_u32_le(code, &mut cursor).expect("root"),
-            borrow.path.root.0
-        );
+        assert_eq!(read_u32_le(code, &mut cursor).expect("root"), root_index);
         assert_eq!(read_u16_le(code, &mut cursor).expect("component count"), 1);
         assert_eq!(
             read_u8(code, &mut cursor).expect("component kind"),

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -363,14 +363,26 @@ pub enum IrInstr {
 /// Canonical execution-layer access path for ownership transport.
 ///
 /// This is intentionally IR-owned and append-only.
+///
+/// #1725 (FA-04-019): `root` is the *lowered runtime-local key* - the same
+/// `__sm_local_<id>_<spelling>` string a matching `StoreVar`/`LoadVar` for
+/// that exact binding carries (see `LoweredLocalEnv::resolve`) - not a raw
+/// frontend `SymbolId`. OWN0 emission (`emit_ownership_events`) resolves
+/// this string against the function's own `StringInterner` (the same table
+/// `LoadVar`/`StoreVar` operands are interned into) to get the artifact-
+/// local index the VM already expects on load (`build_vm_program_view_from_decoded`'s
+/// `remap_paths`). Before #1725 this field held the raw frontend `SymbolId`
+/// number directly, which the VM's *consumer* code already (silently,
+/// incorrectly) treated as a string-table index - the producer and
+/// consumer were never speaking the same identity domain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccessPath {
-    pub root: SymbolId,
+    pub root: String,
     pub components: Vec<PathComponent>,
 }
 
 impl AccessPath {
-    pub fn new(root: SymbolId) -> Self {
+    pub fn new(root: String) -> Self {
         Self {
             root,
             components: Vec::new(),
@@ -381,7 +393,7 @@ impl AccessPath {
         let mut components = self.components.clone();
         components.push(PathComponent::TupleIndex(index));
         Self {
-            root: self.root,
+            root: self.root.clone(),
             components,
         }
     }
@@ -390,7 +402,7 @@ impl AccessPath {
         let mut components = self.components.clone();
         components.push(PathComponent::SequenceIndexStatic(index));
         Self {
-            root: self.root,
+            root: self.root.clone(),
             components,
         }
     }
@@ -399,7 +411,7 @@ impl AccessPath {
         let mut components = self.components.clone();
         components.push(PathComponent::Field(name));
         Self {
-            root: self.root,
+            root: self.root.clone(),
             components,
         }
     }
@@ -408,7 +420,7 @@ impl AccessPath {
         let mut components = self.components.clone();
         components.push(PathComponent::AdtPayload { variant, index });
         Self {
-            root: self.root,
+            root: self.root.clone(),
             components,
         }
     }
@@ -1540,7 +1552,12 @@ fn emit_semcode_function(
             write_u16_le(&mut code, col);
         }
     }
-    emit_ownership_events(&f.ownership_events, require_ownership_section, &mut code)?;
+    emit_ownership_events(
+        &f.ownership_events,
+        require_ownership_section,
+        &interner,
+        &mut code,
+    )?;
     // #1773 (FA-09-005): unconditional, never a per-function/emission-time
     // choice like `debug_symbols` - every function gets a SIG0 section once
     // the chosen header can carry one, so `sm-format`'s decoder can expect
@@ -2280,6 +2297,7 @@ fn has_v12_record_field_ownership_events(funcs: &[IrFunction]) -> bool {
 fn emit_ownership_events(
     ownership_events: &[OwnershipPathEvent],
     require_section: bool,
+    interner: &StringInterner,
     out: &mut Vec<u8>,
 ) -> Result<(), FrontendError> {
     if ownership_events.is_empty() {
@@ -2305,7 +2323,16 @@ fn emit_ownership_events(
             OwnershipPathEventKind::Borrow => OWNERSHIP_EVENT_KIND_BORROW,
             OwnershipPathEventKind::Write => OWNERSHIP_EVENT_KIND_WRITE,
         });
-        write_u32_le(out, event.path.root.0);
+        // #1725 (FA-04-019): resolve the lowered-local key against this
+        // function's own string table - the same one LoadVar/StoreVar
+        // operands for this exact binding are interned into - instead of
+        // writing a raw frontend SymbolId the VM has no way to correctly
+        // interpret. Fails closed (`StringInterner::lookup`) rather than
+        // guessing: every root reaching this point was produced by
+        // `LoweredLocalEnv::resolve`, so a lookup miss here means the
+        // events walk visited a binding no StoreVar/LoadVar ever recorded -
+        // a producer bug, not a case to paper over.
+        write_u32_le(out, u32::from(interner.lookup(&event.path.root)?));
         write_u16_le(
             out,
             u16::try_from(event.path.components.len()).map_err(|_| FrontendError {
@@ -2537,7 +2564,12 @@ fn lower_closure_literal_expr(
     // same way a top-level `lower_stmt` arm prescans its own statement's
     // expression before lowering it. Writes into the child's own sink, not
     // the parent's - the closure body is a new function boundary.
-    append_record_update_write_events_from_expr(closure.body, arena, &mut lifted_ownership_events);
+    append_record_update_write_events_from_expr(
+        closure.body,
+        arena,
+        &mut lifted_ownership_events,
+        lowered_locals,
+    )?;
     let (body_reg, body_ty) = lower_expr_with_expected(
         closure.body,
         arena,
@@ -5202,7 +5234,7 @@ fn assign_tuple_items(
         });
         ownership_events.push(OwnershipPathEvent {
             kind: OwnershipPathEventKind::Write,
-            path: AccessPath::new(*name),
+            path: AccessPath::new(lowered_locals.resolve(arena, *name)?),
         });
     }
     Ok(())
@@ -5426,7 +5458,12 @@ fn lower_while_stmt(
     record_table: &RecordTable,
     adt_table: &AdtTable,
 ) -> Result<(), FrontendError> {
-    append_record_update_write_events_from_expr(condition, arena, &mut ctx.ownership_events);
+    append_record_update_write_events_from_expr(
+        condition,
+        arena,
+        &mut ctx.ownership_events,
+        &ctx.lowered_locals,
+    )?;
     let id = ctx.next_if_id();
     let test_label = format!("while_{}_test", id);
     let body_label = format!("while_{}_body", id);
@@ -6025,7 +6062,12 @@ fn lower_stmt(
     let stmt = arena.stmt(stmt_id);
     match stmt {
         Stmt::Const { name, ty, value } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
             let (reg, vty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6060,7 +6102,12 @@ fn lower_stmt(
             ty,
             value,
         } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
             let (reg, vty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6094,8 +6141,13 @@ fn lower_stmt(
             Ok(())
         }
         Stmt::LetTuple { items, ty, value } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
-            let sequence_path = sequence_access_path_from_expr(*value, arena);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
+            let sequence_path = sequence_access_path_from_expr(*value, arena, &ctx.lowered_locals)?;
             let (tuple_reg, vty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6135,8 +6187,14 @@ fn lower_stmt(
             items,
             value,
         } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
-            let record_path = direct_record_access_path_from_expr(*value, arena);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
+            let record_path =
+                direct_record_access_path_from_expr(*value, arena, &ctx.lowered_locals)?;
             let (record_reg, record_ty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6175,8 +6233,14 @@ fn lower_stmt(
             value,
             else_return,
         } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
-            let record_path = direct_record_access_path_from_expr(*value, arena);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
+            let record_path =
+                direct_record_access_path_from_expr(*value, arena, &ctx.lowered_locals)?;
             let (record_reg, record_ty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6224,8 +6288,13 @@ fn lower_stmt(
             value,
             else_return,
         } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
-            let sequence_path = sequence_access_path_from_expr(*value, arena);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
+            let sequence_path = sequence_access_path_from_expr(*value, arena, &ctx.lowered_locals)?;
             let (tuple_reg, vty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6272,7 +6341,12 @@ fn lower_stmt(
             )
         }
         Stmt::Discard { ty, value } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
             let _ = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6308,7 +6382,12 @@ fn lower_stmt(
                     ),
                 });
             }
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
             let (reg, _) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6331,12 +6410,17 @@ fn lower_stmt(
             });
             ctx.ownership_events.push(OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*name),
+                path: AccessPath::new(ctx.lowered_locals.resolve(arena, *name)?),
             });
             Ok(())
         }
         Stmt::AssignTuple { items, value } => {
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
             let (tuple_reg, tuple_ty) = lower_expr(
                 *value,
                 arena,
@@ -6452,7 +6536,12 @@ fn lower_stmt(
                     frame.result_ty.clone(),
                 )
             };
-            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
+            append_record_update_write_events_from_expr(
+                *value,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
             let (reg, break_ty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -6518,7 +6607,8 @@ fn lower_stmt(
                 *condition,
                 arena,
                 &mut ctx.ownership_events,
-            );
+                &ctx.lowered_locals,
+            )?;
             let (cond_reg, cond_ty) = lower_expr(
                 *condition,
                 arena,
@@ -6572,7 +6662,12 @@ fn lower_stmt(
             Ok(())
         }
         Stmt::Expr(expr) => {
-            append_record_update_write_events_from_expr(*expr, arena, &mut ctx.ownership_events);
+            append_record_update_write_events_from_expr(
+                *expr,
+                arena,
+                &mut ctx.ownership_events,
+                &ctx.lowered_locals,
+            )?;
             lower_expr_stmt(
                 *expr,
                 arena,
@@ -6591,7 +6686,8 @@ fn lower_stmt(
                     value,
                     arena,
                     &mut ctx.ownership_events,
-                );
+                    &ctx.lowered_locals,
+                )?;
             }
             lower_return_payload(
                 *v,
@@ -6622,7 +6718,8 @@ fn lower_stmt(
                 *condition,
                 arena,
                 &mut ctx.ownership_events,
-            );
+                &ctx.lowered_locals,
+            )?;
             let (cond_reg, cond_ty) = lower_expr(
                 *condition,
                 arena,
@@ -6714,7 +6811,8 @@ fn lower_stmt(
                 *scrutinee,
                 arena,
                 &mut ctx.ownership_events,
-            );
+                &ctx.lowered_locals,
+            )?;
             let (scr_reg, scr_ty) = lower_expr(
                 *scrutinee,
                 arena,
@@ -7174,7 +7272,12 @@ fn lower_value_block_expr(
                 // enclosing authority (the pre-scan that reaches nested
                 // blocks only follows a block's `tail`, never its
                 // `statements`), so this call is required, not a duplicate.
-                append_record_update_write_events_from_expr(*value, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    *value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
                 let (reg, vty) = lower_expr_with_expected(
                     *value,
                     arena,
@@ -7208,7 +7311,12 @@ fn lower_value_block_expr(
                 ty,
                 value,
             } => {
-                append_record_update_write_events_from_expr(*value, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    *value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
                 let (reg, vty) = lower_expr_with_expected(
                     *value,
                     arena,
@@ -7241,13 +7349,18 @@ fn lower_value_block_expr(
                 });
             }
             Stmt::LetTuple { items, ty, value } => {
-                append_record_update_write_events_from_expr(*value, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    *value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
                 // #1709: derive the same canonical `AccessPath` the
                 // top-level `lower_stmt` arm derives - previously hardcoded
                 // to `None` here, which meant `bind_tuple_items` could never
                 // emit a Borrow event for this call site regardless of the
                 // sink, since it only pushes when a path is present.
-                let sequence_path = sequence_access_path_from_expr(*value, arena);
+                let sequence_path = sequence_access_path_from_expr(*value, arena, lowered_locals)?;
                 let (tuple_reg, vty) = lower_expr_with_expected(
                     *value,
                     arena,
@@ -7287,8 +7400,14 @@ fn lower_value_block_expr(
                 items,
                 value,
             } => {
-                append_record_update_write_events_from_expr(*value, arena, ownership_events);
-                let record_path = direct_record_access_path_from_expr(*value, arena);
+                append_record_update_write_events_from_expr(
+                    *value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
+                let record_path =
+                    direct_record_access_path_from_expr(*value, arena, lowered_locals)?;
                 let (record_reg, record_ty) = lower_expr_with_expected(
                     *value,
                     arena,
@@ -7333,7 +7452,12 @@ fn lower_value_block_expr(
                 // `lower_stmt`'s `Stmt::Discard` arm, which prescans before
                 // lowering. This nested arm had the correct sink but was
                 // never wired to the producer authority itself.
-                append_record_update_write_events_from_expr(*value, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    *value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
                 let _ = lower_expr_with_expected(
                     *value,
                     arena,
@@ -7353,7 +7477,12 @@ fn lower_value_block_expr(
             }
             Stmt::Expr(expr) => {
                 // #1709 corrective: mirrors `lower_stmt`'s `Stmt::Expr` arm.
-                append_record_update_write_events_from_expr(*expr, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    *expr,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
                 lower_expr_stmt_with_parts(
                     *expr,
                     arena,
@@ -8492,7 +8621,12 @@ fn lower_loop_expr_stmt(
             // loop-expression `If` implementation does not delegate to
             // `lower_stmt` (unlike everything reaching the `_` fallback
             // below), so it needs the same call independently.
-            append_record_update_write_events_from_expr(*condition, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                *condition,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
             let (cond_reg, cond_ty) = lower_expr(
                 *condition,
                 arena,
@@ -8594,7 +8728,12 @@ fn lower_loop_expr_stmt(
             // which prescans `scrutinee` before lowering it. This dedicated
             // loop-expression `Match` implementation does not delegate to
             // `lower_stmt`, so it needs the same call independently.
-            append_record_update_write_events_from_expr(*scrutinee, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                *scrutinee,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
             let (scr_reg, scr_ty) = lower_expr(
                 *scrutinee,
                 arena,
@@ -10543,75 +10682,149 @@ fn find_named_var_symbol(
     }
 }
 
+// #1725 (FA-04-018/019): both of these resolve their `Expr::Var` root
+// through `LoweredLocalEnv`, the same scope-aware authority `StoreVar`/
+// `LoadVar` resolve through, so the `AccessPath` they hand back carries the
+// exact lowered runtime-local key for the binding *currently* selected by
+// lexical scope at this call site - not a raw, scope-blind frontend
+// `SymbolId`. `resolve` fails closed (no fallback to raw spelling); that
+// failure propagates as `Err` here rather than collapsing to `None`; a
+// resolve miss on an already-typechecked `Expr::Var` means a producer bug
+// upstream, not a legitimate "no path" case indistinguishable from e.g. a
+// numeric literal.
 fn sequence_access_path_from_expr(
     expr_id: ExprId,
     arena: &AstArena,
-) -> Option<SequenceOwnershipPath> {
+    lowered_locals: &LoweredLocalEnv,
+) -> Result<Option<SequenceOwnershipPath>, FrontendError> {
     match arena.expr(expr_id) {
-        Expr::Var(name) => Some(SequenceOwnershipPath::Exact(AccessPath::new(*name))),
+        Expr::Var(name) => Ok(Some(SequenceOwnershipPath::Exact(AccessPath::new(
+            lowered_locals.resolve(arena, *name)?,
+        )))),
         Expr::SequenceIndex(index_expr) => {
-            let base = sequence_access_path_from_expr(index_expr.base, arena)?;
+            let Some(base) =
+                sequence_access_path_from_expr(index_expr.base, arena, lowered_locals)?
+            else {
+                return Ok(None);
+            };
             let base_path = base.as_path().clone();
             if base.is_dynamic_fallback() {
-                return Some(SequenceOwnershipPath::DynamicFallback(base_path));
+                return Ok(Some(SequenceOwnershipPath::DynamicFallback(base_path)));
             }
             let Expr::NumericLiteral(NumericLiteral::I32(index)) = arena.expr(index_expr.index)
             else {
-                return Some(SequenceOwnershipPath::DynamicFallback(base_path));
+                return Ok(Some(SequenceOwnershipPath::DynamicFallback(base_path)));
             };
             if *index < 0 {
-                return Some(SequenceOwnershipPath::DynamicFallback(base_path));
+                return Ok(Some(SequenceOwnershipPath::DynamicFallback(base_path)));
             }
-            let index = u32::try_from(*index).ok()?;
-            Some(SequenceOwnershipPath::Exact(
+            let Some(index) = u32::try_from(*index).ok() else {
+                return Ok(None);
+            };
+            Ok(Some(SequenceOwnershipPath::Exact(
                 base_path.sequence_index_static(index),
-            ))
+            )))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
-fn direct_record_access_path_from_expr(expr_id: ExprId, arena: &AstArena) -> Option<AccessPath> {
+fn direct_record_access_path_from_expr(
+    expr_id: ExprId,
+    arena: &AstArena,
+    lowered_locals: &LoweredLocalEnv,
+) -> Result<Option<AccessPath>, FrontendError> {
     match arena.expr(expr_id) {
-        Expr::Var(name) => Some(AccessPath::new(*name)),
-        _ => None,
+        Expr::Var(name) => Ok(Some(AccessPath::new(lowered_locals.resolve(arena, *name)?))),
+        _ => Ok(None),
     }
 }
 
+// #1725 (FA-04-019): threads `lowered_locals` (read-only) through this
+// producer so `direct_record_access_path_from_expr`/
+// `sequence_access_path_from_expr` resolve their `AccessPath` roots through
+// the same scope-aware `LoweredLocalEnv` authority `StoreVar`/`LoadVar` do,
+// at the exact lowering-walk position this producer is called from (every
+// call site already has `lowered_locals` live in scope for the surrounding
+// `lower_expr`/`lower_stmt` call, so this mirrors the current scope state
+// exactly). Returns `Result` now (was `()`) purely to propagate a resolve
+// failure fail-closed instead of a silent fallback.
 fn append_record_update_write_events_from_expr(
     expr_id: ExprId,
     arena: &AstArena,
     ownership_events: &mut Vec<OwnershipPathEvent>,
-) {
+    lowered_locals: &LoweredLocalEnv,
+) -> Result<(), FrontendError> {
     match arena.expr(expr_id) {
         Expr::Tuple(items) => {
             for item in items {
-                append_record_update_write_events_from_expr(*item, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    *item,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
             }
         }
         Expr::RecordLiteral(record_literal) => {
             for field in &record_literal.fields {
-                append_record_update_write_events_from_expr(field.value, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    field.value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
             }
         }
         Expr::RecordField(field_expr) => {
-            append_record_update_write_events_from_expr(field_expr.base, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                field_expr.base,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
         }
         Expr::SequenceLiteral(sequence) => {
             for item in &sequence.items {
-                append_record_update_write_events_from_expr(*item, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    *item,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
             }
         }
         Expr::SequenceIndex(index_expr) => {
-            append_record_update_write_events_from_expr(index_expr.base, arena, ownership_events);
-            append_record_update_write_events_from_expr(index_expr.index, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                index_expr.base,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
+            append_record_update_write_events_from_expr(
+                index_expr.index,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
         }
         Expr::RecordUpdate(update_expr) => {
-            append_record_update_write_events_from_expr(update_expr.base, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                update_expr.base,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
             for field in &update_expr.fields {
-                append_record_update_write_events_from_expr(field.value, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    field.value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
             }
-            if let Some(record_path) = direct_record_access_path_from_expr(update_expr.base, arena)
+            if let Some(record_path) =
+                direct_record_access_path_from_expr(update_expr.base, arena, lowered_locals)?
             {
                 for field in &update_expr.fields {
                     ownership_events.push(OwnershipPathEvent {
@@ -10623,57 +10836,133 @@ fn append_record_update_write_events_from_expr(
         }
         Expr::Call(_, args) => {
             for arg in args {
-                append_record_update_write_events_from_expr(arg.value, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    arg.value,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
             }
         }
         Expr::Unary(_, inner) => {
-            append_record_update_write_events_from_expr(*inner, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                *inner,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
         }
         Expr::Binary(lhs, _, rhs) => {
-            append_record_update_write_events_from_expr(*lhs, arena, ownership_events);
-            append_record_update_write_events_from_expr(*rhs, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                *lhs,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
+            append_record_update_write_events_from_expr(
+                *rhs,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
         }
         Expr::Range(range) => {
-            append_record_update_write_events_from_expr(range.start, arena, ownership_events);
-            append_record_update_write_events_from_expr(range.end, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                range.start,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
+            append_record_update_write_events_from_expr(
+                range.end,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
         }
         Expr::If(if_expr) => {
-            append_record_update_write_events_from_expr(if_expr.condition, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                if_expr.condition,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
             append_record_update_write_events_from_expr(
                 if_expr.then_block.tail,
                 arena,
                 ownership_events,
-            );
+                lowered_locals,
+            )?;
             append_record_update_write_events_from_expr(
                 if_expr.else_block.tail,
                 arena,
                 ownership_events,
-            );
+                lowered_locals,
+            )?;
         }
         Expr::IfLet(if_let_expr) => {
-            append_record_update_write_events_from_expr(if_let_expr.value, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                if_let_expr.value,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
             append_record_update_write_events_from_expr(
                 if_let_expr.then_block.tail,
                 arena,
                 ownership_events,
-            );
+                lowered_locals,
+            )?;
             append_record_update_write_events_from_expr(
                 if_let_expr.else_block.tail,
                 arena,
                 ownership_events,
-            );
+                lowered_locals,
+            )?;
         }
         Expr::Block(block) => {
-            append_record_update_write_events_from_expr(block.tail, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                block.tail,
+                arena,
+                ownership_events,
+                lowered_locals,
+            )?;
         }
         Expr::Match(match_expr) => {
             append_record_update_write_events_from_expr(
                 match_expr.scrutinee,
                 arena,
                 ownership_events,
-            );
+                lowered_locals,
+            )?;
 
-            let scrutinee_path = sequence_access_path_from_expr(match_expr.scrutinee, arena);
+            // #1725 corrective: only attempt to resolve the scrutinee's
+            // ownership path if some arm's pattern actually needs it (a
+            // real Borrow-mode ADT payload capture below) - the scrutinee
+            // may be a variable bound by an *enclosing* match/if-let arm's
+            // own pattern within this same prescan tree (e.g.
+            // `Option::Some(dir) => { match dir { ... } }`), which
+            // genuinely has no `LoweredLocalEnv` entry yet at prescan time
+            // (real binding only happens later, during that arm's own real
+            // lowering). Gating on actual need means the common case - no
+            // Borrow capture anywhere in this match - never attempts a
+            // resolve that would otherwise fail closed for no reason.
+            let any_arm_borrows_adt_payload = match_expr.arms.iter().any(|arm| {
+                matches!(&arm.pat, sm_front::types::MatchPattern::Adt(adt_pat) if adt_pat.items.iter().any(|item| {
+                    matches!(
+                        item,
+                        sm_front::types::AdtPatternItem::Bind {
+                            capture: sm_front::types::CaptureMode::Borrow,
+                            ..
+                        }
+                    )
+                }))
+            });
+            let scrutinee_path = if any_arm_borrows_adt_payload {
+                sequence_access_path_from_expr(match_expr.scrutinee, arena, lowered_locals)?
+            } else {
+                None
+            };
             let mut borrowed_dynamic_scrutinee_root = false;
             for arm in &match_expr.arms {
                 if let sm_front::types::MatchPattern::Adt(adt_pat) = &arm.pat {
@@ -10715,16 +11004,27 @@ fn append_record_update_write_events_from_expr(
                 }
 
                 if let Some(guard) = arm.guard {
-                    append_record_update_write_events_from_expr(guard, arena, ownership_events);
+                    append_record_update_write_events_from_expr(
+                        guard,
+                        arena,
+                        ownership_events,
+                        lowered_locals,
+                    )?;
                 }
                 append_record_update_write_events_from_expr(
                     arm.block.tail,
                     arena,
                     ownership_events,
-                );
+                    lowered_locals,
+                )?;
             }
             if let Some(default) = &match_expr.default {
-                append_record_update_write_events_from_expr(default.tail, arena, ownership_events);
+                append_record_update_write_events_from_expr(
+                    default.tail,
+                    arena,
+                    ownership_events,
+                    lowered_locals,
+                )?;
             }
         }
         Expr::QuadLiteral(_)
@@ -10736,6 +11036,7 @@ fn append_record_update_write_events_from_expr(
         | Expr::Var(_)
         | Expr::Loop(_) => {}
     }
+    Ok(())
 }
 
 #[inline]
@@ -11209,15 +11510,17 @@ mod opt_tests {
 
     #[test]
     fn access_path_root_starts_with_empty_component_list() {
-        let path = AccessPath::new(SymbolId(7));
-        assert_eq!(path.root, SymbolId(7));
+        let path = AccessPath::new("__sm_local_7_x".to_string());
+        assert_eq!(path.root, "__sm_local_7_x");
         assert!(path.components.is_empty());
     }
 
     #[test]
     fn access_path_tuple_indices_preserve_append_order() {
-        let path = AccessPath::new(SymbolId(3)).tuple_index(1).tuple_index(4);
-        assert_eq!(path.root, SymbolId(3));
+        let path = AccessPath::new("__sm_local_3_x".to_string())
+            .tuple_index(1)
+            .tuple_index(4);
+        assert_eq!(path.root, "__sm_local_3_x");
         assert_eq!(
             path.components,
             vec![PathComponent::TupleIndex(1), PathComponent::TupleIndex(4)]
@@ -11227,17 +11530,17 @@ mod opt_tests {
     #[test]
     fn access_path_record_field_can_be_represented() {
         let camera = SymbolId(11);
-        let path = AccessPath::new(SymbolId(3)).field(camera);
-        assert_eq!(path.root, SymbolId(3));
+        let path = AccessPath::new("__sm_local_3_x".to_string()).field(camera);
+        assert_eq!(path.root, "__sm_local_3_x");
         assert_eq!(path.components, vec![PathComponent::Field(camera)]);
     }
 
     #[test]
     fn access_path_sequence_index_static_can_be_represented() {
-        let path = AccessPath::new(SymbolId(3))
+        let path = AccessPath::new("__sm_local_3_x".to_string())
             .sequence_index_static(2)
             .sequence_index_static(4);
-        assert_eq!(path.root, SymbolId(3));
+        assert_eq!(path.root, "__sm_local_3_x");
         assert_eq!(
             path.components,
             vec![
@@ -11250,9 +11553,15 @@ mod opt_tests {
     #[test]
     fn access_path_component_order_is_deterministic() {
         let field = SymbolId(12);
-        let left = AccessPath::new(SymbolId(9)).tuple_index(0).field(field);
-        let right = AccessPath::new(SymbolId(9)).tuple_index(0).field(field);
-        let different = AccessPath::new(SymbolId(9)).field(field).tuple_index(0);
+        let left = AccessPath::new("__sm_local_9_x".to_string())
+            .tuple_index(0)
+            .field(field);
+        let right = AccessPath::new("__sm_local_9_x".to_string())
+            .tuple_index(0)
+            .field(field);
+        let different = AccessPath::new("__sm_local_9_x".to_string())
+            .field(field)
+            .tuple_index(0);
         assert_eq!(left, right);
         assert_ne!(left, different);
     }
@@ -11281,6 +11590,56 @@ mod opt_tests {
         )
         .expect("function should lower");
         (program, lowered.primary)
+    }
+
+    // #1725 (FA-04-019): `AccessPath.root` now carries the resolved lowered
+    // runtime-local key, not a raw frontend `SymbolId` - these pre-existing
+    // tests compared `ownership_events` against a hand-built `AccessPath`
+    // whose root was the raw `SymbolId`. Rather than hand-computing the
+    // exact `__sm_local_<id>_<spelling>` text (an implementation detail;
+    // see the identical rationale on `ssf08_1724_*` above), this looks up
+    // the actual key a StoreVar/LoadVar for that source spelling carries in
+    // the lowered function - fail-closed on 0 or >1 distinct matches, the
+    // same discipline as `LoweredLocalEnv::resolve` itself.
+    fn is_lowered_local_key_for(candidate: &str, source_name: &str) -> bool {
+        let Some(rest) = candidate.strip_prefix("__sm_local_") else {
+            return false;
+        };
+        let digits_end = rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+        if digits_end == 0 {
+            return false;
+        }
+        let Some(after_digits) = rest.get(digits_end..) else {
+            return false;
+        };
+        let Some(spelling) = after_digits.strip_prefix('_') else {
+            return false;
+        };
+        spelling == source_name
+    }
+
+    fn lowered_local_key_for(func: &IrFunction, source_name: &str) -> String {
+        let matches: BTreeSet<&str> = func
+            .instrs
+            .iter()
+            .filter_map(|instr| match instr {
+                IrInstr::StoreVar { name, .. } | IrInstr::LoadVar { name, .. } => {
+                    Some(name.as_str())
+                }
+                _ => None,
+            })
+            .filter(|name| is_lowered_local_key_for(name, source_name))
+            .collect();
+        match matches.len() {
+            0 => panic!(
+                "no lowered local key found for '{source_name}' in function '{}' instrs {:?}",
+                func.name, func.instrs
+            ),
+            1 => matches.into_iter().next().unwrap().to_string(),
+            _ => panic!("ambiguous lowered local key for '{source_name}': {matches:?}"),
+        }
     }
 
     #[test]
@@ -12561,12 +12920,6 @@ mod opt_tests {
         "#;
 
         let (program, func) = lower_single_function_with_program(src, "use_e");
-        let use_e_func = program
-            .functions
-            .iter()
-            .find(|f| program.arena.symbol_name(f.name) == "use_e")
-            .unwrap();
-        let e_name = use_e_func.params[0].0;
 
         let adt = program
             .adts
@@ -12583,7 +12936,8 @@ mod opt_tests {
             func.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(e_name).adt_payload(variant.name, 0),
+                path: AccessPath::new(lowered_local_key_for(&func, "e"))
+                    .adt_payload(variant.name, 0),
             }]
         );
     }
@@ -12625,14 +12979,14 @@ mod opt_tests {
 
         let (mut program, func) = lower_single_function_with_program(src, "use_opt");
 
-        let opt_name = program.arena.intern_symbol("opt");
         let some_name = program.arena.intern_symbol("Some");
 
         assert_eq!(
             func.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(opt_name).adt_payload(some_name, 0),
+                path: AccessPath::new(lowered_local_key_for(&func, "opt"))
+                    .adt_payload(some_name, 0),
             }]
         );
     }
@@ -12670,14 +13024,13 @@ mod opt_tests {
 
         let (mut program, func) = lower_single_function_with_program(src, "use_result");
 
-        let res_name = program.arena.intern_symbol("res");
         let ok_name = program.arena.intern_symbol("Ok");
 
         assert_eq!(
             func.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(res_name).adt_payload(ok_name, 0),
+                path: AccessPath::new(lowered_local_key_for(&func, "res")).adt_payload(ok_name, 0),
             }]
         );
     }
@@ -12697,14 +13050,13 @@ mod opt_tests {
 
         let (mut program, func) = lower_single_function_with_program(src, "use_result");
 
-        let res_name = program.arena.intern_symbol("res");
         let err_name = program.arena.intern_symbol("Err");
 
         assert_eq!(
             func.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(res_name).adt_payload(err_name, 0),
+                path: AccessPath::new(lowered_local_key_for(&func, "res")).adt_payload(err_name, 0),
             }]
         );
     }
@@ -12721,23 +13073,12 @@ mod opt_tests {
             }
         "#;
 
-        let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let {
-            name: pair_name, ..
-        } = program.arena.stmt(main_fn.body[0])
-        else {
-            panic!("expected pair binding");
-        };
+        let (_, main) = lower_single_function_with_program(src, "main");
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(*pair_name).tuple_index(0),
+                path: AccessPath::new(lowered_local_key_for(&main, "pair")).tuple_index(0),
             }]
         );
     }
@@ -12754,28 +13095,17 @@ mod opt_tests {
             }
         "#;
 
-        let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let {
-            name: pair_name, ..
-        } = program.arena.stmt(main_fn.body[0])
-        else {
-            panic!("expected pair binding");
-        };
+        let (_, main) = lower_single_function_with_program(src, "main");
         assert_eq!(
             main.ownership_events,
             vec![
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*pair_name).tuple_index(0),
+                    path: AccessPath::new(lowered_local_key_for(&main, "pair")).tuple_index(0),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*pair_name).tuple_index(1),
+                    path: AccessPath::new(lowered_local_key_for(&main, "pair")).tuple_index(1),
                 },
             ]
         );
@@ -12819,34 +13149,17 @@ mod opt_tests {
             }
         "#;
 
-        let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let {
-            name: count_name, ..
-        } = program.arena.stmt(main_fn.body[0])
-        else {
-            panic!("expected count binding");
-        };
-        let Stmt::Let {
-            name: ready_name, ..
-        } = program.arena.stmt(main_fn.body[1])
-        else {
-            panic!("expected ready binding");
-        };
+        let (_, main) = lower_single_function_with_program(src, "main");
         assert_eq!(
             main.ownership_events,
             vec![
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Write,
-                    path: AccessPath::new(*count_name),
+                    path: AccessPath::new(lowered_local_key_for(&main, "count")),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Write,
-                    path: AccessPath::new(*ready_name),
+                    path: AccessPath::new(lowered_local_key_for(&main, "ready")),
                 },
             ]
         );
@@ -13631,20 +13944,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let camera_field = program.records[0].fields[0].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(*ctx_name).field(camera_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(camera_field),
             }]
         );
     }
@@ -13666,20 +13971,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*ctx_name).field(quality_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
             }]
         );
     }
@@ -13700,14 +13997,6 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let camera_field = program.records[0].fields[0].name;
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
@@ -13715,11 +14004,11 @@ mod opt_tests {
             vec![
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*ctx_name).field(camera_field),
+                    path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(camera_field),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*ctx_name).field(quality_field),
+                    path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
                 },
             ]
         );
@@ -13742,14 +14031,6 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let camera_field = program.records[0].fields[0].name;
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
@@ -13757,11 +14038,11 @@ mod opt_tests {
             vec![
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Write,
-                    path: AccessPath::new(*ctx_name).field(quality_field),
+                    path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Write,
-                    path: AccessPath::new(*ctx_name).field(camera_field),
+                    path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(camera_field),
                 },
             ]
         );
@@ -13777,27 +14058,19 @@ mod opt_tests {
             }
         "#;
 
-        let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: seq_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected sequence binding");
-        };
+        let (_, main) = lower_single_function_with_program(src, "main");
         assert_eq!(
             main.ownership_events,
             vec![
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*seq_name)
+                    path: AccessPath::new(lowered_local_key_for(&main, "seq"))
                         .sequence_index_static(0)
                         .tuple_index(0),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*seq_name)
+                    path: AccessPath::new(lowered_local_key_for(&main, "seq"))
                         .sequence_index_static(0)
                         .tuple_index(1),
                 },
@@ -13851,39 +14124,31 @@ mod opt_tests {
             }
         "#;
 
-        let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: seq_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected sequence binding");
-        };
+        let (_, main) = lower_single_function_with_program(src, "main");
         assert_eq!(
             main.ownership_events,
             vec![
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*seq_name)
+                    path: AccessPath::new(lowered_local_key_for(&main, "seq"))
                         .sequence_index_static(0)
                         .tuple_index(0),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*seq_name)
+                    path: AccessPath::new(lowered_local_key_for(&main, "seq"))
                         .sequence_index_static(0)
                         .tuple_index(1),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*seq_name)
+                    path: AccessPath::new(lowered_local_key_for(&main, "seq"))
                         .sequence_index_static(1)
                         .tuple_index(0),
                 },
                 OwnershipPathEvent {
                     kind: OwnershipPathEventKind::Borrow,
-                    path: AccessPath::new(*seq_name)
+                    path: AccessPath::new(lowered_local_key_for(&main, "seq"))
                         .sequence_index_static(1)
                         .tuple_index(1),
                 },
@@ -14477,23 +14742,12 @@ mod opt_tests {
             }
         "#;
 
-        let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let {
-            name: source_name, ..
-        } = program.arena.stmt(main_fn.body[0])
-        else {
-            panic!("expected source binding");
-        };
+        let (_, main) = lower_single_function_with_program(src, "main");
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(*source_name).tuple_index(0),
+                path: AccessPath::new(lowered_local_key_for(&main, "source")).tuple_index(0),
             }]
         );
     }
@@ -14539,20 +14793,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*ctx_name).field(quality_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
             }]
         );
     }
@@ -14579,23 +14825,12 @@ mod opt_tests {
             }
         "#;
 
-        let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let {
-            name: source_name, ..
-        } = program.arena.stmt(main_fn.body[0])
-        else {
-            panic!("expected source binding");
-        };
+        let (_, main) = lower_single_function_with_program(src, "main");
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Borrow,
-                path: AccessPath::new(*source_name).tuple_index(0),
+                path: AccessPath::new(lowered_local_key_for(&main, "source")).tuple_index(0),
             }]
         );
     }
@@ -14643,22 +14878,15 @@ mod opt_tests {
         )
         .expect("main should lower");
 
-        let Stmt::Let {
-            name: source_name, ..
-        } = program.arena.stmt(main_fn.body[0])
-        else {
-            panic!("expected source binding");
-        };
-        let expected_event = OwnershipPathEvent {
-            kind: OwnershipPathEventKind::Borrow,
-            path: AccessPath::new(*source_name).tuple_index(0),
-        };
-
         let lifted = lowered
             .lifted
             .iter()
             .find(|func| func.name.starts_with("__closure_main_"))
             .expect("closure lowering should produce a lifted helper");
+        let expected_event = OwnershipPathEvent {
+            kind: OwnershipPathEventKind::Borrow,
+            path: AccessPath::new(lowered_local_key_for(lifted, "source")).tuple_index(0),
+        };
         assert_eq!(lifted.ownership_events, vec![expected_event.clone()]);
         assert!(
             !lowered.primary.ownership_events.contains(&expected_event),
@@ -14693,20 +14921,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*ctx_name).field(quality_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
             }]
         );
     }
@@ -14736,20 +14956,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*ctx_name).field(quality_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
             }]
         );
     }
@@ -14782,20 +14994,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*ctx_name).field(quality_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
             }]
         );
     }
@@ -14827,20 +15031,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*ctx_name).field(quality_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
             }]
         );
     }
@@ -14868,20 +15064,12 @@ mod opt_tests {
         "#;
 
         let (program, main) = lower_single_function_with_program(src, "main");
-        let main_fn = program
-            .functions
-            .iter()
-            .find(|func| program.arena.symbol_name(func.name) == "main")
-            .expect("main fn");
-        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected ctx binding");
-        };
         let quality_field = program.records[0].fields[1].name;
         assert_eq!(
             main.ownership_events,
             vec![OwnershipPathEvent {
                 kind: OwnershipPathEventKind::Write,
-                path: AccessPath::new(*ctx_name).field(quality_field),
+                path: AccessPath::new(lowered_local_key_for(&main, "ctx")).field(quality_field),
             }]
         );
     }
@@ -14925,20 +15113,16 @@ mod opt_tests {
         )
         .expect("main should lower");
 
-        let Stmt::Let { name: r_name, .. } = program.arena.stmt(main_fn.body[0]) else {
-            panic!("expected r binding");
-        };
         let x_field = program.records[0].fields[0].name;
-        let expected_event = OwnershipPathEvent {
-            kind: OwnershipPathEventKind::Write,
-            path: AccessPath::new(*r_name).field(x_field),
-        };
-
         let lifted = lowered
             .lifted
             .iter()
             .find(|func| func.name.starts_with("__closure_main_"))
             .expect("closure lowering should produce a lifted helper");
+        let expected_event = OwnershipPathEvent {
+            kind: OwnershipPathEventKind::Write,
+            path: AccessPath::new(lowered_local_key_for(lifted, "r")).field(x_field),
+        };
         assert_eq!(lifted.ownership_events, vec![expected_event.clone()]);
         assert!(
             !lowered.primary.ownership_events.contains(&expected_event),
@@ -15133,6 +15317,56 @@ mod opt_tests {
         assert_eq!(
             post_loop_x_key, outer_x_key,
             "use of 'x' after the loop expression exits must resolve to the outer binding's exact key"
+        );
+    }
+
+    #[test]
+    fn ssf08_1725_nested_match_on_arm_pattern_bound_scrutinee_does_not_fail_closed_when_unneeded() {
+        // Corrective regression (#1725 / FA-04-019, found via the real
+        // qualification fixture examples/qualification/match_surface/
+        // positive_nested_match/src/main.sm): #1709's prescan producer
+        // (`append_record_update_write_events_from_expr`) walks the AST
+        // strictly ahead of and separately from real lowering, which is
+        // what actually calls `LoweredLocalEnv::bind`. When prescan
+        // recurses into a match arm's own body and that body's inner match
+        // scrutinizes a variable bound by *that same arm's own pattern*
+        // (`dir` below, bound by `Option::Some(dir)`), the variable
+        // genuinely has no `LoweredLocalEnv` entry yet - real binding only
+        // happens later, during that arm's own real lowering. Since this
+        // inner match has no Borrow-mode ADT payload capture anywhere, the
+        // (never-needed) scrutinee path must never be resolved at all, and
+        // lowering must succeed.
+        let src = r#"
+            enum Direction {
+                Up,
+                Right,
+                Down,
+                Left,
+            }
+
+            fn describe(opt: Option(Direction)) -> text {
+                let out: text = match opt {
+                    Option::Some(dir) => {
+                        match dir {
+                            Direction::Up => { "up" }
+                            Direction::Right => { "right" }
+                            Direction::Down => { "down" }
+                            Direction::Left => { "left" }
+                        }
+                    }
+                    Option::None => { "none" }
+                };
+                return out;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let (_, func) = lower_single_function_with_program(src, "describe");
+        assert_eq!(
+            func.ownership_events,
+            vec![],
+            "no Borrow-mode ADT payload capture exists anywhere in this program, so no ownership event should be produced"
         );
     }
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -444,6 +444,13 @@ impl SequenceOwnershipPath {
     }
 }
 
+/// #1725 (FA-04-019) follow-up finding: `Field`'s and `AdtPayload::variant`'s
+/// raw `SymbolId` are deliberately left unresolved here, unlike
+/// `AccessPath.root`. Verified by exhaustive inspection of every consumer
+/// in `sm-vm` (`crates/sm-runtime-core/src/lib.rs`'s `PathComponent` carries
+/// the full rationale): they are used exclusively as opaque, root-gated
+/// equality keys, never resolved through a runtime symbol table - a
+/// materially different, already-sound property from root identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathComponent {
     TupleIndex(u16),

--- a/crates/sm-runtime-core/src/lib.rs
+++ b/crates/sm-runtime-core/src/lib.rs
@@ -98,6 +98,23 @@ impl AccessPath {
     }
 }
 
+/// #1725 (FA-04-019) follow-up finding, verified by direct inspection of
+/// every consumer in `sm-vm`: `Field`'s and `AdtPayload::variant`'s
+/// `SymbolId` are used *exclusively* as opaque, root-gated equality keys
+/// inside `access_paths_overlap` (`lhs.components == rhs.components` after
+/// `lhs.root == rhs.root` already holds) - unlike `AccessPath.root`
+/// pre-#1725, they are never resolved through `RuntimeSymbolTable`/
+/// `vm.symbols`, never used as an index into any table, and never
+/// displayed. Because the overlap check is root-gated first, a field or
+/// variant spelling colliding with an unrelated one on a *different* root
+/// (e.g. two distinct record types both declaring a `value` field) can
+/// never produce a false conflict - only same-root component paths are
+/// ever compared, and within one root's own record/ADT type every field or
+/// variant spelling is unique by construction. This is a materially
+/// different, already-sound property from root identity, which #1725
+/// repairs because roots *are* resolved through a table. See
+/// `field_symbol_collision_across_unrelated_record_types_does_not_false_conflict`
+/// in `tests/own0_root_identity_e2e.rs` for the proof.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum PathComponent {
     TupleIndex(u16),

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1102,11 +1102,26 @@ fn build_vm_program_view_from_decoded(
             paths
                 .iter()
                 .map(|path| {
+                    // #1725 (FA-04-019): `root_symbol_id` is an index into
+                    // this function's own string table (`symbol_ids`, built
+                    // just above from `strings` in table order) - the
+                    // producer (`emit_ownership_events`) now writes that
+                    // index rather than a raw frontend SymbolId, so a
+                    // lookup miss here means the artifact's OWN0 section
+                    // references a local this function's string table
+                    // never declared. Fails closed: no fallback to
+                    // reinterpreting the raw wire number as if it were
+                    // already a valid runtime SymbolId - that fallback is
+                    // exactly the identity confusion #1725 exists to fix.
                     let local_root = path.root_symbol_id as usize;
-                    let root = symbol_ids
-                        .get(local_root)
-                        .copied()
-                        .unwrap_or(SymbolId(path.root_symbol_id));
+                    let root = symbol_ids.get(local_root).copied().ok_or_else(|| {
+                        RuntimeError::BadFormat(format!(
+                            "ownership path root index {} out of bounds for function '{}' string table (len {})",
+                            local_root,
+                            name,
+                            symbol_ids.len()
+                        ))
+                    })?;
                     let mut p = AccessPath::new(root);
                     for c in &path.components {
                         match c {
@@ -4946,9 +4961,17 @@ mod tests {
             frame.borrowed_paths[0].components,
             vec![PathComponent::TupleIndex(0)]
         );
+        // #1725 (FA-04-019): before this fix, `root_symbol_id` was a raw
+        // frontend SymbolId, out of bounds for this function's own string
+        // table, so the (now-removed) fail-open fallback treated it as an
+        // already-valid *global* runtime SymbolId - which happened to
+        // resolve to "pair" only by coincidence (the call `pair(true)`
+        // interns that exact raw string as a Call target elsewhere in the
+        // artifact). The correct identity is the local binding's own
+        // lowered key, not that unrelated string.
         assert_eq!(
             vm.symbols.resolve(frame.borrowed_paths[0].root),
-            Some("pair")
+            Some("__sm_local_0_pair")
         );
     }
 

--- a/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC4-RECORD-POSITIVE-001.trace.json
+++ b/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC4-RECORD-POSITIVE-001.trace.json
@@ -9,10 +9,10 @@
   "expected_status": "accept",
   "source_hash": "ab07713734d22976",
   "ir_hash": "b419ef35fb669085",
-  "semcode_hash": "75e7a209cfe7ae3a",
+  "semcode_hash": "db055bcae9e89ea6",
   "verifier_status": "accept",
   "vm_status": "ok",
   "runtime_config": "default",
-  "expected_output_hash": "df7a93e112e41dc5",
+  "expected_output_hash": "ce6ff31bdd9ca204",
   "notes": "Selected representative record fixture only; no project-root, Map, or 7hell coverage."
 }

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001.replay.json
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001.replay.json
@@ -7,7 +7,7 @@
   "replay_count": 5,
   "expected_status": "accept",
   "source_hash": "4cc5edb44a9c8f32",
-  "summary_hash": "7200410e8ea70a71",
+  "summary_hash": "7963842b993ca57c",
   "verifier_status": "accept",
   "vm_status": "ok",
   "all_runs_equal": true,
@@ -18,7 +18,7 @@
     "check_status": "accept",
     "source_hash": "4cc5edb44a9c8f32",
     "ir_shape_hash": "ce7adee40a6f3732",
-    "semcode_hash": "8e0862584135bd05",
+    "semcode_hash": "68e3e853cbb121bc",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -27,7 +27,7 @@
     "check_status": "accept",
     "source_hash": "4cc5edb44a9c8f32",
     "ir_shape_hash": "ce7adee40a6f3732",
-    "semcode_hash": "8e0862584135bd05",
+    "semcode_hash": "68e3e853cbb121bc",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -36,7 +36,7 @@
     "check_status": "accept",
     "source_hash": "4cc5edb44a9c8f32",
     "ir_shape_hash": "ce7adee40a6f3732",
-    "semcode_hash": "8e0862584135bd05",
+    "semcode_hash": "68e3e853cbb121bc",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -45,7 +45,7 @@
     "check_status": "accept",
     "source_hash": "4cc5edb44a9c8f32",
     "ir_shape_hash": "ce7adee40a6f3732",
-    "semcode_hash": "8e0862584135bd05",
+    "semcode_hash": "68e3e853cbb121bc",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -54,7 +54,7 @@
     "check_status": "accept",
     "source_hash": "4cc5edb44a9c8f32",
     "ir_shape_hash": "ce7adee40a6f3732",
-    "semcode_hash": "8e0862584135bd05",
+    "semcode_hash": "68e3e853cbb121bc",
     "verifier_status": "accept",
     "vm_status": "ok"
   }

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001.replay.json
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001.replay.json
@@ -7,7 +7,7 @@
   "replay_count": 5,
   "expected_status": "accept",
   "source_hash": "f52f7952bcd12bb0",
-  "summary_hash": "4178b340770544cd",
+  "summary_hash": "c19faa031d8f7998",
   "verifier_status": "accept",
   "vm_status": "ok",
   "all_runs_equal": true,
@@ -18,7 +18,7 @@
     "check_status": "accept",
     "source_hash": "f52f7952bcd12bb0",
     "ir_shape_hash": "60a52af62a3728f6",
-    "semcode_hash": "80f07d1f79fbba05",
+    "semcode_hash": "ac4027f89b450a9b",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -27,7 +27,7 @@
     "check_status": "accept",
     "source_hash": "f52f7952bcd12bb0",
     "ir_shape_hash": "60a52af62a3728f6",
-    "semcode_hash": "80f07d1f79fbba05",
+    "semcode_hash": "ac4027f89b450a9b",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -36,7 +36,7 @@
     "check_status": "accept",
     "source_hash": "f52f7952bcd12bb0",
     "ir_shape_hash": "60a52af62a3728f6",
-    "semcode_hash": "80f07d1f79fbba05",
+    "semcode_hash": "ac4027f89b450a9b",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -45,7 +45,7 @@
     "check_status": "accept",
     "source_hash": "f52f7952bcd12bb0",
     "ir_shape_hash": "60a52af62a3728f6",
-    "semcode_hash": "80f07d1f79fbba05",
+    "semcode_hash": "ac4027f89b450a9b",
     "verifier_status": "accept",
     "vm_status": "ok"
   },
@@ -54,7 +54,7 @@
     "check_status": "accept",
     "source_hash": "f52f7952bcd12bb0",
     "ir_shape_hash": "60a52af62a3728f6",
-    "semcode_hash": "80f07d1f79fbba05",
+    "semcode_hash": "ac4027f89b450a9b",
     "verifier_status": "accept",
     "vm_status": "ok"
   }

--- a/tests/own0_root_identity_e2e.rs
+++ b/tests/own0_root_identity_e2e.rs
@@ -1,0 +1,255 @@
+// SSF-08 Lane 2c (#1725 / FA-04-019): "OWN0 roots serialize frontend
+// SymbolId but VM interprets them as function string-table indexes".
+//
+// #1724 already proved (tests/lexical_binding_identity_e2e.rs) that
+// ordinary VM local transport (LoadVar/StoreVar) correctly distinguishes
+// shadowed bindings. This file proves the same property holds for OWN0
+// ownership metadata specifically: a Borrow/Write event attaches to the
+// exact runtime local it was recorded against, even when frontend SymbolId
+// numbering and the function's own string-table ordering deliberately
+// diverge (the normal case since #1724's local-name mangling), and even
+// under lexical shadowing where source spelling alone is ambiguous.
+
+use sm_emit::compile_program_to_semcode;
+use sm_ir::semcode_format::{
+    read_u16_le, read_u32_le, read_u8, read_utf8, OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD,
+    OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX,
+    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
+};
+use sm_runtime_core::RuntimeTrap;
+use sm_vm::RuntimeError;
+
+fn run_source(src: &str) -> Result<(), RuntimeError> {
+    let bytes = compile_program_to_semcode(src).expect("compile");
+    let token = sm_verify::verify_semcode_token(&bytes).expect("token admission");
+    let entry_token = token.require_entry("main").expect("entry resolution");
+    sm_vm::run_verified_entry_semcode(&entry_token)
+}
+
+const SHADOWED_BOX_SOURCE: &str = r#"
+    record Box {
+        value: i32,
+    }
+
+    fn main() {
+        let b: Box = Box { value: 1 };
+        let Box { value: ref v } = b;
+        if true {
+            let mut b: Box = Box { value: 2 };
+            b = Box { value: 99 };
+        }
+        assert(v == 1);
+        return;
+    }
+"#;
+
+#[test]
+fn shadowed_binding_write_does_not_falsely_conflict_with_outer_borrow() {
+    // Positive root mapping + shadowing: the outer `b` (a real StoreVar,
+    // interned into the string table well before the inner shadow's own
+    // StoreVar) is field-borrowed via `ref v`; the *inner*, shadowed `b` -
+    // a completely different lowered-local key, per #1724 - is directly
+    // reassigned (a whole-root write, the shape the VM's StoreVar-time
+    // checker actually enforces) while the outer borrow is still live. If
+    // OWN0 root identity were broken (both events coincidentally resolving
+    // to the same, or an unrelated, string-table index), this would either
+    // falsely reject the inner reassignment as a conflict on the outer's
+    // `value` field, or silently fail to protect the outer borrow at all.
+    run_source(SHADOWED_BOX_SOURCE)
+        .expect("shadowed inner reassignment must not conflict with outer borrow");
+}
+
+#[test]
+fn same_binding_reassignment_still_conflicts_with_its_own_borrow() {
+    // Negative control for the test above: with the shadow removed, a
+    // direct reassignment of the *same* borrowed binding (root-level write
+    // overlapping a field-level borrow, the parent/child overlap shape)
+    // must still be rejected - proving root-identity correctness isn't
+    // achieved by making the checker too permissive to ever conflict.
+    let src = r#"
+        record Box {
+            value: i32,
+        }
+
+        fn main() {
+            let mut b: Box = Box { value: 1 };
+            let Box { value: ref v } = b;
+            b = Box { value: 99 };
+            assert(v == 1);
+            return;
+        }
+    "#;
+    let err = run_source(src).expect_err("reassigning a borrowed binding must still conflict");
+    assert!(
+        matches!(err, RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)),
+        "expected a borrow/write conflict trap, got {err:?}"
+    );
+}
+
+fn read_string_table(code: &[u8]) -> (Vec<String>, usize) {
+    let mut cursor = 0usize;
+    let count = read_u16_le(code, &mut cursor).expect("string count") as usize;
+    let mut strings = Vec::with_capacity(count);
+    for _ in 0..count {
+        let len = read_u16_le(code, &mut cursor).expect("string length") as usize;
+        strings.push(
+            read_utf8(code, &mut cursor, len)
+                .expect("utf8 string")
+                .to_string(),
+        );
+    }
+    (strings, cursor)
+}
+
+#[test]
+fn shadowed_binding_borrow_and_write_decode_to_distinct_string_table_roots() {
+    // Direct wire-level companion to the VM-behavioral test above:
+    // decodes the actual compiled `main` function's OWN0 section and
+    // proves the borrow event's root and the write event's root resolve
+    // to two *different* string-table entries - both ending in the source
+    // spelling `_b`, confirming they're genuinely the outer and inner
+    // shadowed bindings, not merely two unrelated locals that happen to
+    // differ. This is the property #1725 establishes; the VM-behavioral
+    // test above only shows one *consequence* of it.
+    let bytes = compile_program_to_semcode(SHADOWED_BOX_SOURCE).expect("compile");
+    let code_start = find_function_code_start(&bytes, "main");
+    let code = &bytes[code_start..];
+    let (strings, string_table_end) = read_string_table(code);
+
+    let mut cursor = string_table_end;
+    if code[cursor..].starts_with(b"DBG0") {
+        cursor += 4;
+        let count = read_u16_le(code, &mut cursor).expect("debug count") as usize;
+        cursor += count * (4 + 4 + 2);
+    }
+    assert_eq!(&code[cursor..cursor + 4], OWNERSHIP_SECTION_TAG);
+    cursor += 4;
+    let event_count = read_u16_le(code, &mut cursor).expect("event count");
+    assert_eq!(
+        event_count, 2,
+        "expected exactly the outer borrow and the inner reassignment"
+    );
+
+    let mut roots = Vec::with_capacity(2);
+    for _ in 0..event_count {
+        let _kind = read_u8(code, &mut cursor).expect("event kind");
+        let root = read_u32_le(code, &mut cursor).expect("root") as usize;
+        let component_count = read_u16_le(code, &mut cursor).expect("component count");
+        for _ in 0..component_count {
+            let kind = read_u8(code, &mut cursor).expect("component kind");
+            if kind == OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX {
+                let _ = read_u16_le(code, &mut cursor).expect("tuple index");
+            } else if kind == OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX {
+                let _ = read_u32_le(code, &mut cursor).expect("sequence index");
+            } else if kind == OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL {
+                let _ = read_u32_le(code, &mut cursor).expect("field symbol");
+            } else if kind == OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD {
+                let _ = read_u32_le(code, &mut cursor).expect("adt variant");
+                let _ = read_u16_le(code, &mut cursor).expect("adt index");
+            } else {
+                panic!("unexpected component kind {kind}");
+            }
+        }
+        roots.push(root);
+    }
+
+    let root_names: Vec<&str> = roots
+        .iter()
+        .map(|&idx| {
+            strings
+                .get(idx)
+                .map(String::as_str)
+                .expect("root index in bounds")
+        })
+        .collect();
+    assert_ne!(
+        root_names[0], root_names[1],
+        "outer borrow and inner reassignment must resolve to distinct string-table entries, got {root_names:?}"
+    );
+    for name in &root_names {
+        assert!(
+            name.ends_with("_b"),
+            "expected both roots to be lowered keys for source spelling 'b', got {name:?}"
+        );
+    }
+}
+
+fn find_function_code_start(bytes: &[u8], target: &str) -> usize {
+    let mut cursor = 8usize;
+    while cursor < bytes.len() {
+        let name_len = read_u16_le(bytes, &mut cursor).expect("function name len") as usize;
+        let name = read_utf8(bytes, &mut cursor, name_len)
+            .expect("function name")
+            .to_string();
+        let code_len = read_u32_le(bytes, &mut cursor).expect("function code len") as usize;
+        let code_start = cursor;
+        if name == target {
+            return code_start;
+        }
+        cursor = code_start + code_len;
+    }
+    panic!("function '{target}' not found");
+}
+
+fn ownership_section_offset_within_code(code: &[u8]) -> usize {
+    let mut cursor = 0usize;
+    let string_count = read_u16_le(code, &mut cursor).expect("string count") as usize;
+    for _ in 0..string_count {
+        let len = read_u16_le(code, &mut cursor).expect("string len") as usize;
+        cursor += len;
+    }
+    if cursor + 4 <= code.len() && &code[cursor..cursor + 4] == b"DBG0" {
+        cursor += 4;
+        let count = read_u16_le(code, &mut cursor).expect("debug count") as usize;
+        cursor += count * (4 + 4 + 2);
+    }
+    assert_eq!(
+        &code[cursor..cursor + 4],
+        OWNERSHIP_SECTION_TAG,
+        "expected an OWN0 section immediately after the string/debug tables"
+    );
+    cursor
+}
+
+#[test]
+fn corrupted_own0_root_index_rejects_deterministically_on_load() {
+    // Fail-closed negative (#1725 required coverage): an OWN0 root that
+    // cannot be resolved against the function's own string table - here,
+    // deliberately corrupted to an out-of-bounds index - must be rejected
+    // deterministically at load time. Before this fix, the VM's remap
+    // silently fell back to treating the raw wire number as if it were
+    // already a valid *global* runtime SymbolId (`.unwrap_or(SymbolId(..))`);
+    // that fallback is exactly what this test proves is gone.
+    let src = r#"
+        record Box {
+            value: i32,
+        }
+
+        fn main() {
+            let b: Box = Box { value: 1 };
+            let Box { value: ref v } = b;
+            assert(v == 1);
+            return;
+        }
+    "#;
+    let mut bytes = compile_program_to_semcode(src).expect("compile");
+    let code_start = find_function_code_start(&bytes, "main");
+    let own0_offset = ownership_section_offset_within_code(&bytes[code_start..]);
+
+    // OWN0 layout: TAG(4) + event_count:u16(2) + kind:u8(1) + root:u32(4) + ...
+    let root_offset = code_start + own0_offset + 4 + 2 + 1;
+    let corrupted_root: u32 = 0xFFFF_FFFF;
+    bytes[root_offset..root_offset + 4].copy_from_slice(&corrupted_root.to_le_bytes());
+
+    let err = sm_vm::run_verified_entry_semcode(
+        &sm_verify::verify_semcode_token(&bytes)
+            .expect("token admission")
+            .require_entry("main")
+            .expect("entry resolution"),
+    )
+    .expect_err("a corrupted OWN0 root index must be rejected, never silently accepted");
+    assert!(
+        matches!(err, RuntimeError::BadFormat(_)),
+        "expected a deterministic BadFormat rejection, got {err:?}"
+    );
+}

--- a/tests/own0_root_identity_e2e.rs
+++ b/tests/own0_root_identity_e2e.rs
@@ -253,3 +253,74 @@ fn corrupted_own0_root_index_rejects_deterministically_on_load() {
         "expected a deterministic BadFormat rejection, got {err:?}"
     );
 }
+
+// #1725 review follow-up: the fix left `PathComponent::Field`'s and
+// `AdtPayload::variant`'s raw frontend `SymbolId` unresolved (see the doc
+// comments on `PathComponent` in both crates/sm-runtime-core/src/lib.rs and
+// crates/sm-ir/src/legacy_lowering.rs). This is a *narrower, already-sound*
+// property than root identity, not the same defect: `access_paths_overlap`
+// compares these values purely structurally, root-gated first
+// (`lhs.root == rhs.root`, then component-prefix equality) - never through
+// `RuntimeSymbolTable`/`vm.symbols`, verified by exhaustive inspection of
+// every consumer. The pair below proves this exactly: two *unrelated*
+// record types sharing a field spelling (so their raw `SymbolId`s for
+// `value` are the identical number, since `SymbolId` is spelling-interned
+// program-wide) must not be confused by the checker, because the check is
+// root-gated first - while a genuine same-root, same-field conflict must
+// still be caught. Both use `x = x with { field: v }` (self-update
+// reassignment), the shape that actually round-trips through a field-level
+// `Write` `AccessPath` the VM's StoreVar-time checker evaluates - a
+// `with`-update into a *new* variable never reaches that check at all (see
+// `Stmt::Assign`'s StoreVar-time `ensure_write_path_allowed`, which only
+// fires when the reassigned symbol already exists as a local).
+
+#[test]
+fn field_symbol_collision_across_unrelated_record_types_does_not_false_conflict() {
+    let src = r#"
+        record Meter {
+            value: f64,
+        }
+        record Counter {
+            value: i32,
+        }
+
+        fn main() {
+            let m: Meter = Meter { value: 1.0 };
+            let Meter { value: ref mv } = m;
+            let mut c: Counter = Counter { value: 2 };
+            c = c with { value: 99 };
+            assert(mv == 1.0);
+            return;
+        }
+    "#;
+    run_source(src).expect(
+        "an unrelated record type's same-spelled field write must not conflict with the outer borrow",
+    );
+}
+
+#[test]
+fn field_symbol_same_root_same_field_still_conflicts() {
+    // Negative control for the test above: with the same field on the same
+    // root (no unrelated type involved), the self-update reassignment must
+    // still be rejected - proving the checker's root-gating isn't hiding a
+    // genuine field-level conflict, only correctly ignoring an unrelated one.
+    let src = r#"
+        record Meter {
+            value: f64,
+        }
+
+        fn main() {
+            let mut m: Meter = Meter { value: 1.0 };
+            let Meter { value: ref mv } = m;
+            m = m with { value: 99.0 };
+            assert(mv == 1.0);
+            return;
+        }
+    "#;
+    let err =
+        run_source(src).expect_err("same-root same-field self-update reassignment must conflict");
+    assert!(
+        matches!(err, RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)),
+        "expected a borrow/write conflict trap, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Repairs #1725 (FA-04-019): OWN0 roots serialized the frontend's own `SymbolId` while the VM's decode/remap already treated the wire `root` field as an index into the function's own string table — two identity domains that were never the same table, aligned only by numeric coincidence in simple pre-#1724 programs.

**Baseline:** `main @ 8387c46d17cafe5a283e7b72da55dcb00199c658` (verified before any work started).

## Investigation (confirmed by direct code inspection)

1. **`AccessPath.root`'s origin/domain** (`crates/sm-ir/src/legacy_lowering.rs`): built from `Expr::Var(name)` — the frontend's own spelling-interned `SymbolId` (`AstArena::intern_symbol`), an identity domain with zero relationship to any runtime table.
2. **Where OWN0 roots are serialized**: `emit_ownership_events` wrote `event.path.root.0` (the raw `SymbolId` number) directly into the wire `root: u32` field.
3. **How the function string table is built**: `emit_semcode_function` builds a `StringInterner` by walking every `IrInstr` and interning `LoadText`/`LoadVar`/`StoreVar`/`Call`/etc. string operands in first-use order — `emit_ownership_events` is called immediately after `interner.emit_table(&mut code)`, but never consulted `interner` at all.
4. **How the VM resolves OWN0 roots today**: `build_vm_program_view_from_decoded`'s `remap_paths` already does `let local_root = path.root_symbol_id as usize; symbol_ids.get(local_root)...` — i.e. it already treats the wire number as an index into this same function-local string table (`symbol_ids`, built in identical order from the same `strings`). The consumer's design already assumed the correct identity domain; only the producer wrote the wrong number. This same remap also carried a forbidden fail-open fallback — `.unwrap_or(SymbolId(path.root_symbol_id))` — for when that index was out of bounds: not merely wrong data, an explicit guess.
5. **Field/variant components**: `PathComponent::Field(SymbolId)` / `AdtPayload.variant: SymbolId` use the same raw-`SymbolId` representation as root did — but **verified, not assumed, to be a materially different situation, not the same bug**. See "Field/variant identity — verified, not assumed" below.
6. **Existing canonical identity authority**: yes — the function's own `StringInterner` (`interner.lookup`, already used identically for e.g. `LoadText`) is exactly the right authority; no second/duplicate symbol table was introduced.
7. **Repair location**: a minimal combination of sm-ir emission (resolve-at-construction via `LoweredLocalEnv`, resolve-at-emission via `StringInterner`) and VM decode/remap (fail-closed instead of guessing). No `sm-format` or `sm-verify` changes were needed — the wire format's `root: u32` slot is unchanged in shape, and neither of those crates references `root_symbol_id`'s value today.

## Before/after identity model (root only)

```
frontend lexical binding identity (SymbolId)
    -> lowered runtime-local key (LoweredLocalEnv::resolve, same authority StoreVar/LoadVar use)
    -> function-local artifact identity (StringInterner index, same table LoadVar/StoreVar operands share)
    -> OWN0 serialized root (u32 index into that table)
    -> VM resolves that exact artifact-local identity (remap_paths, now fail-closed on a miss)
```

`AccessPath.root`'s type changes from `SymbolId` to `String` (the resolved lowered-local key). Every real-lowering construction site resolves through `LoweredLocalEnv` at the point of construction, capturing the identity of whichever binding is lexically current — correct under shadowing, exactly mirroring how StoreVar/LoadVar already resolve.

## Field/variant identity — verified, not assumed (review follow-up)

An earlier version of this PR body claimed field/variant `SymbolId` components were "the identical broken assumption" as root and left deliberately deferred. Independent review correctly flagged that claim as unproven — asserted by extension from the root fix, not demonstrated. Investigated properly:

- Exhaustively grepped every consumer of `PathComponent::Field`/`AdtPayload::variant` across `sm-vm`, `sm-runtime-core`, and `sm-format`: **zero** call sites ever pass these values to `.resolve()`, use them as a table index, or display them. Their one and only consumer is `access_paths_overlap`:
  ```rust
  fn access_paths_overlap(lhs: &AccessPath, rhs: &AccessPath) -> bool {
      if lhs.root != rhs.root { return false; }
      let shared_len = lhs.components.len().min(rhs.components.len());
      lhs.components[..shared_len] == rhs.components[..shared_len]
  }
  ```
  root-gated first, then pure derived-`PartialEq` structural comparison — never resolved through `RuntimeSymbolTable`/`vm.symbols`.
- This makes the raw `SymbolId` value sufficient as an **opaque, deterministic equality key** (spelling-interned, so the same field/variant spelling always produces the same number within one compilation): a spelling collision with an *unrelated* root (e.g. two distinct record types both declaring a `value` field) can never reach the comparison at all, because the root-gate already filters to same-root-only comparisons; and within one root's own record/ADT type, every field or variant spelling is unique by construction (duplicate field names don't type-check). Root identity's bug was different in kind: the raw number *was* resolved, through the wrong table.
- Documented this explicitly on `PathComponent` in both crates that declare it (`crates/sm-runtime-core/src/lib.rs` is canonical; `crates/sm-ir/src/legacy_lowering.rs`'s copy points to it), so it isn't left implicit again.
- Added a proof pair to `tests/own0_root_identity_e2e.rs` (see Tests below), mutation-falsified.

No SemCode/artifact-format redesign was introduced for this — the finding closes the open question about field/variant identity with evidence, it doesn't require a fix, because there is no proven bug there.

## Corrective finding during requalification (#1709-adjacent, fixed within #1725's scope)

#1709's prescan producer (`append_record_update_write_events_from_expr`) walks the AST strictly ahead of and separately from real lowering. It can recurse into a match arm's own body while that body references a variable the same arm's own pattern introduces (`Option::Some(dir) => { match dir {...} }`) — a binding `LoweredLocalEnv` genuinely doesn't have yet, since real binding only happens later. Before #1725 this was silently wrong-but-usually-unconsumed (raw `SymbolId`, no resolution attempted); the new fail-closed resolve turned it into a hard compile failure on a real qualification fixture (`examples/qualification/match_surface/positive_nested_match`).

Fixed by gating the one prescan-internal resolve attempt (the match-scrutinee ADT-payload-borrow path) on whether any arm's pattern actually needs it — matching exactly when the computed path would ever be consumed. The common case (no such capture) never attempts a resolve that would otherwise fail closed for no reason; a genuine need still resolves correctly or fails closed with an honest diagnostic. No event is ever silently dropped.

## Production files changed

- `crates/sm-ir/src/legacy_lowering.rs` — `AccessPath.root` type change, `LoweredLocalEnv`-based resolution at construction sites, `StringInterner`-based resolution at emission, the prescan gating fix, `PathComponent` doc comment.
- `crates/sm-vm/src/semcode_vm.rs` — `remap_paths` fails closed (`RuntimeError::BadFormat`) instead of the removed `.unwrap_or` guess.
- `crates/sm-runtime-core/src/lib.rs` — `PathComponent` doc comment (the field/variant identity finding, canonical copy).
- `crates/sm-emit/src/lib.rs` — one pre-existing test updated to decode the actual string table and assert the wire root by resolved index, since `.root` is no longer a raw comparable number.

## Tests (`tests/own0_root_identity_e2e.rs`, new — 6 tests)

- `shadowed_binding_borrow_and_write_decode_to_distinct_string_table_roots` — direct wire-level decode proving an outer borrow and an inner shadowed reassignment resolve to two distinct string-table entries (both ending `_b`). Mutation-falsified: forcing the producer to always write index 0 collapses both roots to `"Box"` (caught by this test) — restored, confirmed green.
- `shadowed_binding_write_does_not_falsely_conflict_with_outer_borrow` / `same_binding_reassignment_still_conflicts_with_its_own_borrow` — VM-behavioral positive/negative pair: shadowing doesn't cause false conflicts; a genuine same-binding conflict is still rejected.
- `corrupted_own0_root_index_rejects_deterministically_on_load` — fail-closed negative: a hand-corrupted out-of-bounds OWN0 root index is rejected with `RuntimeError::BadFormat`, never silently accepted.
- `field_symbol_collision_across_unrelated_record_types_does_not_false_conflict` / `field_symbol_same_root_same_field_still_conflicts` — the field/variant proof pair (review follow-up): two unrelated record types sharing a field spelling must not be confused (root-gated); the same field on the same root must still conflict (negative control). Both use `x = x with { field: v }` self-update reassignment specifically — confirmed by direct experimentation to be the shape that actually routes a field-level `Write` `AccessPath` through the VM's StoreVar-time checker (`ensure_write_path_allowed` only fires when the reassigned symbol already exists as a local; a `with`-update into a *new* variable never reaches that check, which would have made a naive version of this test vacuous). Mutation-falsified: removing `access_paths_overlap`'s root-gate makes the positive test fail with the exact predicted false conflict — restored, confirmed green.

Plus `crates/sm-ir/src/legacy_lowering.rs::opt_tests::ssf08_1725_nested_match_on_arm_pattern_bound_scrutinee_does_not_fail_closed_when_unneeded` (mutation-falsified: reverting the gate reproduces the exact original `"cannot resolve lexical binding 'dir'"` failure — restored, confirmed green).

Existing `runtime_ownership_e2e.rs` and `sm-vm` unit tests required zero logic changes — the #1724-era test resolver already anticipated this exact representation. One assertion updated (`vm_tracks_borrowed_paths_on_frame_push`): its expected root string was itself only coincidentally `"pair"` before this fix (a stray fail-open match via an unrelated `Call`-target string sharing that text); now correctly the local's own key.

## Golden/snapshot fallout (same representation-drift class as #1724)

Regenerated 3 fixtures pinning compiled semcode bytes (`CTF-E1-PCC4`, `CTF-E2-SEQUENCE-ITERATION`, `CTF-E2-SEQUENCE-MUTATION`) — confirmed zero-semantic-drift (`source_hash`/`ir_hash`/`verifier_status`/`vm_status`/`all_runs_equal` all byte-identical) before regenerating.

## Boundaries confirmed untouched

- **#1726** (OWN0 event timing/ordering) — open, untouched. No OWN0 event timing semantics changed.
- **#1718** (capability/path-family) — open, untouched.
- **#1888** (FA-04-025 residual) — open, untouched.
- No SemCode/artifact-format redesign in this PR — root fix stays as originally scoped; the field/variant finding is evidence-only.

## Test plan

- [x] `cargo test -p sm-ir --lib` — 152/152
- [x] `cargo test -p sm-vm --lib` — 118/118
- [x] `cargo test -p sm-runtime-core` — clean
- [x] `cargo test --test own0_root_identity_e2e` — 6/6 (new; was 4/4 before the field/variant proof pair)
- [x] `cargo test --test runtime_ownership_e2e` — 34/34 (unchanged)
- [x] `cargo test --test lexical_binding_identity_e2e` — 10/10 (unchanged)
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace` — clean, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p sm-ir/-p sm-vm/-p sm-emit/-p sm-runtime-core --all-targets -- -D warnings` — clean (sm-vm's sole warning is the pre-existing, unrelated `VmProgramView.header` dead_code finding documented in #1724, predating this work)
- [x] `git diff --check` — clean

Closes #1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)
