### PR TITLE
fix(ownership): enforce explicit Sequence/ADT path-family authority

### DIFF
--- a/crates/sm-format/src/local_format.rs
+++ b/crates/sm-format/src/local_format.rs
@@ -19,6 +19,7 @@ pub const MAGIC17: [u8; 8] = *b"SEMCOD17";
 pub const MAGIC18: [u8; 8] = *b"SEMCOD18";
 pub const MAGIC19: [u8; 8] = *b"SEMCOD19";
 pub const MAGIC20: [u8; 8] = *b"SEMCOD20";
+pub const MAGIC21: [u8; 8] = *b"SEMCOD21";
 
 pub const CAP_DEBUG_SYMBOLS: u32 = 1 << 0;
 pub const CAP_F64_MATH: u32 = 1 << 1;
@@ -46,6 +47,25 @@ pub const CAP_PATH_INSPECT: u32 = 1 << 22;
 pub const CAP_FS_READ: u32 = 1 << 23;
 pub const CAP_FS_WRITE: u32 = 1 << 24;
 pub const CAP_TIME_DURATION: u32 = 1 << 25;
+/// #1718: explicit admission authority for `SequenceIndexStatic` ownership
+/// path components (both `Borrow` and `Write` events) - see
+/// `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`.
+/// Deliberately a *separate* bit from `CAP_OWNERSHIP_ADT_BORROW_PATHS` even
+/// though both are new in the same header revision: Sequence and ADT are two
+/// independently-decided admission domains (the frozen contract gave them
+/// different final dispositions - Sequence is fully admitted, ADT is
+/// Borrow-only), and folding them into one generic "extended ownership" bit
+/// would erase that distinction and make a future, separately-authorized
+/// change to just one of them impossible without repurposing this bit.
+pub const CAP_OWNERSHIP_SEQUENCE_PATHS: u32 = 1 << 26;
+/// #1718: explicit admission authority for `AdtPayload` ownership path
+/// components in `Borrow` events only. `Write(AdtPayload)` has no
+/// compiler-reachable production path and is unconditionally rejected at
+/// decode/verify regardless of header or capability - see this bit's sibling
+/// doc comment above and the frozen contract decision. A future, separately
+/// authorized promotion of `Write(AdtPayload)` must allocate its own
+/// capability, never reinterpret this one.
+pub const CAP_OWNERSHIP_ADT_BORROW_PATHS: u32 = 1 << 27;
 
 pub const SIGNATURE_SECTION_TAG: [u8; 4] = *b"SIG0";
 
@@ -428,11 +448,52 @@ pub const HEADER_V20: SemcodeHeaderSpec = SemcodeHeaderSpec {
     capabilities: HEADER_V19.capabilities,
 };
 
+/// #1718: the first header revision carrying explicit admission authority for
+/// `SequenceIndexStatic` (`Borrow`+`Write`) and `AdtPayload` (`Borrow` only)
+/// ownership path components - see
+/// `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`.
+/// Purely additive: `HEADER_V20`'s own capabilities, wire layout, and OWN0
+/// execution-site grammar (`SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION`) are
+/// unchanged and fully inherited - this revision answers only "which path
+/// components may this header's OWN0 section carry," an orthogonal question
+/// to "how are Borrow activation / Write execution sites encoded," which
+/// `HEADER_V20` already settled and this revision does not reopen.
+/// `Write(AdtPayload)` is deliberately NOT authorized by any capability here
+/// or added by any later header without a separate, dedicated decision - see
+/// `CAP_OWNERSHIP_ADT_BORROW_PATHS`'s doc comment.
+pub const HEADER_V21: SemcodeHeaderSpec = SemcodeHeaderSpec {
+    magic: MAGIC21,
+    epoch: 0,
+    rev: 22,
+    capabilities: HEADER_V20.capabilities
+        | CAP_OWNERSHIP_SEQUENCE_PATHS
+        | CAP_OWNERSHIP_ADT_BORROW_PATHS,
+};
+
+/// #1718: the minimum SemCode header revision whose capability contract
+/// authorizes `SequenceIndexStatic` ownership path components (`Borrow` and
+/// `Write` both). Named by numeric revision, not header index, to avoid the
+/// exact confusion `SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION`'s doc comment
+/// already warns about: this constant's value is `HEADER_V21.rev == 22`, not
+/// `21` (`HEADER_V20`'s revision) and not `20` (`HEADER_V19`'s).
+pub const SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION: u16 = HEADER_V21.rev;
+
+/// #1718: the minimum SemCode header revision whose capability contract
+/// authorizes `AdtPayload` ownership path components in `Borrow` events.
+/// Deliberately has no `Write`-side counterpart - `Write(AdtPayload)` is not
+/// admitted under any header revision, current or future, without a
+/// separate, explicitly authorized contract change (see
+/// `CAP_OWNERSHIP_ADT_BORROW_PATHS`). Same numeric value as
+/// `SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION` (`HEADER_V21.rev == 22`) today,
+/// kept as a distinct named constant because the two families' admission
+/// authority is independently decided and may diverge in a future revision.
+pub const SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION: u16 = HEADER_V21.rev;
+
 pub fn supported_headers() -> &'static [SemcodeHeaderSpec] {
     &[
         HEADER_V0, HEADER_V1, HEADER_V2, HEADER_V3, HEADER_V4, HEADER_V5, HEADER_V6, HEADER_V7,
         HEADER_V8, HEADER_V9, HEADER_V10, HEADER_V11, HEADER_V12, HEADER_V13, HEADER_V14,
-        HEADER_V15, HEADER_V16, HEADER_V17, HEADER_V18, HEADER_V19, HEADER_V20,
+        HEADER_V15, HEADER_V16, HEADER_V17, HEADER_V18, HEADER_V19, HEADER_V20, HEADER_V21,
     ]
 }
 

--- a/crates/sm-format/src/semcode_decode.rs
+++ b/crates/sm-format/src/semcode_decode.rs
@@ -505,6 +505,28 @@ fn parse_string_table_debug_and_ownership(
                         components.push(DecodedAccessPathComponent::FieldSymbol(field));
                     }
                     OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD => {
+                        // #1718: `Write(AdtPayload)` is not an admitted
+                        // SemCode ownership path under any header revision,
+                        // current or future, without a separate, explicitly
+                        // authorized contract change - see
+                        // `CAP_OWNERSHIP_ADT_BORROW_PATHS`'s doc comment.
+                        // Checked before `Borrow`'s revision floor below so
+                        // the rejection reason is unambiguous even at/above
+                        // `SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION`.
+                        if kind == OWNERSHIP_EVENT_KIND_WRITE {
+                            return Err(DecodeError::InvalidOwnershipSection {
+                                offset: diag_offset(base_offset, cursor),
+                                msg: "Write(AdtPayload) is not an admitted ownership path \
+                                      under any header revision",
+                            });
+                        }
+                        if header_rev < SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION {
+                            return Err(DecodeError::InvalidOwnershipSection {
+                                offset: diag_offset(base_offset, cursor),
+                                msg: "Borrow(AdtPayload) requires a header at or above \
+                                      SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION",
+                            });
+                        }
                         let variant = read_u32_le(code, &mut cursor).map_err(|_| {
                             DecodeError::InvalidOwnershipSection {
                                 offset: diag_offset(base_offset, cursor),
@@ -520,6 +542,16 @@ fn parse_string_table_debug_and_ownership(
                         components.push(DecodedAccessPathComponent::AdtPayload { variant, index });
                     }
                     OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX => {
+                        // #1718: admitted for both Borrow and Write, but only
+                        // at or above the header revision that carries
+                        // explicit Sequence ownership capability authority.
+                        if header_rev < SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION {
+                            return Err(DecodeError::InvalidOwnershipSection {
+                                offset: diag_offset(base_offset, cursor),
+                                msg: "SequenceIndexStatic requires a header at or above \
+                                      SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION",
+                            });
+                        }
                         let index = read_u32_le(code, &mut cursor).map_err(|_| {
                             DecodeError::InvalidOwnershipSection {
                                 offset: diag_offset(base_offset, cursor),
@@ -663,7 +695,7 @@ fn parse_string_table_debug_and_ownership(
 mod tests {
     use super::*;
 
-    fn sequence_ownership_semcode_bytes(index: u32) -> Vec<u8> {
+    fn sequence_ownership_code_bytes(index: u32) -> Vec<u8> {
         let mut code = Vec::new();
         code.extend_from_slice(&0u16.to_le_bytes());
         code.extend_from_slice(&OWNERSHIP_SECTION_TAG);
@@ -673,11 +705,20 @@ mod tests {
         code.extend_from_slice(&1u16.to_le_bytes());
         code.push(OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX);
         code.extend_from_slice(&index.to_le_bytes());
+        code
+    }
 
+    // #1718: retained under its original (pre-#1718) name and shape - this
+    // helper predates the path-family capability gate and was the fixture
+    // `decode_sequence_index_static_ownership_component` used to prove
+    // successful decode under `MAGIC11`. It now proves the opposite (legacy
+    // rejection); see that test below.
+    fn sequence_ownership_semcode_bytes(index: u32) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&MAGIC11);
         bytes.extend_from_slice(&4u16.to_le_bytes());
         bytes.extend_from_slice(b"main");
+        let code = sequence_ownership_code_bytes(index);
         bytes.extend_from_slice(&(code.len() as u32).to_le_bytes());
         bytes.extend_from_slice(&code);
         bytes
@@ -816,16 +857,186 @@ mod tests {
         assert_eq!(checked_end(97, 4, 100), None);
     }
 
+    // #1718: header-grammar-aware ownership-event fixture builders. Unlike
+    // `sequence_ownership_code_bytes` above (frozen at MAGIC11's pre-rev21
+    // grammar on purpose, for the legacy-rejection test that reuses it),
+    // these build a well-formed event for *any* header revision under test -
+    // at/above `SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION` (21) every event
+    // carries a mode/execution byte (see `decode_rev21_header_borrow_frame_entry_round_trips`
+    // and `decode_rev21_header_write_event_store_var_site_round_trips` above),
+    // and at/above `SEMCODE_SIGNATURE_MIN_REVISION` (20) every function
+    // envelope carries a `SIG0` section. Getting this wrong would make a
+    // rejection test pass for the wrong reason (malformed bytes) instead of
+    // the reason under test (missing path-family capability authority).
+    fn ownership_borrow_event_bytes(
+        header_rev: u16,
+        component_kind: u8,
+        component_payload: &[u8],
+    ) -> Vec<u8> {
+        let mut code = Vec::new();
+        code.extend_from_slice(&0u16.to_le_bytes()); // empty string table
+        code.extend_from_slice(&OWNERSHIP_SECTION_TAG);
+        code.extend_from_slice(&1u16.to_le_bytes()); // 1 ownership event
+        code.push(OWNERSHIP_EVENT_KIND_BORROW);
+        if header_rev >= SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION {
+            code.push(ACTIVATION_MODE_FRAME_ENTRY);
+        }
+        code.extend_from_slice(&0u32.to_le_bytes()); // root_symbol_id
+        code.extend_from_slice(&1u16.to_le_bytes()); // 1 component
+        code.push(component_kind);
+        code.extend_from_slice(component_payload);
+        if header_rev >= SEMCODE_SIGNATURE_MIN_REVISION {
+            code.extend_from_slice(&empty_sig0());
+        }
+        code
+    }
+
+    fn ownership_write_event_bytes(
+        header_rev: u16,
+        component_kind: u8,
+        component_payload: &[u8],
+    ) -> Vec<u8> {
+        let mut code = Vec::new();
+        code.extend_from_slice(&0u16.to_le_bytes());
+        code.extend_from_slice(&OWNERSHIP_SECTION_TAG);
+        code.extend_from_slice(&1u16.to_le_bytes());
+        code.push(OWNERSHIP_EVENT_KIND_WRITE);
+        if header_rev >= SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION {
+            code.push(WRITE_EXECUTION_MODE_STORE_VAR_SITE);
+            code.extend_from_slice(&0u32.to_le_bytes()); // executable anchor
+        }
+        code.extend_from_slice(&0u32.to_le_bytes()); // root_symbol_id
+        code.extend_from_slice(&1u16.to_le_bytes());
+        code.push(component_kind);
+        code.extend_from_slice(component_payload);
+        if header_rev >= SEMCODE_SIGNATURE_MIN_REVISION {
+            code.extend_from_slice(&empty_sig0());
+        }
+        code
+    }
+
+    fn magic_rev(magic: [u8; 8]) -> u16 {
+        header_spec_from_magic(&magic).expect("known magic").rev
+    }
+
+    // #1718: before the path-family capability gate, `MAGIC11` (bare
+    // `CAP_OWNERSHIP_PATHS`, tuple-only per `docs/spec/semcode.md`) admitted
+    // a `SequenceIndexStatic` component with no contract authority for it at
+    // all - the exact gap the frozen decision (PR #1895) requires closed.
+    // This is now a legacy fail-closed rejection test, not a positive one.
     #[test]
-    fn decode_sequence_index_static_ownership_component() {
+    fn decode_sequence_index_static_ownership_component_rejected_under_legacy_header() {
         let bytes = sequence_ownership_semcode_bytes(7);
-        let (_, functions) = decode_semcode_envelope(&bytes).expect("decode");
+        let err = decode_semcode_envelope(&bytes).expect_err("must reject under MAGIC11");
+        assert!(matches!(err, DecodeError::InvalidOwnershipSection { .. }));
+    }
+
+    #[test]
+    fn decode_sequence_index_static_ownership_component_admitted_under_v21() {
+        let code = ownership_borrow_event_bytes(
+            magic_rev(MAGIC21),
+            OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX,
+            &7u32.to_le_bytes(),
+        );
+        let bytes = function_bytes_with_header(MAGIC21, "main", &code);
+        let (header, functions) = decode_semcode_envelope(&bytes).expect("decode under V21");
+        assert_eq!(header.rev, SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION);
         let env = &functions[0];
         assert_eq!(env.borrowed_paths.len(), 1);
         assert_eq!(
             env.borrowed_paths[0].components,
             vec![DecodedAccessPathComponent::SequenceIndexStatic(7)]
         );
+    }
+
+    #[test]
+    fn decode_sequence_write_rejected_under_legacy_header() {
+        let code = ownership_write_event_bytes(
+            magic_rev(MAGIC20),
+            OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX,
+            &3u32.to_le_bytes(),
+        );
+        let bytes = function_bytes_with_header(MAGIC20, "main", &code);
+        let err = decode_semcode_envelope(&bytes).expect_err("must reject under MAGIC20");
+        assert!(matches!(err, DecodeError::InvalidOwnershipSection { .. }));
+    }
+
+    #[test]
+    fn decode_sequence_write_admitted_under_v21() {
+        let code = ownership_write_event_bytes(
+            magic_rev(MAGIC21),
+            OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX,
+            &3u32.to_le_bytes(),
+        );
+        let bytes = function_bytes_with_header(MAGIC21, "main", &code);
+        let (_, functions) = decode_semcode_envelope(&bytes).expect("decode under V21");
+        assert_eq!(functions[0].write_paths.len(), 1);
+        assert_eq!(
+            functions[0].write_paths[0].components,
+            vec![DecodedAccessPathComponent::SequenceIndexStatic(3)]
+        );
+    }
+
+    fn adt_payload_bytes(variant: u32, index: u16) -> Vec<u8> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&variant.to_le_bytes());
+        payload.extend_from_slice(&index.to_le_bytes());
+        payload
+    }
+
+    #[test]
+    fn decode_adt_borrow_rejected_under_legacy_header() {
+        for magic in [MAGIC11, MAGIC12, MAGIC20] {
+            let code = ownership_borrow_event_bytes(
+                magic_rev(magic),
+                OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD,
+                &adt_payload_bytes(9, 1),
+            );
+            let bytes = function_bytes_with_header(magic, "main", &code);
+            let err = decode_semcode_envelope(&bytes).expect_err(
+                "Borrow(AdtPayload) must reject below SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION",
+            );
+            assert!(matches!(err, DecodeError::InvalidOwnershipSection { .. }));
+        }
+    }
+
+    #[test]
+    fn decode_adt_borrow_admitted_under_v21() {
+        let code = ownership_borrow_event_bytes(
+            magic_rev(MAGIC21),
+            OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD,
+            &adt_payload_bytes(9, 1),
+        );
+        let bytes = function_bytes_with_header(MAGIC21, "main", &code);
+        let (_, functions) = decode_semcode_envelope(&bytes).expect("decode under V21");
+        assert_eq!(functions[0].borrowed_paths.len(), 1);
+        assert_eq!(
+            functions[0].borrowed_paths[0].components,
+            vec![DecodedAccessPathComponent::AdtPayload {
+                variant: 9,
+                index: 1
+            }]
+        );
+    }
+
+    // #1718: `Write(AdtPayload)` is unconditionally rejected - not merely
+    // "not yet promoted" - under every header, including V21, which DOES
+    // carry `CAP_OWNERSHIP_ADT_BORROW_PATHS`. The frozen contract (PR #1895)
+    // admits ADT Borrow only; Write is a distinct, independently-decided
+    // admission domain.
+    #[test]
+    fn decode_adt_write_rejected_under_every_header_including_v21() {
+        for magic in [MAGIC11, MAGIC12, MAGIC20, MAGIC21] {
+            let code = ownership_write_event_bytes(
+                magic_rev(magic),
+                OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD,
+                &adt_payload_bytes(9, 1),
+            );
+            let bytes = function_bytes_with_header(magic, "main", &code);
+            let err = decode_semcode_envelope(&bytes)
+                .expect_err("Write(AdtPayload) must reject under every header");
+            assert!(matches!(err, DecodeError::InvalidOwnershipSection { .. }));
+        }
     }
 
     // #1773 (FA-09-005) format tests: the SIG0 section.

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -4,12 +4,12 @@ use crate::semcode_format::{
     header_spec_from_magic, write_f64_le, write_i32_le, write_u16_le, write_u32_le,
     CallableValueFamily, Opcode, ACTIVATION_MODE_FRAME_ENTRY, ACTIVATION_MODE_STORE_VAR_SITE,
     MAGIC0, MAGIC1, MAGIC10, MAGIC11, MAGIC12, MAGIC13, MAGIC14, MAGIC15, MAGIC16, MAGIC17,
-    MAGIC18, MAGIC19, MAGIC2, MAGIC20, MAGIC3, MAGIC4, MAGIC5, MAGIC6, MAGIC7, MAGIC8, MAGIC9,
-    OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE, OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL,
-    OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,
-    OWNERSHIP_SECTION_TAG, SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION, SEMCODE_SIGNATURE_MIN_REVISION,
-    SIGNATURE_SECTION_TAG, WRITE_EXECUTION_MODE_MAKE_RECORD_SITE,
-    WRITE_EXECUTION_MODE_STORE_VAR_SITE,
+    MAGIC18, MAGIC19, MAGIC2, MAGIC20, MAGIC21, MAGIC3, MAGIC4, MAGIC5, MAGIC6, MAGIC7, MAGIC8,
+    MAGIC9, OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE,
+    OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX,
+    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
+    SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION, SEMCODE_SIGNATURE_MIN_REVISION, SIGNATURE_SECTION_TAG,
+    WRITE_EXECUTION_MODE_MAKE_RECORD_SITE, WRITE_EXECUTION_MODE_STORE_VAR_SITE,
 };
 use sm_front::types::{
     AdtCtorExpr, ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily,
@@ -1360,20 +1360,41 @@ pub fn emit_ir_to_semcode(
 }
 
 fn emit_semcode(funcs: &[IrFunction], debug_symbols: bool) -> Result<Vec<u8>, FrontendError> {
+    // #1718: fail closed at the single producer boundary every public
+    // emission entrypoint converges on (`compile_program_to_semcode_*` and
+    // `emit_ir_to_semcode` both call this function) - before any header is
+    // chosen, before any bytes are written. `Write(AdtPayload)` is not
+    // "unreachable today so it's fine to skip checking" - the frozen
+    // contract (PR #1895) requires deterministic rejection of this exact
+    // internal state regardless of how it was constructed, including
+    // hand-built `IrFunction` values that never went through source lowering
+    // at all. No silent drop, no downgrade to a parent/Tuple/Field path, no
+    // "emit it and let the verifier catch it" - refuse emission outright.
+    if has_adt_write_ownership_event(funcs) {
+        return Err(FrontendError {
+            pos: 0,
+            message: "internal error: a Write ownership event carries an AdtPayload path \
+                      component, which is not an admitted SemCode ownership path under the \
+                      current Stable Foundation contour (#1718) - emission refused"
+                .to_string(),
+        });
+    }
+
     let mut out = Vec::new();
     // require_ownership_section: whenever the chosen header includes CAP_OWNERSHIP_PATHS,
     // every function must have an OWN0 section (even if empty) so the verifier check passes.
     let opcode_driven_magic: [u8; 8];
     let opcode_driven_require_ownership_section;
-    // #1726 Checkpoint D2a: content-driven, exactly like every other branch
-    // here (never SIG0-style unconditional) - only artifacts whose Borrow
-    // events actually resolved a StoreVarSite anchor (Checkpoint D1) need the
-    // rev21 OWN0 grammar. The downstream `chosen_magic` composition step
-    // (below) already handles this floor correctly with zero changes: it
-    // compares `opcode_driven_header.rev` against `SEMCODE_SIGNATURE_MIN_REVISION`
-    // (20) as a plain number, and 21 is never less than 20 - proved in
-    // Checkpoint D1.5 before this branch was added.
-    if has_v20_ownership_execution_anchor(funcs) {
+    // #1718: checked first (highest revision requirement in this chain) so a
+    // program needing BOTH V20's exact-site OWN0 grammar AND V21's
+    // Sequence/ADT-Borrow admission authority correctly promotes to V21,
+    // which is purely additive over V20 (same OWN0 layout, same execution-site
+    // grammar - see `HEADER_V21`'s doc comment) and therefore satisfies both
+    // requirements at once.
+    if has_v21_sequence_ownership_events(funcs) || has_v21_adt_borrow_ownership_events(funcs) {
+        opcode_driven_magic = MAGIC21;
+        opcode_driven_require_ownership_section = true;
+    } else if has_v20_ownership_execution_anchor(funcs) {
         opcode_driven_magic = MAGIC20;
         opcode_driven_require_ownership_section = true;
     } else if has_v18_qtruth_instr(funcs) {
@@ -2596,6 +2617,67 @@ fn has_v20_ownership_execution_anchor(funcs: &[IrFunction]) -> bool {
         f.ownership_events.iter().any(|event| {
             (event.kind == OwnershipPathEventKind::Borrow && event.activation_site.is_some())
                 || (event.kind == OwnershipPathEventKind::Write && event.write_site.is_some())
+        })
+    })
+}
+
+/// #1718: true when any function's ownership events contain a
+/// `SequenceIndexStatic` path component, in either `Borrow` or `Write`
+/// events - the frozen contract (PR #1895) admits both event kinds for this
+/// family, so unlike `has_v12_record_field_ownership_events` this predicate
+/// does not need to distinguish event kind at all.
+fn has_v21_sequence_ownership_events(funcs: &[IrFunction]) -> bool {
+    funcs.iter().any(|f| {
+        f.ownership_events.iter().any(|event| {
+            event
+                .path
+                .components
+                .iter()
+                .any(|component| matches!(component, PathComponent::SequenceIndexStatic(_)))
+        })
+    })
+}
+
+/// #1718: true when any function's `Borrow` ownership events contain an
+/// `AdtPayload` path component. Deliberately Borrow-only - the frozen
+/// contract admits ADT payload ownership in `Borrow` events only; a `Write`
+/// event carrying `AdtPayload` is not "not yet promoted," it is
+/// unconditionally rejected (see `has_adt_write_ownership_event` and
+/// `CAP_OWNERSHIP_ADT_BORROW_PATHS`'s doc comment), so this predicate must
+/// never be widened to also match `Write` without a separate, explicitly
+/// authorized contract change.
+fn has_v21_adt_borrow_ownership_events(funcs: &[IrFunction]) -> bool {
+    funcs.iter().any(|f| {
+        f.ownership_events.iter().any(|event| {
+            event.kind == OwnershipPathEventKind::Borrow
+                && event
+                    .path
+                    .components
+                    .iter()
+                    .any(|component| matches!(component, PathComponent::AdtPayload { .. }))
+        })
+    })
+}
+
+/// #1718: true when any function's `Write` ownership events contain an
+/// `AdtPayload` path component. No source syntax reaches this today (the
+/// language has no mutable ADT-payload reassignment), so this should only
+/// ever fire for hand-constructed/synthetic `IrFunction` values passed
+/// directly to `emit_ir_to_semcode` - but the producer boundary must fail
+/// closed regardless of how such a state was constructed, per the frozen
+/// contract's explicit "cannot prove -> deterministic rejection" invariant.
+/// `emit_semcode` checks this unconditionally, before any header selection,
+/// and refuses emission entirely rather than silently dropping, downgrading,
+/// or rewriting the event.
+fn has_adt_write_ownership_event(funcs: &[IrFunction]) -> bool {
+    funcs.iter().any(|f| {
+        f.ownership_events.iter().any(|event| {
+            event.kind == OwnershipPathEventKind::Write
+                && event
+                    .path
+                    .components
+                    .iter()
+                    .any(|component| matches!(component, PathComponent::AdtPayload { .. }))
         })
     })
 }
@@ -12631,10 +12713,22 @@ mod opt_tests {
     }
 
     // Mixed artifact: an ADT/Option/Result Borrow (FrameEntry) alongside a
-    // Tuple/Record Borrow (StoreVarSite) in the same rev21 program. Because
-    // header revision is artifact-global, the ADT event's FrameEntry mode
-    // must still be explicitly encoded once the artifact is rev21 -- it does
-    // not stay in the legacy shape just because its own producer didn't change.
+    // Tuple/Record Borrow (StoreVarSite) in the same program. Because header
+    // revision is artifact-global, the ADT event's FrameEntry mode must
+    // still be explicitly encoded once the artifact carries the rev21 OWN0
+    // grammar -- it does not stay in the legacy shape just because its own
+    // producer didn't change.
+    //
+    // #1718 update: this program's `Option::Some(ref value)` arm produces a
+    // real `Borrow(AdtPayload)` event (`Option` is represented via the ADT
+    // runtime family), so this artifact now also carries
+    // `CAP_OWNERSHIP_ADT_BORROW_PATHS` and promotes one revision further, to
+    // `HEADER_V21`/`SEMCOD21` (rev22) - purely additive over `HEADER_V20`
+    // (same FrameEntry/StoreVarSite OWN0 grammar this test's own name and
+    // assertions are about, unchanged). Before #1718, ADT Borrow had no
+    // dedicated capability at all, so this same source only ever reached
+    // `SEMCOD20`; the magic/rev assertions below were updated for that
+    // reason, not because this test's own D2a subject matter changed.
     #[test]
     fn ssf08_1726_checkpoint_d2a_mixed_frame_entry_and_store_var_site_in_one_rev21_artifact() {
         let src = r#"
@@ -12654,7 +12748,7 @@ mod opt_tests {
         let ir = compile_program_to_ir_with_options(src, CompileProfile::RustLike, OptLevel::O0)
             .expect("compiles");
         let bytes = emit_ir_to_semcode(&ir, false).expect("emit full artifact");
-        assert_eq!(&bytes[0..8], b"SEMCOD20");
+        assert_eq!(&bytes[0..8], b"SEMCOD21");
         let (_, decoded) = crate::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
         let decoded_main = decoded.iter().find(|f| f.name == "main").expect("main");
         assert_eq!(decoded_main.borrowed_paths.len(), 2);

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -8,10 +8,11 @@ use sm_format::semcode_format::{
     read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, Opcode, SemcodeFormatError,
     SemcodeHeaderSpec, CAP_ARGS_READ, CAP_CLOCK_READ, CAP_CLOSURE_VALUES, CAP_DEBUG_SYMBOLS,
     CAP_EVENT_POST, CAP_F64_MATH, CAP_FS_READ, CAP_FS_WRITE, CAP_FX_MATH, CAP_FX_VALUES,
-    CAP_GATE_SURFACE, CAP_MAP_VALUES, CAP_OWNERSHIP_FIELD_PATHS, CAP_OWNERSHIP_PATHS,
-    CAP_PATH_INSPECT, CAP_PRNG, CAP_SEQUENCE_ITERATION, CAP_SEQUENCE_VALUES, CAP_STATE_QUERY,
-    CAP_STATE_UPDATE, CAP_STDERR_WRITE, CAP_STDIN_READ_TEXT, CAP_STDOUT, CAP_STDOUT_WRITE,
-    CAP_TEXT_VALUES, CAP_TIME_DURATION,
+    CAP_GATE_SURFACE, CAP_MAP_VALUES, CAP_OWNERSHIP_ADT_BORROW_PATHS, CAP_OWNERSHIP_FIELD_PATHS,
+    CAP_OWNERSHIP_PATHS, CAP_OWNERSHIP_SEQUENCE_PATHS, CAP_PATH_INSPECT, CAP_PRNG,
+    CAP_SEQUENCE_ITERATION, CAP_SEQUENCE_VALUES, CAP_STATE_QUERY, CAP_STATE_UPDATE,
+    CAP_STDERR_WRITE, CAP_STDIN_READ_TEXT, CAP_STDOUT, CAP_STDOUT_WRITE, CAP_TEXT_VALUES,
+    CAP_TIME_DURATION,
 };
 use sm_runtime_core::RuntimeQuotas;
 use std::collections::HashSet;
@@ -1234,22 +1235,71 @@ fn verify_function_code(
 
     let has_ownership_section = env.has_ownership_section;
     let mut has_record_field_ownership = false;
-    for p in env.borrowed_paths.iter().chain(env.write_paths.iter()) {
+    // #1718: `has_sequence_ownership` and `has_adt_borrow_ownership` feed the
+    // same `used_caps`/`missing_caps` capability-consistency mechanism
+    // `has_record_field_ownership` already uses below - this is the
+    // verifier's OWN independent authority over the frozen path-family
+    // contract, not a check that trusts `sm-format`'s decode-time gate to
+    // have already done this work. `has_adt_write_ownership` is tracked
+    // separately from `borrowed_paths`/`write_paths` (not chained together,
+    // unlike the loop this replaces) specifically so a `Write` event's
+    // `AdtPayload` component can never be silently folded into
+    // `has_adt_borrow_ownership` - the two are independently-decided
+    // admission domains (see
+    // `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`)
+    // and must never share one accounting flag.
+    let mut has_sequence_ownership = false;
+    let mut has_adt_borrow_ownership = false;
+    let mut has_adt_write_ownership = false;
+    for p in env.borrowed_paths.iter() {
         for c in &p.components {
             match c {
                 sm_format::semcode_decode::DecodedAccessPathComponent::FieldSymbol(_) => {
                     has_record_field_ownership = true;
                 }
                 sm_format::semcode_decode::DecodedAccessPathComponent::AdtPayload { .. } => {
+                    has_adt_borrow_ownership = true;
                     // Variant is a global SymbolId; it cannot be bounds-checked
                     // against the local string table. Structural acceptance only.
                 }
                 sm_format::semcode_decode::DecodedAccessPathComponent::SequenceIndexStatic(_) => {
-                    // Static sequence index ownership is structurally accepted.
+                    has_sequence_ownership = true;
                 }
                 _ => {}
             }
         }
+    }
+    for p in env.write_paths.iter() {
+        for c in &p.components {
+            match c {
+                sm_format::semcode_decode::DecodedAccessPathComponent::FieldSymbol(_) => {
+                    has_record_field_ownership = true;
+                }
+                sm_format::semcode_decode::DecodedAccessPathComponent::AdtPayload { .. } => {
+                    has_adt_write_ownership = true;
+                }
+                sm_format::semcode_decode::DecodedAccessPathComponent::SequenceIndexStatic(_) => {
+                    has_sequence_ownership = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // #1718: unconditional rejection, independent of capability. No header
+    // revision or capability bit - present, future, or hypothetically
+    // reinterpreted - authorizes `Write(AdtPayload)`; this is not a missing-
+    // capability situation (`CapabilityViolation`) that a wider header could
+    // ever cure, so it is checked and rejected before, and separately from,
+    // the capability-consistency check below.
+    if has_adt_write_ownership {
+        return Err(reject_one(
+            name,
+            VerificationCode::InvalidOwnershipSection,
+            0,
+            "Write(AdtPayload) is not an admitted SemCode ownership path under any header \
+             revision (#1718)",
+        ));
     }
 
     let code = env.code_slice;
@@ -1420,6 +1470,19 @@ fn verify_function_code(
     }
     if has_record_field_ownership {
         used_caps |= CAP_OWNERSHIP_FIELD_PATHS;
+    }
+    // #1718: reuses the exact same capability-consistency mechanism as
+    // `CAP_OWNERSHIP_FIELD_PATHS` above - a header below
+    // `SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION`/
+    // `SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION` lacks these bits entirely,
+    // so `missing_caps` below naturally rejects it without any new rejection
+    // path. `has_adt_write_ownership` never reaches here - it already
+    // returned `Err` above, unconditionally, before this point.
+    if has_sequence_ownership {
+        used_caps |= CAP_OWNERSHIP_SEQUENCE_PATHS;
+    }
+    if has_adt_borrow_ownership {
+        used_caps |= CAP_OWNERSHIP_ADT_BORROW_PATHS;
     }
 
     let missing_caps = used_caps & !header.capabilities;
@@ -4219,7 +4282,7 @@ mod tests {
     use super::*;
     use sm_format::semcode_format::{
         read_u16_le, read_u32_le, CallableValueFamily, MAGIC0, MAGIC10, MAGIC11, MAGIC18, MAGIC20,
-        MAGIC3, MAGIC4, MAGIC5, MAGIC6, MAGIC7, OWNERSHIP_SECTION_TAG,
+        MAGIC21, MAGIC3, MAGIC4, MAGIC5, MAGIC6, MAGIC7, OWNERSHIP_SECTION_TAG,
     };
     use sm_ir::{
         compile_program_to_semcode, compile_program_to_semcode_with_options_debug,
@@ -5160,10 +5223,17 @@ mod tests {
             }
         "#;
         let bytes = compile_program_to_semcode(src).expect("compile");
-        assert_eq!(&bytes[..MAGIC20.len()], &MAGIC20);
+        // #1718: this program's `Option::Some(ref value)` arm is a real
+        // `Borrow(AdtPayload)` event (`Option` is ADT-represented), which
+        // now requires `CAP_OWNERSHIP_ADT_BORROW_PATHS` and promotes one
+        // revision past `HEADER_V20`/rev21 (this test's original D2b
+        // subject), to `HEADER_V21`/rev22 - purely additive, same OWN0
+        // grammar. Before #1718, ADT Borrow had no dedicated capability, so
+        // this program only ever reached `MAGIC20`/rev21.
+        assert_eq!(&bytes[..MAGIC21.len()], &MAGIC21);
         let verified = verify_semcode(&bytes)
             .expect("D2b must admit a mixed FrameEntry+StoreVarSite artifact");
-        assert_eq!(verified.header.rev, 21);
+        assert_eq!(verified.header.rev, 22);
     }
 
     #[test]
@@ -5204,19 +5274,42 @@ mod tests {
         );
     }
 
+    // #1718 update: this test's original claim - a FrameEntry-only ADT
+    // Borrow (no StoreVarSite anchor anywhere) never gets promoted to the
+    // rev21 anchor grammar - is no longer true in general, and cannot be:
+    // #1718 requires `CAP_OWNERSHIP_ADT_BORROW_PATHS` for ANY `AdtPayload`
+    // Borrow event regardless of activation mode, and that capability first
+    // exists at `HEADER_V21`/rev22, which is unconditionally >=
+    // `SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION` (21). What the original D2b
+    // checkpoint actually cared about - that the anchor *mechanism itself*
+    // (`has_v20_ownership_execution_anchor`) is not what's driving
+    // promotion here, since there is no StoreVarSite anywhere - remains true
+    // and is what this renamed test now asserts directly: the artifact is
+    // admitted, promoted by the *ADT-Borrow* capability requirement, and its
+    // Borrow event still faithfully encodes `FrameEntry`, not a spuriously
+    // invented anchor.
     #[test]
-    fn checkpoint_d2b_legacy_rev20_borrow_admitted_unchanged() {
-        // ADT/Option/Result Borrow events stay FrameEntry-only (D1 never
-        // touches this producer); with no StoreVarSite anchor anywhere in
-        // the artifact, `has_v20_ownership_execution_anchor` never fires and
-        // the header never reaches rev21, so this program's Borrow event
-        // takes the pre-D2b legacy grammar path through admission.
+    fn checkpoint_1718_frame_entry_only_adt_borrow_admitted_via_adt_capability_not_anchor() {
         let bytes = adt_payload_ownership_semcode_bytes();
         let verified =
-            verify_semcode(&bytes).expect("legacy FrameEntry-only artifact must still admit");
-        assert!(
-            verified.header.rev < sm_format::semcode_format::SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION,
-            "a FrameEntry-only program must never be promoted to the rev21 anchor grammar"
+            verify_semcode(&bytes).expect("FrameEntry-only ADT Borrow artifact must admit");
+        assert_eq!(
+            verified.header.rev,
+            sm_format::semcode_format::SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION,
+            "promotion here must land exactly on the ADT-Borrow capability floor, not higher"
+        );
+        let (_, decoded) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let read_payload = decoded
+            .iter()
+            .find(|f| f.name == "read_payload")
+            .expect("read_payload");
+        assert_eq!(read_payload.borrowed_paths.len(), 1);
+        assert_eq!(
+            read_payload.borrowed_paths[0].activation,
+            Some(sm_format::semcode_decode::DecodedBorrowActivation::FrameEntry),
+            "the ADT producer's Borrow event must stay FrameEntry - promotion here is driven \
+             by the #1718 ADT-Borrow capability requirement, not by the anchor mechanism"
         );
     }
 
@@ -10781,6 +10874,16 @@ mod tests {
         let component_kind_offset = section_offset + 4 + 2 + 1 + 1 + 4 + 4 + 2;
         code[component_kind_offset] =
             sm_format::semcode_format::OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX;
+        // #1718: a real emitter faced with a `SequenceIndexStatic` component
+        // would promote the header to `HEADER_V21`/`MAGIC21` (see
+        // `has_v21_sequence_ownership_events` in `sm-ir`) - this helper
+        // patches the component-kind byte in isolation (the base fixture's
+        // real header only reflects a Field Borrow), so it must patch the
+        // header magic to match what a real compiler would have chosen for
+        // this content, or the resulting artifact would understate its own
+        // capability requirement and get rejected for a reason unrelated to
+        // whatever the calling test actually wants to exercise.
+        bytes[0..8].copy_from_slice(&sm_format::semcode_format::MAGIC21);
         bytes
     }
 

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -1178,6 +1178,141 @@ fn validate_write_execution_site_anchors(
     Ok(())
 }
 
+/// #1718 (I4.1): the verifier's independent ownership path-family capability
+/// contract, extracted into its own function so it is directly testable at
+/// the Rust level - given a header and the already-decoded `borrowed_paths`/
+/// `write_paths`, with no byte-level decode involved at all.
+///
+/// This extraction exists because of a real gap mutation M4b found during
+/// the #1718 implementation checkpoint: `sm-format`'s decode-time gate
+/// already rejects a `Write(AdtPayload)` artifact (or a `Sequence`/
+/// `AdtPayload`-Borrow artifact under too old a header) before
+/// `verify_function_code`'s body is ever reached through the public,
+/// byte-oriented API (`verify_semcode`/`verify_semcode_token` both decode
+/// first) - so removing *this* function's own rejection, while leaving
+/// `sm-format`'s decode-time gate intact, changed nothing any end-to-end
+/// test could observe. The frozen contract requires the verifier to
+/// independently enforce this policy, not merely inherit decode's
+/// enforcement by accident of call order; this function is the seam that
+/// makes that independent enforcement exercisable on its own terms (see
+/// `verifier_rejects_adt_payload_write_independently_of_decoder` below,
+/// and its own mutation-M4b proof).
+///
+/// Owns exactly: `Field`/`Sequence`/ADT-Borrow capability accounting, and
+/// the unconditional ADT-Write rejection. Does **not** own
+/// `CAP_OWNERSHIP_PATHS`/`has_ownership_section` accounting, which predates
+/// #1718 and is unaffected by it - that stays in `verify_function_code`
+/// alongside debug-symbol and opcode-driven capability accounting, all of
+/// which feed one shared, combined `missing_caps` diagnostic there.
+///
+/// Returns the ownership-family capability bits this function's content
+/// actually requires (to be folded into the caller's own `used_caps`) on
+/// success, or a `RejectReport` if `Write(AdtPayload)` is present (always,
+/// regardless of header) or if the header lacks a capability this content
+/// requires.
+#[cfg(feature = "std")]
+fn verify_ownership_path_family_contract(
+    name: &str,
+    header: &SemcodeHeaderSpec,
+    borrowed_paths: &[sm_format::semcode_decode::DecodedAccessPath],
+    write_paths: &[sm_format::semcode_decode::DecodedAccessPath],
+) -> Result<u32, RejectReport> {
+    let mut has_record_field_ownership = false;
+    // #1718: `has_sequence_ownership` and `has_adt_borrow_ownership` feed the
+    // same capability-consistency mechanism `has_record_field_ownership`
+    // already uses below - this is the verifier's OWN independent authority
+    // over the frozen path-family contract, not a check that trusts
+    // `sm-format`'s decode-time gate to have already done this work.
+    // `has_adt_write_ownership` is tracked separately from `borrowed_paths`/
+    // `write_paths` (not chained together) specifically so a `Write` event's
+    // `AdtPayload` component can never be silently folded into
+    // `has_adt_borrow_ownership` - the two are independently-decided
+    // admission domains (see
+    // `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`)
+    // and must never share one accounting flag.
+    let mut has_sequence_ownership = false;
+    let mut has_adt_borrow_ownership = false;
+    let mut has_adt_write_ownership = false;
+    for p in borrowed_paths {
+        for c in &p.components {
+            match c {
+                sm_format::semcode_decode::DecodedAccessPathComponent::FieldSymbol(_) => {
+                    has_record_field_ownership = true;
+                }
+                sm_format::semcode_decode::DecodedAccessPathComponent::AdtPayload { .. } => {
+                    has_adt_borrow_ownership = true;
+                    // Variant is a global SymbolId; it cannot be bounds-checked
+                    // against the local string table. Structural acceptance only.
+                }
+                sm_format::semcode_decode::DecodedAccessPathComponent::SequenceIndexStatic(_) => {
+                    has_sequence_ownership = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    for p in write_paths {
+        for c in &p.components {
+            match c {
+                sm_format::semcode_decode::DecodedAccessPathComponent::FieldSymbol(_) => {
+                    has_record_field_ownership = true;
+                }
+                sm_format::semcode_decode::DecodedAccessPathComponent::AdtPayload { .. } => {
+                    has_adt_write_ownership = true;
+                }
+                sm_format::semcode_decode::DecodedAccessPathComponent::SequenceIndexStatic(_) => {
+                    has_sequence_ownership = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // #1718: unconditional rejection, independent of capability. No header
+    // revision or capability bit - present, future, or hypothetically
+    // reinterpreted - authorizes `Write(AdtPayload)`; this is not a missing-
+    // capability situation (`CapabilityViolation`) that a wider header could
+    // ever cure, so it is checked and rejected before, and separately from,
+    // the capability-consistency check below.
+    if has_adt_write_ownership {
+        return Err(reject_one(
+            name,
+            VerificationCode::InvalidOwnershipSection,
+            0,
+            "Write(AdtPayload) is not an admitted SemCode ownership path under any header \
+             revision (#1718)",
+        ));
+    }
+
+    let mut used_caps = 0u32;
+    if has_record_field_ownership {
+        used_caps |= CAP_OWNERSHIP_FIELD_PATHS;
+    }
+    if has_sequence_ownership {
+        used_caps |= CAP_OWNERSHIP_SEQUENCE_PATHS;
+    }
+    if has_adt_borrow_ownership {
+        used_caps |= CAP_OWNERSHIP_ADT_BORROW_PATHS;
+    }
+
+    let missing_caps = used_caps & !header.capabilities;
+    if missing_caps != 0 {
+        return Err(reject_one(
+            name,
+            VerificationCode::CapabilityViolation,
+            0,
+            format!(
+                "function requires capability bits 0x{missing_caps:08x}, but header '{}' \
+                 provides only 0x{:08x}",
+                String::from_utf8_lossy(&header.magic),
+                header.capabilities
+            ),
+        ));
+    }
+
+    Ok(used_caps)
+}
+
 #[cfg(feature = "std")]
 fn verify_function_code(
     env: &sm_format::semcode_decode::DecodedFunctionEnvelope,
@@ -1234,73 +1369,12 @@ fn verify_function_code(
     }
 
     let has_ownership_section = env.has_ownership_section;
-    let mut has_record_field_ownership = false;
-    // #1718: `has_sequence_ownership` and `has_adt_borrow_ownership` feed the
-    // same `used_caps`/`missing_caps` capability-consistency mechanism
-    // `has_record_field_ownership` already uses below - this is the
-    // verifier's OWN independent authority over the frozen path-family
-    // contract, not a check that trusts `sm-format`'s decode-time gate to
-    // have already done this work. `has_adt_write_ownership` is tracked
-    // separately from `borrowed_paths`/`write_paths` (not chained together,
-    // unlike the loop this replaces) specifically so a `Write` event's
-    // `AdtPayload` component can never be silently folded into
-    // `has_adt_borrow_ownership` - the two are independently-decided
-    // admission domains (see
-    // `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`)
-    // and must never share one accounting flag.
-    let mut has_sequence_ownership = false;
-    let mut has_adt_borrow_ownership = false;
-    let mut has_adt_write_ownership = false;
-    for p in env.borrowed_paths.iter() {
-        for c in &p.components {
-            match c {
-                sm_format::semcode_decode::DecodedAccessPathComponent::FieldSymbol(_) => {
-                    has_record_field_ownership = true;
-                }
-                sm_format::semcode_decode::DecodedAccessPathComponent::AdtPayload { .. } => {
-                    has_adt_borrow_ownership = true;
-                    // Variant is a global SymbolId; it cannot be bounds-checked
-                    // against the local string table. Structural acceptance only.
-                }
-                sm_format::semcode_decode::DecodedAccessPathComponent::SequenceIndexStatic(_) => {
-                    has_sequence_ownership = true;
-                }
-                _ => {}
-            }
-        }
-    }
-    for p in env.write_paths.iter() {
-        for c in &p.components {
-            match c {
-                sm_format::semcode_decode::DecodedAccessPathComponent::FieldSymbol(_) => {
-                    has_record_field_ownership = true;
-                }
-                sm_format::semcode_decode::DecodedAccessPathComponent::AdtPayload { .. } => {
-                    has_adt_write_ownership = true;
-                }
-                sm_format::semcode_decode::DecodedAccessPathComponent::SequenceIndexStatic(_) => {
-                    has_sequence_ownership = true;
-                }
-                _ => {}
-            }
-        }
-    }
-
-    // #1718: unconditional rejection, independent of capability. No header
-    // revision or capability bit - present, future, or hypothetically
-    // reinterpreted - authorizes `Write(AdtPayload)`; this is not a missing-
-    // capability situation (`CapabilityViolation`) that a wider header could
-    // ever cure, so it is checked and rejected before, and separately from,
-    // the capability-consistency check below.
-    if has_adt_write_ownership {
-        return Err(reject_one(
-            name,
-            VerificationCode::InvalidOwnershipSection,
-            0,
-            "Write(AdtPayload) is not an admitted SemCode ownership path under any header \
-             revision (#1718)",
-        ));
-    }
+    // #1718 (I4.1): extracted into its own function so it is directly,
+    // independently testable at the Rust level - see
+    // `verify_ownership_path_family_contract`'s own doc comment for why
+    // this extraction exists (mutation M4b's finding).
+    let ownership_family_caps =
+        verify_ownership_path_family_contract(name, header, &env.borrowed_paths, &env.write_paths)?;
 
     let code = env.code_slice;
     let mut cursor = env.instr_start_offset;
@@ -1468,22 +1542,15 @@ fn verify_function_code(
     if has_ownership_section {
         used_caps |= CAP_OWNERSHIP_PATHS;
     }
-    if has_record_field_ownership {
-        used_caps |= CAP_OWNERSHIP_FIELD_PATHS;
-    }
-    // #1718: reuses the exact same capability-consistency mechanism as
-    // `CAP_OWNERSHIP_FIELD_PATHS` above - a header below
-    // `SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION`/
-    // `SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION` lacks these bits entirely,
-    // so `missing_caps` below naturally rejects it without any new rejection
-    // path. `has_adt_write_ownership` never reaches here - it already
-    // returned `Err` above, unconditionally, before this point.
-    if has_sequence_ownership {
-        used_caps |= CAP_OWNERSHIP_SEQUENCE_PATHS;
-    }
-    if has_adt_borrow_ownership {
-        used_caps |= CAP_OWNERSHIP_ADT_BORROW_PATHS;
-    }
+    // #1718 (I4.1): Field/Sequence/ADT-Borrow capability accounting now
+    // lives in `verify_ownership_path_family_contract`, which already
+    // independently checked these bits against `header.capabilities` on its
+    // own terms (see that function). Folding its result into this function's
+    // own `used_caps`/`missing_caps` pass keeps a single combined diagnostic
+    // for callers that also care about opcode-driven/debug-symbol
+    // capabilities, without re-deriving or duplicating the ownership-family
+    // policy itself.
+    used_caps |= ownership_family_caps;
 
     let missing_caps = used_caps & !header.capabilities;
     if missing_caps != 0 {
@@ -5311,6 +5378,110 @@ mod tests {
             "the ADT producer's Borrow event must stay FrameEntry - promotion here is driven \
              by the #1718 ADT-Borrow capability requirement, not by the anchor mechanism"
         );
+    }
+
+    // #1718 (I4.1): direct, Rust-level tests of
+    // `verify_ownership_path_family_contract`, with no byte-level decode
+    // involved at all - constructing `DecodedAccessPath` values directly and
+    // calling the verifier's own policy function. These exist because
+    // mutation M4b found that removing this function's `Write(AdtPayload)`
+    // rejection, while leaving `sm-format`'s decode-time gate intact, broke
+    // no existing test: `verify_semcode`/`verify_semcode_token` both decode
+    // first, so a `Write(AdtPayload)` artifact never reaches this function's
+    // body through the public API. `verifier_rejects_adt_payload_write_independently_of_decoder`
+    // below is the one that closes that gap - it must not obtain its input
+    // by decoding bytes, or it would prove the same thing the decoder-level
+    // tests already prove, not this function's own independent authority.
+    mod ownership_path_family_contract_tests {
+        use super::*;
+        use sm_format::semcode_decode::{
+            DecodedAccessPath, DecodedAccessPathComponent, DecodedBorrowActivation,
+        };
+        use sm_format::semcode_format::{HEADER_V20, HEADER_V21};
+
+        fn path(components: Vec<DecodedAccessPathComponent>) -> DecodedAccessPath {
+            DecodedAccessPath {
+                root_symbol_id: 0,
+                components,
+                activation: Some(DecodedBorrowActivation::FrameEntry),
+                write_execution: None,
+            }
+        }
+
+        #[test]
+        fn v21_sequence_borrow_admitted() {
+            let borrowed = vec![path(vec![DecodedAccessPathComponent::SequenceIndexStatic(
+                0,
+            )])];
+            verify_ownership_path_family_contract("f", &HEADER_V21, &borrowed, &[])
+                .expect("V21 must admit Sequence Borrow");
+        }
+
+        #[test]
+        fn v21_sequence_write_admitted() {
+            let write = vec![path(vec![DecodedAccessPathComponent::SequenceIndexStatic(
+                0,
+            )])];
+            verify_ownership_path_family_contract("f", &HEADER_V21, &[], &write)
+                .expect("V21 must admit Sequence Write");
+        }
+
+        #[test]
+        fn v21_adt_borrow_admitted() {
+            let borrowed = vec![path(vec![DecodedAccessPathComponent::AdtPayload {
+                variant: 9,
+                index: 0,
+            }])];
+            verify_ownership_path_family_contract("f", &HEADER_V21, &borrowed, &[])
+                .expect("V21 must admit ADT Borrow");
+        }
+
+        // The critical test (I4.1's acceptance criterion): proves the
+        // verifier's OWN rejection, independent of sm-format's decode-time
+        // gate - the input here was never decoded from bytes at all, so
+        // decoder cannot have "already caught this" the way it does for
+        // every other test in this file that goes through
+        // decode_semcode_envelope/verify_semcode/verify_semcode_token.
+        #[test]
+        fn verifier_rejects_adt_payload_write_independently_of_decoder() {
+            let write = vec![path(vec![DecodedAccessPathComponent::AdtPayload {
+                variant: 9,
+                index: 0,
+            }])];
+            let report = verify_ownership_path_family_contract("f", &HEADER_V21, &[], &write)
+                .expect_err("verifier must independently reject Write(AdtPayload)");
+            assert_eq!(
+                report.diagnostics[0].code,
+                VerificationCode::InvalidOwnershipSection
+            );
+        }
+
+        #[test]
+        fn v20_sequence_rejected_for_missing_capability() {
+            let borrowed = vec![path(vec![DecodedAccessPathComponent::SequenceIndexStatic(
+                0,
+            )])];
+            let report = verify_ownership_path_family_contract("f", &HEADER_V20, &borrowed, &[])
+                .expect_err("V20 lacks CAP_OWNERSHIP_SEQUENCE_PATHS");
+            assert_eq!(
+                report.diagnostics[0].code,
+                VerificationCode::CapabilityViolation
+            );
+        }
+
+        #[test]
+        fn v20_adt_borrow_rejected_for_missing_capability() {
+            let borrowed = vec![path(vec![DecodedAccessPathComponent::AdtPayload {
+                variant: 9,
+                index: 0,
+            }])];
+            let report = verify_ownership_path_family_contract("f", &HEADER_V20, &borrowed, &[])
+                .expect_err("V20 lacks CAP_OWNERSHIP_ADT_BORROW_PATHS");
+            assert_eq!(
+                report.diagnostics[0].code,
+                VerificationCode::CapabilityViolation
+            );
+        }
     }
 
     // #1726 Checkpoint D2b, item 8 fail-closed / adversarial tests, all

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -7613,47 +7613,117 @@ mod tests {
         }
     }
 
+    // #1718 reconciliation: before this checkpoint, the five tests below
+    // proved the VM's borrow-conflict machinery correctly evaluated
+    // `Write(AdtPayload)` overlap (same-payload conflicts, different
+    // index/variant don't, parent/child overlaps either direction conflict)
+    // via a synthetic, hand-patched artifact (`adt_payload_write_overlap_bytes`,
+    // `rewrite_adt_main_ownership_section`). That artifact-level surface is
+    // now, correctly, not admitted at all: `Write(AdtPayload)` fails closed
+    // at decode/verify regardless of header, before the VM's overlap logic
+    // is ever reached (see `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`).
+    // The five scenarios below are consolidated into one test proving this
+    // rejection is unconditional - it does not matter what the synthetic
+    // events' *would-be* overlap relationship was, every one of them is
+    // refused identically and for the identical reason. This is exactly the
+    // "artifact-level Write(AdtPayload) must now fail before execution"
+    // requirement, using an even more adversarial construction than a
+    // hand-built decode fixture: a *rewritten* real artifact, proving the
+    // rejection survives this specific downgrade/re-encode path too.
+    //
+    // The overlap-detection logic itself (`access_paths_overlap`) is still
+    // real production code other path families depend on - its correctness
+    // for `AdtPayload`'s specific shape is now proven directly, at the Rust
+    // level, by `access_paths_overlap_adt_payload_mechanism_tests` below,
+    // entirely independent of whether `AdtPayload` is an admitted artifact
+    // surface for any particular event kind.
     #[test]
-    fn vm_rejects_adt_payload_write_when_borrowed_same_payload() {
-        let bytes = adt_payload_write_overlap_bytes(Some((42, 0)), Some((42, 0)));
-        let err = run_semcode(&bytes).expect_err("same ADT payload overlap must fail");
-        assert!(matches!(
-            err,
-            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)
-        ));
-        assert_eq!(format!("{err}"), "write path overlaps active borrow");
+    fn vm_rejects_synthetic_adt_payload_write_artifact_regardless_of_overlap_shape() {
+        type AdtPayloadSpec = Option<(u32, u16)>;
+        let scenarios: [(AdtPayloadSpec, AdtPayloadSpec); 5] = [
+            (Some((42, 0)), Some((42, 0))), // same payload
+            (Some((42, 0)), Some((42, 1))), // different index
+            (Some((42, 0)), Some((43, 0))), // different variant
+            (None, Some((42, 0))),          // parent borrow, child write
+            (Some((42, 0)), None),          // child borrow, parent write
+        ];
+        for (borrowed_adt, write_adt) in scenarios {
+            let bytes = adt_payload_write_overlap_bytes(borrowed_adt, write_adt);
+            let err = run_semcode(&bytes).expect_err(
+                "a Write(AdtPayload) event must be rejected before execution regardless of \
+                 its overlap relationship with any Borrow event",
+            );
+            assert!(
+                matches!(err, RuntimeError::BadFormat(_)),
+                "expected artifact-level rejection (BadFormat), got {err:?} for \
+                 borrowed={borrowed_adt:?} write={write_adt:?}"
+            );
+        }
     }
 
-    #[test]
-    fn vm_allows_adt_payload_write_when_borrowed_different_index() {
-        let bytes = adt_payload_write_overlap_bytes(Some((42, 0)), Some((42, 1)));
-        run_semcode(&bytes).expect("different index does not overlap");
-    }
+    // #1718: internal overlap-mechanism tests only - these call
+    // `access_paths_overlap`/`ensure_write_path_allowed` directly, at the
+    // Rust level, with no SemCode encoding/decoding/verification involved
+    // at all. They prove the overlap math itself still correctly handles
+    // `PathComponent::AdtPayload`'s equality-based shape (same reasoning
+    // `#1725` already established for `Field`'s opaque `SymbolId` treatment)
+    // - they are NOT evidence that `Write(AdtPayload)` is an admitted
+    // artifact surface, which the test above proves it is not.
+    mod access_paths_overlap_adt_payload_mechanism_tests {
+        use super::*;
 
-    #[test]
-    fn vm_allows_adt_payload_write_when_borrowed_different_variant() {
-        let bytes = adt_payload_write_overlap_bytes(Some((42, 0)), Some((43, 0)));
-        run_semcode(&bytes).expect("different variant does not overlap");
-    }
+        fn adt_payload_path(root: u32, variant: u32, index: u16) -> AccessPath {
+            AccessPath::new(SymbolId(root)).adt_payload(SymbolId(variant), index)
+        }
 
-    #[test]
-    fn vm_rejects_adt_payload_write_when_borrowed_parent_overlaps_child() {
-        let bytes = adt_payload_write_overlap_bytes(None, Some((42, 0)));
-        let err = run_semcode(&bytes).expect_err("adt parent-child overlap must fail");
-        assert!(matches!(
-            err,
-            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)
-        ));
-    }
+        #[test]
+        fn same_payload_overlaps() {
+            let borrow = adt_payload_path(1, 42, 0);
+            let write = adt_payload_path(1, 42, 0);
+            assert!(access_paths_overlap(&write, &borrow));
+            assert!(matches!(
+                ensure_write_path_allowed(&write, &[borrow]),
+                Err(RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict))
+            ));
+        }
 
-    #[test]
-    fn vm_rejects_adt_payload_write_when_borrowed_child_overlaps_parent() {
-        let bytes = adt_payload_write_overlap_bytes(Some((42, 0)), None);
-        let err = run_semcode(&bytes).expect_err("adt child-parent overlap must fail");
-        assert!(matches!(
-            err,
-            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)
-        ));
+        #[test]
+        fn different_index_does_not_overlap() {
+            let borrow = adt_payload_path(1, 42, 0);
+            let write = adt_payload_path(1, 42, 1);
+            assert!(!access_paths_overlap(&write, &borrow));
+            assert_eq!(ensure_write_path_allowed(&write, &[borrow]), Ok(()));
+        }
+
+        #[test]
+        fn different_variant_does_not_overlap() {
+            let borrow = adt_payload_path(1, 42, 0);
+            let write = adt_payload_path(1, 43, 0);
+            assert!(!access_paths_overlap(&write, &borrow));
+            assert_eq!(ensure_write_path_allowed(&write, &[borrow]), Ok(()));
+        }
+
+        #[test]
+        fn parent_borrow_overlaps_child_write() {
+            let borrow = AccessPath::new(SymbolId(1)); // parent: root only
+            let write = adt_payload_path(1, 42, 0); // child: root.AdtPayload
+            assert!(access_paths_overlap(&write, &borrow));
+            assert!(matches!(
+                ensure_write_path_allowed(&write, &[borrow]),
+                Err(RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict))
+            ));
+        }
+
+        #[test]
+        fn child_borrow_overlaps_parent_write() {
+            let borrow = adt_payload_path(1, 42, 0); // child: root.AdtPayload
+            let write = AccessPath::new(SymbolId(1)); // parent: root only
+            assert!(access_paths_overlap(&write, &borrow));
+            assert!(matches!(
+                ensure_write_path_allowed(&write, &[borrow]),
+                Err(RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict))
+            ));
+        }
     }
 
     fn record_field_write_overlap_bytes(

--- a/docs/architecture/adt_payload_ownership_paths.md
+++ b/docs/architecture/adt_payload_ownership_paths.md
@@ -11,13 +11,34 @@ To solve this cleanly, we introduce ADT Payload ownership path vocabulary *befor
 
 1. **`sm-format`**: Introduced `OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD`. The binary format represents this as `[tag: 1 byte] + [variant_symbol_id: 4 bytes] + [payload_index: 2 bytes]`.
 2. **`sm-runtime-core`**: The runtime representation `AccessPath` uses `PathComponent::AdtPayload { variant: SymbolId, index: u16 }` to describe stable paths into ADTs.
-3. **`sm-verify`**: The verifier structurally accepts the `AdtPayload` component and asserts that the `variant` symbol ID is within bounds of the string table.
+3. **`sm-verify`**: The verifier structurally accepts the `AdtPayload` component in `Borrow` events. The `variant` `SymbolId` is **not** bounds-checked against the string table - it is used exclusively as an opaque, root-gated equality key inside the VM's overlap check (`access_paths_overlap`), the same treatment `#1725` already established for `Field`'s `SymbolId`. A `Write` event carrying an `AdtPayload` component is rejected unconditionally, under every header, regardless of capability (#1718).
 
 ### Why not just an `index`?
 A naive solution would use `AdtPayloadIndex(u16)`, analogous to a tuple index. But different variants in the same enum can have payloads with identical indices (`Some(T)` vs `Data(T)`). Dropping the variant tag creates paths that can falsely overlap or improperly alias if the variant changes, rendering it unsuitable for the stable runtime ownership checker. Including the `variant` ensures a safe, non-colliding alias path (e.g. `Option::Some.0` does not collide with `Result::Err.0`).
 
-## What remains
-This document describes only the *vocabulary* layer.
+## Current status (updated for #1718)
 
-- **Lowering**: `sm-ir` does not yet emit these paths. (Pending ADT-2)
-- **Runtime Borrows**: `sm-vm` does not yet process these paths in match expressions. (Pending ADT-3)
+This document originally described only the *vocabulary* layer, before
+lowering or VM semantics existed for it. Both now exist and are qualified:
+
+- **Lowering**: `sm-ir` emits `Borrow(AdtPayload)` for real source
+  (`match value { MyEnum::Variant(ref inner) => ... }`), proven by a
+  real-source positive E2E test
+  (`vm_runs_adt_payload_ownership_positive_e2e_path`,
+  `crates/sm-vm/src/semcode_vm.rs`). No source syntax produces
+  `Write(AdtPayload)` - the language has no mutable ADT-payload
+  reassignment - so lowering never emits it, and the producer boundary
+  (`emit_semcode` in `crates/sm-ir/src/legacy_lowering.rs`) fails closed if
+  one is ever constructed internally/synthetically.
+- **Runtime Borrows**: `sm-vm` processes `Borrow(AdtPayload)` in match
+  expressions and enforces overlap against later writes through the same
+  `AccessPath`/`access_paths_overlap` machinery used for tuple/record/
+  sequence paths.
+- **Admission contract (#1718)**: `Borrow(AdtPayload)` requires
+  `CAP_OWNERSHIP_ADT_BORROW_PATHS`, carried starting `HEADER_V21`/`SEMCOD21`
+  (rev 22). `Write(AdtPayload)` is rejected unconditionally, under every
+  header including `SEMCOD21`, regardless of capability - this is not a
+  missing-capability gap; promoting it requires a new, separately authorized
+  contract change. Full evidence and rationale:
+  `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`
+  and `docs/spec/runtime_ownership.md`.

--- a/docs/spec/runtime_ownership.md
+++ b/docs/spec/runtime_ownership.md
@@ -1,6 +1,6 @@
 # Runtime Ownership Specification
 
-Status: frozen tuple+record v0
+Status: frozen tuple+record+sequence+(ADT Borrow-only) v1 (#1718)
 Source ownership owner: `sm-front`
 IR ownership owner: `sm-ir`
 SemCode transport owner: `sm-ir`
@@ -10,20 +10,30 @@ Shared runtime vocabulary owner: `sm-runtime-core`
 
 ## Purpose
 
-This document freezes the current runtime ownership contract for tuple paths
-and direct record field paths.
+This document freezes the current runtime ownership contract for tuple
+paths, direct record field paths, `Sequence` static-index paths, and ADT
+payload paths in `Borrow` events only.
 
 Current supported slice:
 
 - tuple `AccessPath`
 - direct record field `AccessPath`
-- `Borrow` and `Write` ownership events for both supported path families
+- `Sequence` static-index `AccessPath` (`SequenceIndexStatic`), both `Borrow`
+  and `Write` (#1718)
+- ADT payload `AccessPath` (`AdtPayload`), `Borrow` events only - `Write`
+  events carrying an `AdtPayload` component are not part of this contract
+  and are rejected unconditionally at admission, under every header,
+  regardless of capability (#1718)
+- `Borrow` and `Write` ownership events for tuple, direct record field, and
+  `Sequence` static-index paths; `Borrow`-only for ADT payload paths
 - frame-local borrow lifetime
 - structural `OWN0` admission before execution
-- runtime write rejection for overlapping borrowed tuple and direct record
-  field paths
+- runtime write rejection for overlapping borrowed tuple, direct record
+  field, `Sequence` static-index, and ADT payload paths
 
-This document does not claim a general runtime borrow checker.
+This document does not claim a general runtime borrow checker, general ADT
+mutation, alias analysis, lifetimes/regions, or Rust-equivalent borrow
+checking.
 
 ## Public Position
 
@@ -34,9 +44,10 @@ value paths and runtime invariants inside this bounded, frame-local model.
 Semantic does not claim Rust-equivalent lifetime inference, region
 inference, general borrow checking, unrestricted alias analysis, or
 systems-language memory-safety equivalence. The decision record also names
-known implementation gaps inside this frozen tuple/record slice (OWN0 root
-identity and event-timing correctness) that remain open repair work, not
-positioning questions.
+known implementation gaps inside this frozen ownership slice (OWN0 root
+identity and event-timing correctness, since closed - see Lane 2, #1709/
+#1724/#1725/#1726/#1891) that were open repair work, not positioning
+questions.
 
 ## Layer Separation
 
@@ -46,8 +57,9 @@ The current ownership pipeline is intentionally split:
 - IR/lowering preserves only the canonical execution-path contract
 - SemCode transports that lowered ownership metadata in `OWN0`
 - verifier admits or rejects the `OWN0` payload structurally
-- VM enforces the runtime write-path guard over admitted tuple and direct
-  record field paths
+- VM enforces the runtime write-path guard over admitted tuple, direct
+  record field, `Sequence` static-index, and ADT payload (`Borrow`-only)
+  paths
 
 Important rule:
 
@@ -64,6 +76,11 @@ Current supported component kinds:
 
 - `TupleIndex(u16)`
 - `Field(SymbolId)` for direct named record field projection only
+- `SequenceIndexStatic(u32)`, admitted in both `Borrow` and `Write` events
+  (#1718)
+- `AdtPayload { variant: SymbolId, index: u16 }`, admitted in `Borrow` events
+  only - a `Write` event carrying this component is rejected
+  unconditionally, not merely deferred (#1718)
 
 Current ordering rule:
 
@@ -78,13 +95,14 @@ Important boundary:
 
 ## Supported Behavior
 
-Current supported runtime ownership behavior covers tuple paths and direct
-record field paths.
+Current supported runtime ownership behavior covers tuple paths, direct
+record field paths, `Sequence` static-index paths (`Borrow` and `Write`),
+and ADT payload paths (`Borrow` only).
 
 Borrow lifetime v0:
 
-- a borrowed tuple or direct record field path becomes active for the current
-  frame
+- a borrowed tuple, direct record field, `Sequence` static-index, or ADT
+  payload path becomes active for the current frame
 - the active borrowed-path set is cleared when that frame exits
 
 Current runtime write rule:
@@ -101,18 +119,26 @@ Current allowed case:
 
 - sibling tuple paths
 - sibling direct record fields
+- sibling `Sequence` static indices
+- sibling ADT payload variants/indices (evaluated only against a real
+  `Borrow`; no genuine `Write(AdtPayload)` artifact is admissible to
+  exercise this case in practice - see `## Explicitly Unsupported`)
 
 ## Frontend And Lowering Contract
 
 Current source/frontend contract:
 
-- tuple and direct record field borrow/write intent must not be erased before
-  lowering
+- tuple, direct record field, and `Sequence` static-index borrow/write
+  intent, and ADT payload borrow intent, must not be erased before lowering
 - lowering must preserve enough ownership metadata to recover:
   - borrow event kind
   - write event kind
   - canonical `AccessPath`
   - direct record field projection as `Field(SymbolId)` when present
+  - `Sequence` static-index projection as `SequenceIndexStatic(u32)` when
+    present
+  - ADT payload projection as `AdtPayload { variant, index }` when present
+    (`Borrow` events only)
 
 Current lowering contract:
 
@@ -125,6 +151,8 @@ Current binary contract:
 
 - tuple-only ownership metadata is transported through `SEMCOD11`
 - direct record-field `Borrow`/`Write` transport is emitted through `SEMCOD12`
+- `Sequence` static-index `Borrow`/`Write` transport, and ADT payload
+  `Borrow`-only transport, are emitted through `SEMCOD21` (#1718)
 - the ownership section tag is `OWN0`
 - each event carries:
   - event kind (`Borrow` or `Write`)
@@ -136,9 +164,19 @@ Current transport scope:
 - tuple-only path components admitted end-to-end through `SEMCOD11`
 - direct record-field `Borrow`/`Write` transport, encoded as `Field(SymbolId)`,
   admitted end-to-end through `SEMCOD12`
+- `Sequence` static-index `Borrow`/`Write` transport, encoded as
+  `SequenceIndexStatic(u32)`, admitted end-to-end through `SEMCOD21`
+- ADT payload `Borrow`-only transport, encoded as
+  `AdtPayload { variant, index }`, admitted end-to-end through `SEMCOD21`;
+  the identical component in a `Write` event is rejected unconditionally,
+  under every header
 - deterministic event order
 - `CAP_OWNERSHIP_PATHS` remains the tuple ownership capability family
 - `CAP_OWNERSHIP_FIELD_PATHS` marks direct record-field ownership path transport
+- `CAP_OWNERSHIP_SEQUENCE_PATHS` marks `Sequence` static-index ownership path
+  transport (#1718)
+- `CAP_OWNERSHIP_ADT_BORROW_PATHS` marks ADT payload `Borrow`-only ownership
+  path transport (#1718)
 
 ## Verifier Admission Contract
 
@@ -146,10 +184,16 @@ Current verifier responsibility:
 
 - validate `OWN0` section structure
 - validate admitted ownership event kinds
-- validate tuple and direct record-field path payload shape
-- validate header/capability consistency for ownership transport
-- admit valid `Borrow(Field)` and `Write(Field)` payloads structurally
-- reject malformed or unsupported record ownership payload before execution
+- validate tuple, direct record-field, `Sequence` static-index, and ADT
+  payload path payload shape
+- validate header/capability consistency for ownership transport,
+  independently re-derived from decoded content for each path family
+  (#1718) - not delegated to `sm-format`'s own decode-time gate
+- admit valid `Borrow(Field)`, `Write(Field)`, `Borrow(SequenceIndexStatic)`,
+  `Write(SequenceIndexStatic)`, and `Borrow(AdtPayload)` payloads structurally
+- reject `Write(AdtPayload)` unconditionally, before and independent of
+  capability accounting, under every header (#1718)
+- reject malformed or unsupported ownership payload before execution
 
 Current verifier non-goal:
 
@@ -160,10 +204,12 @@ Current verifier non-goal:
 
 Current VM responsibility:
 
-- keep a frame-local set of active borrowed tuple and direct record field paths
+- keep a frame-local set of active borrowed tuple, direct record field,
+  `Sequence` static-index, and ADT payload paths
 - consume admitted ownership metadata only
-- reject overlapping writes at runtime for the supported tuple and direct
-  record field slice
+- reject overlapping writes at runtime for the supported tuple, direct
+  record field, `Sequence` static-index, and ADT payload (`Borrow`-only)
+  slice
 - surface ownership conflicts through `BorrowWriteConflict`
 
 Current VM non-goals:
@@ -189,12 +235,21 @@ Legacy artifact execution (#1891 Checkpoint W2F):
 
 The current implemented runtime ownership contract does not claim support for:
 
-- ADT payload paths
-- schema paths
+- `Write(AdtPayload)` - ADT payload paths are supported in `Borrow` events
+  only; a `Write` event carrying an `AdtPayload` component is rejected
+  unconditionally at admission, under every header, regardless of
+  capability. No source syntax reaches this today (the language has no
+  mutable ADT-payload reassignment), and promoting it later requires a new,
+  separately authorized contract change - not an incidental relaxation of
+  this document or of #1718's own mechanism (see
+  `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`)
+- `Map`/schema paths
 - partial borrow release before frame exit
 - advanced aliasing or region reasoning
 - inter-frame borrow persistence
 - indirect field selection or broader smart path normalization
+- general ADT mutation beyond `Borrow`-only payload access, general alias
+  analysis, lifetimes/regions, or Rust-equivalent borrow checking
 
 ## Honesty Rule
 

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -94,10 +94,12 @@ Current supported header family:
 - `SEMCOD14`
 - `SEMCOD18`
 - `SEMCOD19`
+- `SEMCOD21`
 
-`SEMCOD15`, `SEMCOD16`, and `SEMCOD17` are also currently emitted/admitted
-by the toolchain but are not yet documented in this section; that is a
-pre-existing documentation gap, not part of the #1732 repair.
+`SEMCOD15`, `SEMCOD16`, `SEMCOD17`, and `SEMCOD20` are also currently
+emitted/admitted by the toolchain but are not yet documented in this
+section; that is a pre-existing documentation gap, not part of the #1732 or
+#1718 repairs.
 
 Observed runtime support in the current toolchain:
 
@@ -118,6 +120,7 @@ Observed runtime support in the current toolchain:
 - `SEMCOD14`: epoch `0`, revision `15`
 - `SEMCOD18`: epoch `0`, revision `19`
 - `SEMCOD19`: epoch `0`, revision `20`
+- `SEMCOD21`: epoch `0`, revision `22`
 
 Header responsibilities:
 
@@ -346,6 +349,40 @@ survives unchanged through IR and SemCode emission - see
 [`vm.md`](vm.md#callable-runtime-family-enforcement) for how it is enforced
 at a callee before execution.
 
+`SEMCOD21`
+
+- promoted contract used when emitted program usage requires ownership path
+  transport for the `SequenceIndexStatic` component (`Borrow` and `Write`
+  both) or the `AdtPayload` component in a `Borrow` event (#1718 /
+  FA-04-012; see
+  `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`)
+- keeps `SEMCODE0..20` fixed for older artifacts that do not use these
+  ownership path families: an artifact under any older header that carries a
+  `SequenceIndexStatic` component, or an `AdtPayload` component in a
+  `Borrow` event, is rejected at decode/verify - the header never had
+  authority over these families, and no older header's meaning changes
+  retroactively
+- uses the fixed-width 8-byte header magic form `SEMCOD21`
+- adds two new capability bits, `CAP_OWNERSHIP_SEQUENCE_PATHS` and
+  `CAP_OWNERSHIP_ADT_BORROW_PATHS` (see `## Capability Contract` below);
+  neither widens `CAP_OWNERSHIP_PATHS`'s or `CAP_OWNERSHIP_FIELD_PATHS`'s
+  own scope, which remain exactly tuple-only and tuple+record as `SEMCOD11`
+  and `SEMCOD12` already defined them
+- does **not** change the `OWN0` section's wire layout, the `SIG0` floor, or
+  the Borrow-activation/Write-execution-mode grammar `SEMCOD11`
+  (`CAP_OWNERSHIP_PATHS`) and the rev21 anchor grammar
+  (`SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION`) already established - this
+  revision answers only "which path components may this header's `OWN0`
+  section carry," not "how are events/anchors encoded"; those two questions
+  are deliberately kept orthogonal
+- does **not** admit `Write(AdtPayload)` under any circumstance: an
+  `AdtPayload` component inside a `Write` event is rejected unconditionally,
+  at every header revision including `SEMCOD21` itself, regardless of
+  capability - this is not a missing-capability gap a future header could
+  close by inheritance; promoting `Write(AdtPayload)` requires a new,
+  separately authorized contract change, never an incidental relaxation of
+  this revision's own grammar
+
 ## Opcode Vocabulary And Header Identity
 
 SemCode header identity constrains the executable opcode vocabulary. Every
@@ -403,6 +440,8 @@ Current canonical capability families:
 - `CAP_CLOSURE_VALUES`
 - `CAP_OWNERSHIP_PATHS`
 - `CAP_OWNERSHIP_FIELD_PATHS`
+- `CAP_OWNERSHIP_SEQUENCE_PATHS`
+- `CAP_OWNERSHIP_ADT_BORROW_PATHS`
 - `CAP_MAP_VALUES`
 - `CAP_DEBUG_SYMBOLS`
 
@@ -447,6 +486,27 @@ Current `SEMCOD12` format extension in this slice:
 - verifier admits direct record-field ownership payload structurally
 - VM consumes admitted direct record-field ownership payload for frame-local
   borrow tracking and overlap enforcement
+- ownership execution semantics remain specified separately in
+  `runtime_ownership.md`
+
+Current `SEMCOD21` format extension in this slice (#1718):
+
+- producer transport may encode `SequenceIndexStatic` paths (`Borrow` and
+  `Write` both) and `AdtPayload` paths in `Borrow` events only, in `OWN0`
+- requires `CAP_OWNERSHIP_SEQUENCE_PATHS` for any `SequenceIndexStatic`
+  component and `CAP_OWNERSHIP_ADT_BORROW_PATHS` for any `AdtPayload`
+  component in a `Borrow` event; an artifact under a header lacking the
+  relevant bit is rejected at decode, independent of the verifier's own
+  separate capability-consistency check
+- an `AdtPayload` component in a `Write` event is rejected unconditionally,
+  under `SEMCOD21` and every other header, regardless of capability
+- verifier admits `SequenceIndexStatic` and `Borrow`-side `AdtPayload`
+  ownership payload structurally, on the same terms as `SEMCOD11`/`SEMCOD12`
+  path kinds, and independently re-derives the same capability requirement
+  from decoded content rather than trusting decode alone
+- VM consumes admitted `SequenceIndexStatic`/`AdtPayload` ownership payload
+  for frame-local borrow tracking and overlap enforcement, using the same
+  `AccessPath`/overlap machinery already used for tuple/record paths
 - ownership execution semantics remain specified separately in
   `runtime_ownership.md`
 

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -80,7 +80,7 @@ without turning this document into a stable bytecode ISA promise.
 | Ordinary source-derived families: control flow, data movement, literal loading, arithmetic, comparison, calls, and returns | Admitted when produced by supported SemCode and consistent with the emitted contract | No extra capability beyond the artifact contract | Baseline verifier-admitted surface; this document intentionally does not stabilize binary opcode numbers. |
 | `SEQUENCE_LEN` | Admitted only when the emitted contract carries `CAP_SEQUENCE_ITERATION` and the header family supports the sequence-iteration contract | Capability-gated | Built-in sequence lowering opcode for the admitted `Sequence(T)` iteration slice. |
 | Effect-oriented host-boundary families such as `GateRead`, `GateWrite`, and `PulseEmit` | Admitted only when the emitted contract matches the required capability envelope | Capability-gated / host-boundary | These opcodes do not define capability policy semantics by themselves. |
-| Ownership transport payloads admitted through `OWN0` | Admitted structurally only when the ownership transport slice is present and well formed | Header and capability consistency required | This covers the currently documented tuple-only and direct record-field ownership transport slices. |
+| Ownership transport payloads admitted through `OWN0` | Admitted structurally only when the ownership transport slice is present and well formed | Header and capability consistency required | Covers tuple-only (`SEMCOD11`), direct record-field (`SEMCOD12`), `SequenceIndexStatic` `Borrow`/`Write` (`SEMCOD21`, `CAP_OWNERSHIP_SEQUENCE_PATHS`), and `AdtPayload` `Borrow`-only (`SEMCOD21`, `CAP_OWNERSHIP_ADT_BORROW_PATHS`) ownership transport. `Write(AdtPayload)` is rejected unconditionally under every header, including `SEMCOD21` - not a capability gap. |
 | Unknown, unsupported, or malformed opcode encodings | Rejected | N/A | Rejection must happen before a successful VM execution path. |
 | Opcode streams that fail operand, jump-target, reachable-control-flow, call-target, closure-function-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | Direct calls may resolve to declared functions or admitted builtins; closure targets must resolve to declared functions. These are verifier admission failures, not successful runtime executions. |
 
@@ -91,6 +91,14 @@ Current ownership-specific structural checks for ownership transport include:
 - tuple `AccessPath` payload validity under `SEMCOD11`
 - direct record-field `AccessPath` payload validity under `SEMCOD12`
 - structural admission for valid `Borrow(Field)` and `Write(Field)` payloads
+- `SequenceIndexStatic` `AccessPath` payload validity (`Borrow`/`Write`) under
+  `SEMCOD21`, independently re-derived from decoded content (not delegated
+  to `sm-format`'s own decode-time gate) via `CAP_OWNERSHIP_SEQUENCE_PATHS`
+  capability-consistency accounting (#1718)
+- `AdtPayload` `AccessPath` payload validity in `Borrow` events only under
+  `SEMCOD21`, via `CAP_OWNERSHIP_ADT_BORROW_PATHS` capability-consistency
+  accounting; an `AdtPayload` component in a `Write` event is rejected
+  unconditionally, before and independent of capability accounting (#1718)
 - header/capability consistency for ownership transport
 
 ## Canonical Operand Value Domains

--- a/tests/golden_snapshots/public_api/sm_format_local_format.txt
+++ b/tests/golden_snapshots/public_api/sm_format_local_format.txt
@@ -20,6 +20,7 @@ pub const MAGIC17: [u8; 8] = *b"SEMCOD17";
 pub const MAGIC18: [u8; 8] = *b"SEMCOD18";
 pub const MAGIC19: [u8; 8] = *b"SEMCOD19";
 pub const MAGIC20: [u8; 8] = *b"SEMCOD20";
+pub const MAGIC21: [u8; 8] = *b"SEMCOD21";
 pub const CAP_DEBUG_SYMBOLS: u32 = 1 << 0;
 pub const CAP_F64_MATH: u32 = 1 << 1;
 pub const CAP_GATE_SURFACE: u32 = 1 << 2;
@@ -46,6 +47,8 @@ pub const CAP_PATH_INSPECT: u32 = 1 << 22;
 pub const CAP_FS_READ: u32 = 1 << 23;
 pub const CAP_FS_WRITE: u32 = 1 << 24;
 pub const CAP_TIME_DURATION: u32 = 1 << 25;
+pub const CAP_OWNERSHIP_SEQUENCE_PATHS: u32 = 1 << 26;
+pub const CAP_OWNERSHIP_ADT_BORROW_PATHS: u32 = 1 << 27;
 pub const SIGNATURE_SECTION_TAG: [u8; 4] = *b"SIG0";
 pub const OWNERSHIP_SECTION_TAG: [u8; 4] = *b"OWN0";
 pub const OWNERSHIP_EVENT_KIND_BORROW: u8 = 0;
@@ -87,6 +90,9 @@ pub const ACTIVATION_MODE_STORE_VAR_SITE: u8 = 1;
 pub const WRITE_EXECUTION_MODE_STORE_VAR_SITE: u8 = 0;
 pub const WRITE_EXECUTION_MODE_MAKE_RECORD_SITE: u8 = 1;
 pub const HEADER_V20: SemcodeHeaderSpec = SemcodeHeaderSpec { magic: MAGIC20, epoch: 0, rev: 21, capabilities: HEADER_V19.capabilities, };
+pub const HEADER_V21: SemcodeHeaderSpec = SemcodeHeaderSpec { magic: MAGIC21, epoch: 0, rev: 22, capabilities: HEADER_V20.capabilities | CAP_OWNERSHIP_SEQUENCE_PATHS | CAP_OWNERSHIP_ADT_BORROW_PATHS, };
+pub const SEMCODE_SEQUENCE_OWNERSHIP_MIN_REVISION: u16 = HEADER_V21.rev;
+pub const SEMCODE_ADT_BORROW_OWNERSHIP_MIN_REVISION: u16 = HEADER_V21.rev;
 pub fn supported_headers() -> &'static [SemcodeHeaderSpec] {
 pub fn header_spec_from_magic(magic: &[u8; 8]) -> Option<SemcodeHeaderSpec> {
 #[repr(u8)]

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -5681,7 +5681,7 @@ fn supported_headers_match_canonical_contract() {
     let canonical_family: &[SemcodeHeaderSpec] = &[
         HEADER_V0, HEADER_V1, HEADER_V2, HEADER_V3, HEADER_V4, HEADER_V5, HEADER_V6, HEADER_V7,
         HEADER_V8, HEADER_V9, HEADER_V10, HEADER_V11, HEADER_V12, HEADER_V13, HEADER_V14,
-        HEADER_V15, HEADER_V16, HEADER_V17, HEADER_V18, HEADER_V19, HEADER_V20,
+        HEADER_V15, HEADER_V16, HEADER_V17, HEADER_V18, HEADER_V19, HEADER_V20, HEADER_V21,
     ];
 
     let actual = supported_headers();

--- a/tests/runtime_ownership_e2e.rs
+++ b/tests/runtime_ownership_e2e.rs
@@ -2,7 +2,7 @@
 use sm_emit::compile_program_to_semcode;
 use sm_ir::semcode_format::{
     header_spec_from_magic, read_u16_le, read_u32_le, read_u8, read_utf8,
-    ACTIVATION_MODE_FRAME_ENTRY, ACTIVATION_MODE_STORE_VAR_SITE, MAGIC20,
+    ACTIVATION_MODE_FRAME_ENTRY, ACTIVATION_MODE_STORE_VAR_SITE, MAGIC20, MAGIC21,
     OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE, OWNERSHIP_PATH_COMPONENT_ADT_PAYLOAD,
     OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_SEQUENCE_INDEX,
     OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
@@ -1033,18 +1033,63 @@ fn function_has_ownership_section(bytes: &[u8], target: &str) -> bool {
         .is_some()
 }
 
+// #1718: a real emitter faced with a `SequenceIndexStatic` (either event
+// kind) or `AdtPayload` Borrow component would promote the header to
+// `HEADER_V21`/`MAGIC21` (see `has_v21_sequence_ownership_events` /
+// `has_v21_adt_borrow_ownership_events` in `sm-ir`). This rewrite harness
+// injects such components into an artifact whose real header only reflects
+// its *original*, pre-rewrite content, so it must independently compute and
+// write the header a real compiler would have chosen for the *rewritten*
+// content - otherwise the rewritten artifact understates its own capability
+// requirement and is rejected for a reason unrelated to whatever the test
+// actually wants to exercise (exactly the class of bug this comment is
+// warning against elsewhere in this file for `header_rev`-dependent byte
+// offsets). `Write(AdtPayload)` is deliberately excluded here: it is
+// unconditionally rejected under the frozen #1718 contract regardless of
+// header, so no header choice makes it admitted - callers injecting it are
+// testing that rejection itself, not overlap behavior.
+fn required_header_magic(original_bytes: &[u8], events: &[OwnershipEventSpec<'_>]) -> [u8; 8] {
+    let needs_v21 = events.iter().any(|event| {
+        event.components.iter().any(|component| {
+            matches!(
+                component,
+                OwnershipPathComponentSpec::SequenceIndexStatic(_)
+            ) || (event.kind == OWNERSHIP_EVENT_KIND_BORROW
+                && matches!(component, OwnershipPathComponentSpec::AdtPayload(_, _)))
+        })
+    });
+    if needs_v21 {
+        MAGIC21
+    } else {
+        let mut magic = [0u8; 8];
+        magic.copy_from_slice(&original_bytes[..8]);
+        magic
+    }
+}
+
 fn rewrite_function_ownership_events(
     bytes: &[u8],
     target: &str,
     events: &[OwnershipEventSpec<'_>],
 ) -> Vec<u8> {
-    let header_rev = header_rev_of(bytes);
+    // #1718: `parse_rev` interprets the EXISTING, pre-rewrite OWN0 bytes
+    // (genuinely encoded under the original header - must never change).
+    // `encode_rev` is the grammar the NEW, synthetic `events` are written
+    // in, which must match `final_magic` below, not necessarily the
+    // original header. These are two different questions that happened to
+    // share one `header_rev` value before #1718, because no rewrite ever
+    // needed to promote past what the base compile already produced.
+    let parse_rev = header_rev_of(bytes);
+    let final_magic = required_header_magic(bytes, events);
+    let encode_rev = header_spec_from_magic(&final_magic)
+        .expect("required_header_magic returns a known header")
+        .rev;
     // #1891 Checkpoint W2E: computed from the REAL, pre-rewrite compiled
     // bytes (only ever needed - and only ever guaranteed to exist - when
     // this call is about to author a synthetic Write event at rev21+); see
     // `find_real_store_var_anchor` and the design note on
     // `ownership_section_bytes` for why any genuine StoreVar boundary works.
-    let real_store_var_anchor = if header_rev >= SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION
+    let real_store_var_anchor = if encode_rev >= SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION
         && events.iter().any(|e| e.kind == OWNERSHIP_EVENT_KIND_WRITE)
     {
         Some(find_real_store_var_anchor(bytes, target))
@@ -1052,7 +1097,7 @@ fn rewrite_function_ownership_events(
         None
     };
     let mut out = Vec::with_capacity(bytes.len());
-    out.extend_from_slice(&bytes[..8]);
+    out.extend_from_slice(&final_magic);
 
     let mut cursor = 8usize;
     let mut rewrote = false;
@@ -1060,7 +1105,7 @@ fn rewrite_function_ownership_events(
         let (name, code, next) = next_function(bytes, cursor);
         let rewritten = if name == target {
             rewrote = true;
-            rewrite_function_code(code, events, header_rev, real_store_var_anchor)
+            rewrite_function_code(code, events, parse_rev, encode_rev, real_store_var_anchor)
         } else {
             code.to_vec()
         };
@@ -1111,17 +1156,18 @@ fn find_real_store_var_anchor(bytes: &[u8], function: &str) -> u32 {
 fn rewrite_function_code(
     code: &[u8],
     events: &[OwnershipEventSpec<'_>],
-    header_rev: u16,
+    parse_rev: u16,
+    encode_rev: u16,
     real_store_var_anchor: Option<u32>,
 ) -> Vec<u8> {
-    let layout = parse_function_layout(code, header_rev);
+    let layout = parse_function_layout(code, parse_rev);
     let ownership_start = layout.ownership_start.expect("OWN0 section");
     let mut out = Vec::with_capacity(code.len());
     out.extend_from_slice(&code[..ownership_start]);
     out.extend_from_slice(&ownership_section_bytes(
         &layout,
         events,
-        header_rev,
+        encode_rev,
         real_store_var_anchor,
     ));
     // #1773 (FA-09-005): preserve the real SIG0 section verbatim - only
@@ -1475,48 +1521,57 @@ fn main() {
 "#
 }
 
+// #1718 reconciliation: both scenarios below - same-payload conflict and
+// sibling (different-payload) non-conflict - used to distinguish at the
+// runtime overlap layer (`BorrowWriteConflict` vs. success), the same way
+// the tuple/record/sequence sibling-write tests elsewhere in this file
+// still do. `Write(AdtPayload)` is now, correctly, rejected at admission
+// under the frozen #1718 contract regardless of header or overlap shape (no
+// compiler-reachable source syntax produces it - see
+// `docs/roadmap/stable_foundation/ssf08_1718_path_family_contract_decision.md`),
+// so both scenarios now hit the identical admission failure before the VM's
+// overlap logic is ever reached. Consolidated into one test proving that
+// rejection is unconditional, mirroring `sm-vm`'s own reconciliation
+// (`vm_rejects_synthetic_adt_payload_write_artifact_regardless_of_overlap_shape`).
 #[test]
-fn runtime_ownership_option_rejects_same_path_write_deterministically() {
-    let bytes = compile_program_to_semcode(option_assignment_source()).expect("compile");
-    let rewritten = rewrite_function_ownership_events(
-        &bytes,
-        "main",
-        &[
-            OwnershipEventSpec {
-                kind: OWNERSHIP_EVENT_KIND_BORROW,
-                root: "opt",
-                components: &[OwnershipPathComponentSpec::AdtPayload(42, 0)],
-            },
-            OwnershipEventSpec {
-                kind: OWNERSHIP_EVENT_KIND_WRITE,
-                root: "opt",
-                components: &[OwnershipPathComponentSpec::AdtPayload(42, 0)],
-            },
-        ],
-    );
+fn runtime_ownership_option_write_rejected_at_admission_regardless_of_overlap_shape() {
+    let scenarios: [(u32, u16, u32, u16); 2] = [
+        (42, 0, 42, 0), // same payload
+        (42, 0, 43, 0), // sibling (different variant)
+    ];
+    for (borrow_variant, borrow_index, write_variant, write_index) in scenarios {
+        let bytes = compile_program_to_semcode(option_assignment_source()).expect("compile");
+        let rewritten = rewrite_function_ownership_events(
+            &bytes,
+            "main",
+            &[
+                OwnershipEventSpec {
+                    kind: OWNERSHIP_EVENT_KIND_BORROW,
+                    root: "opt",
+                    components: &[OwnershipPathComponentSpec::AdtPayload(
+                        borrow_variant,
+                        borrow_index,
+                    )],
+                },
+                OwnershipEventSpec {
+                    kind: OWNERSHIP_EVENT_KIND_WRITE,
+                    root: "opt",
+                    components: &[OwnershipPathComponentSpec::AdtPayload(
+                        write_variant,
+                        write_index,
+                    )],
+                },
+            ],
+        );
 
-    assert_write_overlap_rejects_deterministically(&rewritten, "opt");
-}
-
-#[test]
-fn runtime_ownership_option_sibling_write_passes_on_verified_path() {
-    let bytes = compile_program_to_semcode(option_assignment_source()).expect("compile");
-    let rewritten = rewrite_function_ownership_events(
-        &bytes,
-        "main",
-        &[
-            OwnershipEventSpec {
-                kind: OWNERSHIP_EVENT_KIND_BORROW,
-                root: "opt",
-                components: &[OwnershipPathComponentSpec::AdtPayload(42, 0)],
-            },
-            OwnershipEventSpec {
-                kind: OWNERSHIP_EVENT_KIND_WRITE,
-                root: "opt",
-                components: &[OwnershipPathComponentSpec::AdtPayload(43, 0)],
-            },
-        ],
-    );
-
-    run_token_first_main(&rewritten).expect("sibling adt payload write should pass");
+        let report = sm_verify::verify_semcode_token(&rewritten)
+            .expect_err("Write(AdtPayload) must be rejected at token admission");
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|d| d.code == sm_verify::VerificationCode::InvalidOwnershipSection),
+            "expected InvalidOwnershipSection, got {report:?}"
+        );
+    }
 }

--- a/tests/sequence_ownership_golden.rs
+++ b/tests/sequence_ownership_golden.rs
@@ -1,5 +1,6 @@
 use sm_emit::compile_program_to_semcode;
 use sm_format::semcode_decode::{decode_semcode_envelope, DecodedAccessPathComponent};
+use sm_format::semcode_format::{MAGIC20, MAGIC21};
 use sm_verify::verify_semcode_token;
 use sm_vm::run_verified_entry_semcode;
 
@@ -60,4 +61,36 @@ fn positive_sequence_ownership_e2e_golden() {
     let token = verify_semcode_token(&bytes).expect("token admission");
     let entry_token = token.require_entry("main").expect("entry resolution");
     run_verified_entry_semcode(&entry_token).expect("vm run");
+}
+
+// #1718 downgrade/re-encode audit (item 13): a real `HEADER_V21` artifact
+// containing `SequenceIndexStatic` ownership paths must not become
+// admissible again merely by relabeling its header magic down to
+// `HEADER_V20` - the two headers share the identical OWN0 wire grammar
+// (both are at/above `SEMCODE_OWNERSHIP_ANCHOR_MIN_REVISION`, so no byte
+// other than the 8-byte magic prefix needs to change for this to be a
+// structurally well-formed, if dishonestly labeled, `HEADER_V20` artifact),
+// which is exactly the scenario a content-sniffing or "if bytes decode,
+// admit them" implementation would get wrong. The real gate is
+// `header_rev`-derived, not inferred from OWN0 content, so relabeling alone
+// must still fail closed.
+#[test]
+fn v21_sequence_artifact_cannot_be_relabeled_to_v20_and_still_verify() {
+    let src = include_str!("fixtures/pcc_sequence_ownership/positive_sequence_ownership.sm");
+    let bytes = compile_program_to_semcode(src).expect("compile");
+    assert_eq!(
+        &bytes[..8],
+        &MAGIC21,
+        "this fixture must genuinely require HEADER_V21 for this audit to be meaningful"
+    );
+
+    let mut downgraded = bytes.clone();
+    downgraded[..8].copy_from_slice(&MAGIC20);
+
+    let err = verify_semcode_token(&downgraded)
+        .expect_err("a relabeled-to-V20 Sequence artifact must not verify");
+    assert!(err
+        .diagnostics
+        .iter()
+        .any(|d| d.code == sm_verify::VerificationCode::InvalidOwnershipSection));
 }


### PR DESCRIPTION
Closes #1718
SSF-08 #1579

Implements the frozen path-family contract from PR #1895.

- **Sequence (`SequenceIndexStatic`) Borrow + Write** → admitted under new explicit authority (`CAP_OWNERSHIP_SEQUENCE_PATHS`, `HEADER_V21`/`SEMCOD21`, rev 22).
- **ADT payload (`AdtPayload`) Borrow** → admitted under new explicit authority (`CAP_OWNERSHIP_ADT_BORROW_PATHS`, same header).
- **ADT payload (`AdtPayload`) Write** → fails closed, unconditionally, under every header including `SEMCOD21` itself. Not a missing-capability gap — a future promotion requires a new, separately authorized contract change.

`HEADER_V21` is purely additive over `HEADER_V20`: identical OWN0 wire layout, identical Borrow-activation/Write-execution-mode grammar and anchor floor. No new component byte tags, no OWN0 layout mutation, no `HEADER_V20` semantics changed.

## What changed, by layer

- **I1 (`sm-format`)**: two new capability bits (audited free bits 26/27, kept separate per family since Sequence and ADT Borrow are independently-decided admission domains), `HEADER_V21`/`MAGIC21`, two new `MIN_REVISION` constants.
- **I2 (`sm-ir`)**: emitter promotion predicates for Sequence (either event kind) and ADT Borrow; `emit_semcode` fails closed, before any header is chosen, if a synthetic `Write(AdtPayload)` event is ever constructed.
- **I3 (`sm-format` decode)**: header/revision/event-kind-aware admission gating for both families; `Write(AdtPayload)` rejected unconditionally.
- **I4 (`sm-verify`)**: an independent capability-consistency check (does not rely on decode's gate alone), plus the same unconditional `Write(AdtPayload)` rejection.
- **I4.1 (`sm-verify`, qualification seam)**: extracts that policy into its own function, `verify_ownership_path_family_contract`, taking a header and already-decoded paths directly (no byte-level decode) — closing a coverage gap mutation M4b found (see below). No production semantics changed; not a second policy implementation.
- **I5 (tests)**: legacy fail-closed matrix (old header + new component kinds → reject), `HEADER_V21` admission matrix, a downgrade/re-encode audit (a real `HEADER_V21` Sequence artifact relabeled to `HEADER_V20` still fails verification), and reconciliation of pre-#1718 fixtures/tests whose real content now correctly promotes further or is now correctly rejected as an artifact surface.
- **I6 (docs)**: `docs/spec/semcode.md`, `docs/spec/verifier.md`, `docs/spec/runtime_ownership.md` updated to describe the implemented contract; `docs/architecture/adt_payload_ownership_paths.md` (previously stale, claiming lowering/VM support didn't exist yet) corrected.

## Falsification (mutation proofs, all reverted before this PR — not present in the diff)

- **M1** removed Sequence promotion → `sequence_ownership_golden` failed as expected.
- **M2** removed the old-header Sequence decode gate → the legacy-rejection test wrongly passed.
- **M3** removed ADT Borrow promotion → the real-source ADT Borrow test failed as expected.
- **M4a** removed the `Write(AdtPayload)` decode rejection → the legacy/V21 rejection test wrongly admitted a `MAGIC21` artifact.
- **M4b** removed the verifier's independent `Write(AdtPayload)` rejection → `verifier_rejects_adt_payload_write_independently_of_decoder` (added in I4.1, calling `verify_ownership_path_family_contract` directly with hand-built decoded paths, no byte decode involved) now correctly fails. Decoder rejection and verifier rejection are each independently regression-pinned: M4a proves decoder authority, M4b proves verifier authority.
- **M5** reinterpreted generic `CAP_OWNERSHIP_PATHS` as sufficient (used a low, non-dedicated revision floor) → the legacy-rejection test wrongly passed.

## Qualification

- `cargo fmt --all -- --check` — clean
- `cargo clean` + `cargo clippy --workspace --all-targets -- -D warnings` — clean (fresh rebuild)
- `cargo check --workspace --all-targets` — clean
- `cargo test --workspace --no-fail-fast` — 332 test result blocks, all green
- `git diff --check` — clean

Cross-layer qualification complete on exact HEAD `2e04c0be5d788465f8d777002f39b979c5f111ef`. Hosted CI/security and a fresh exact-HEAD Codex review are both clean on this commit. Awaiting owner-controlled manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)