### PR TITLE
docs(quota): freeze #1759 Steps/Calls execution semantics

### DIFF
--- a/docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md
+++ b/docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md
@@ -319,38 +319,100 @@ Both are direct applications of the already-frozen general rules, not
 additional policy - this is the conceptual-consistency check item 10 asks
 for, and it passes: no new mechanism is invoked for the boundary value 0.
 
-## 10. Counter overflow / `usize::MAX` audit
+## 10. Counter overflow / `usize::MAX` — fully frozen
 
-**Finding (in-scope contract rule, not deferred):** `RuntimeQuotas::exceed`
-itself (`(used > limit).then_some(...)`) never overflows - it only compares
-two already-computed `usize` values. The risk lives entirely in how a
-*caller* computes the incremented `used` value before passing it in - the
-existing precedent, `bump_effect_calls`'s `let next = vm.effect_calls + 1;`,
-uses a bare `+`, which **wraps silently in a release build** (Rust's
-default, non-panicking release behavior for integer overflow) rather than
-erroring. A custom `ExecutionConfig` supplying `max_steps = usize::MAX` (or
-any caller-controlled quota field near that ceiling) combined with a
-sufficiently long-running program would eventually drive the counter's own
-`+ 1` increment past `usize::MAX`, wrapping to `0` - at which point `next
-(0) > limit (usize::MAX)` is false, and the quota silently stops
-functioning as fuel, defeating the entire bounded-termination guarantee
-this checkpoint exists to establish. This is a real, currently-latent
-pattern already present for `EffectCalls` today, not a new concern this
-decision invents, but #1759 must not repeat it for Steps/Calls given that
-Steps is specifically the bounded-*termination* promise.
+**Finding:** `RuntimeQuotas::exceed` itself (`(used > limit).then_some(...)`)
+never overflows - it only compares two already-computed `usize` values. The
+risk lives entirely in how a *caller* computes the incremented `used` value
+before passing it in - the existing precedent, `bump_effect_calls`'s
+`let next = vm.effect_calls + 1;`, uses a bare `+`, which **wraps silently
+in a release build** (Rust's default, non-panicking release behavior for
+integer overflow) rather than erroring. §10.1 records why this same pattern
+is not acceptable for `EffectCalls` either, as a newly discovered residual
+(tracked in the Lane 5 audit, not fixed here). This section freezes the
+Steps/Calls charge primitive so the same defect cannot be reintroduced.
 
-**Frozen rule for the implementation checkpoint (not implemented here):**
-Steps/Calls counters must increment via `checked_add` (or equivalent),
-returning a deterministic error if the increment itself would overflow -
-never a silent wraparound, and never a `wrapping_add`. This mirrors the
-exact discipline `docs/spec/semcode.md`'s own "Offset Arithmetic Must Stay
-Inside The Result Model" section already mandates for decode-time
-cursor/length arithmetic, generalized to runtime counters for the identical
-reason: an attacker- or misconfiguration-controlled value must never be
-able to wrap a safety-relevant counter back into an apparently-valid range.
-This audit does not extend the same requirement to the pre-existing
-`EffectCalls` counter's own `+ 1` - that is a `#1760`-or-later-adjacent
-finding outside #1759's own scope, recorded here for visibility only.
+**Why "return a deterministic error on overflow" alone was insufficient
+(the gap closed by this revision):** the failure channel is already frozen
+(§11) as `RuntimeError::QuotaExceeded { kind, limit, used }` with
+`used: usize`. At `limit = usize::MAX`, the *ordinary* rejection case
+(`used = limit + 1`) is itself unrepresentable as a `usize` - three already-
+frozen constraints (exact `used = N+1` reporting, `usize` representation,
+no new failure channel) cannot all hold simultaneously at this single
+numeric ceiling. This is now resolved, not left to the implementation
+checkpoint's discretion.
+
+**Frozen charge primitive (both Steps and Calls, identical shape):**
+
+```
+next = used.checked_add(1)
+
+match next {
+    Some(next) => {
+        // ordinary path - existing RuntimeQuotas::exceed / used > limit
+        // convention, completely unchanged by this decision
+        if next > limit {
+            reject before this instruction/call semantically executes:
+                RuntimeError::QuotaExceeded { kind, limit, used: next }
+        } else {
+            used = next; proceed
+        }
+    }
+    None => {
+        // used was already usize::MAX; the attempted usage
+        // (usize::MAX + 1) is not representable as a usize at all
+        reject before this instruction/call semantically executes:
+            RuntimeError::QuotaExceeded { kind, limit, used: usize::MAX }
+    }
+}
+```
+
+**Normative statement (frozen):**
+- `QuotaExceeded.used` is the *exact* attempted usage whenever that value is
+  representable as a `usize`.
+- At the single numeric-ceiling case where the attempted usage would be
+  `usize::MAX + 1`, the externally reported `used` value **saturates** at
+  `usize::MAX`. This saturation is reporting-only - it is not a new charge
+  semantic, not a rounding rule for any other value, and applies to no
+  other point in this contract.
+- This case is unconditionally **fail-closed**: no wrap, no warning, no
+  continued execution. The instruction/call that triggered it does not run.
+- No `RuntimeTrap::QuotaExceeded` involvement - the channel stays
+  `RuntimeError::QuotaExceeded` exactly as §11 already freezes, with no new
+  `RuntimeError`/`RuntimeTrap` variant introduced for this edge case.
+- This closes the overflow question independently of whether `limit` itself
+  is ever actually configured near `usize::MAX` in a shipped profile
+  (`verified_local`/`pure_compute`/`kernel_bound` are not) - the rule exists
+  because `ExecutionConfig`/`RuntimeQuotas` construction is not restricted
+  to those three baselines (`ExecutionConfig::new` performs no
+  cross-validation, per the existing `sm-runtime-core` inspection), so a
+  caller-supplied near-ceiling limit is a real, not merely theoretical,
+  input.
+
+**Future regression test design (specified, not implemented):** must not
+execute `usize::MAX` instructions/calls to exercise this path. Instead, the
+implementation checkpoint must expose the charge primitive above as a small
+internal helper (e.g. `fn charge(used: usize, limit: usize) -> Result<usize, QuotaExceeded>`)
+directly unit-testable by constructing `used = usize::MAX` as a starting
+value and asserting the `None`/saturated-`usize::MAX` branch fires - the
+same "test the extracted policy function directly, do not rely on driving
+the real engine to the boundary" pattern already used for the #1718
+checkpoint's `verify_ownership_path_family_contract` extraction.
+
+### 10.1 New residual finding surfaced by this audit — `EffectCalls` overflow discipline
+
+This decision's own re-inspection of `bump_effect_calls` found that
+`EffectCalls` - an already-**ACTIVE**, already-enforced, already-qualified
+runtime quota per the Lane 5 inventory (§10 there) - uses the identical
+unchecked `vm.effect_calls + 1` pattern this section rejects for Steps/
+Calls. This is **not** a #1760 finding (#1760 is `TraceEntries`/
+`trace_enabled`) and is **not** repaired by #1759 (Steps/Calls are new
+counters; `EffectCalls` is a pre-existing, separate one). It is recorded
+here because it was discovered during this pass, and propagated into the
+Lane 5 audit doc (§8 there) as its own residual finding so it is not lost
+inside a #1759-scoped document. **#1759's implementation scope is NOT
+expanded to include fixing `EffectCalls`** - that remains a separate,
+not-yet-triaged item.
 
 ## 11. Failure taxonomy boundary
 
@@ -414,6 +476,7 @@ newly-invented signal instead of the one already justified here.
 | Call charge order | before Frames/StackDepth/Registers | counts invocations that never actually produced a frame (§6) |
 | Call charge order | as a derived count from Step-charged `CALL` opcodes | conflates builtin-resolved `CALL`s (no real invocation) with real ones (§5) |
 | Counter overflow | silent wraparound (bare `+`, matching existing `EffectCalls` precedent) | defeats the bounded-termination guarantee itself for a caller-controlled near-`usize::MAX` limit (§10) |
+| Counter overflow reporting | inventing a new error variant / new failure channel for the `usize::MAX` ceiling case | unnecessary - exact `used=N+1` reporting, `usize` representation, and the existing `RuntimeError::QuotaExceeded` channel can all be kept by saturating the reported `used` at `usize::MAX` for this one unrepresentable case only (§10) |
 | Failure channel | `RuntimeTrap::QuotaExceeded` | pre-empts `#1763`'s own, later, independent taxonomy decision (§11) |
 
 ## 15. Effect on Lane 5 / AC4
@@ -423,8 +486,16 @@ implemented. AC4.a is **NOT SATISFIED**: no counter exists yet, so "every
 quota advertised as an active runtime bound has an authoritative resource"
 still fails for `Steps`/`Calls`. The next checkpoint is implementation,
 gated on a separate, explicit GO, covering: the two counters on `VM`, the
-charge points and root-exemption test frozen in §2-§9, `checked_add`
-overflow discipline per §10, the `RuntimeError::QuotaExceeded` channel per
-§11, and the reproduction matrix in §12 as permanent regression tests.
+charge points and root-exemption test frozen in §2-§9, the fully-frozen
+`checked_add`/saturated-reporting overflow discipline per §10, the
+`RuntimeError::QuotaExceeded` channel per §11, and the reproduction matrix
+in §12 (plus the §10 helper-level ceiling test) as permanent regression
+tests.
+
+This pass also surfaced one residual finding **outside** #1759's own scope:
+`EffectCalls` - an already-active, already-enforced quota - shares the same
+unchecked `+ 1` defect this section closes for Steps/Calls (§10.1). It is
+recorded in the Lane 5 audit doc as its own finding, not folded into
+#1759's implementation scope, and not yet assigned a tracking issue.
 
 **Wait for explicit GO before implementation.**

--- a/docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md
+++ b/docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md
@@ -1,0 +1,430 @@
+# SSF-08 Lane 5 / #1759 — Steps & Calls Bounded-Execution Contract Decision
+
+Status: **CONTRACT DECISION ONLY. NO PRODUCTION BEHAVIOR CHANGE.**
+Baseline SHA: `a2543bc3a4f0b37fea3e4208c531cd9c6eb99a1b` (`main`, confirmed
+current; `origin/main` unmoved).
+Umbrella: SSF-08 umbrella #1579 remains OPEN.
+
+This document freezes the exact semantic contract for `RuntimeQuotas::max_steps`
+and `RuntimeQuotas::max_calls` before any counter is implemented. It does not
+add a VM counter, restructure `RuntimeError`/`RuntimeTrap`, or touch
+`#1760`/`#1761`/`#1762`/`#1763`. #1759 remains OPEN after this document.
+
+## 1. Current architecture (re-inspected fresh, not assumed)
+
+`crates/sm-vm/src/semcode_vm.rs::exec_loop_with_profile` is the **single**
+instruction-dispatch loop for the entire VM - one shared `loop { ... }`
+spanning every frame of an execution, not a per-frame or per-function loop.
+Each iteration: reads `frame_idx = vm.callstack.len() - 1` (the *current
+top* frame, whichever function that is), decodes exactly one opcode byte
+(`Opcode::from_byte`), records it for profiling, runs
+`check_write_execution_site`, then dispatches through one large `match
+opcode { ... }`. A decode failure returns `Err` via `?` **before** reaching
+any of the code that would charge a quota - it never enters the match body.
+
+`push_frame` is confirmed, by exhaustive grep, to be **the only
+`vm.callstack.push` call site in the entire file**. Every root/entry
+invocation (`run_verified_entry_semcode*`, `run_verified_function_semcode_with_args_and_config`,
+the raw/diagnostic entrypoints, and every test harness) calls it once with
+an *empty* callstack; every nested `Opcode::Call`/`Opcode::ClosureCall`
+calls it with a *non-empty* callstack. `push_frame`'s current order is:
+resolve function → `validate_call_arguments` (signature/arity) →
+`enforce_quota(Frames, next_depth)` → `enforce_quota(StackDepth, next_depth)`
+(remapped to `RuntimeError::StackOverflow` on failure, per the existing
+documented compatibility note) → `enforce_quota(Registers, initial_reg_count)`
+→ construct frame and ownership state → `vm.callstack.push(frame)`.
+
+`Opcode::Call`'s own handling resolves the callee three ways: (a) a real
+internal Semantic function → `push_frame` then `continue` the loop; (b) a
+builtin (`try_eval_builtin_call`) → evaluated **inline, without ever
+calling `push_frame`**, `next_pc` advances normally; (c) truly unknown →
+routed through `push_frame` anyway so it fails with the existing
+`UnknownFunction` error. Effect opcodes (`GateRead`/`GateWrite`/etc.) are
+ordinary arms in the same `match`, each calling `bump_effect_calls` (which
+itself calls `enforce_quota(EffectCalls, ...)`) as part of their own body -
+they do not call `push_frame` and are not routed through it.
+
+**No prior commit, test, or doc anywhere in this repository defines what
+"one Step" or "one Call" means** - `docs/spec/quotas.md` and `docs/spec/vm.md`
+both state the *existence* of the quota kinds and baseline numbers, never
+the charging semantics. This decision is genuinely being made fresh, not
+recovered from an existing but undocumented convention.
+
+## 2. Decision A — Step definition
+
+**Frozen: Step = one successfully decoded VM opcode dispatch attempt,
+charged before that opcode's own semantic body executes.**
+
+- Charge point: immediately after `Opcode::from_byte` succeeds, before
+  `check_write_execution_site` and before the `match opcode { ... }` body -
+  i.e. before any semantic effect of that instruction can occur.
+- `CALL`/`ClosureCall` consume one Step each, for the `CALL`/`ClosureCall`
+  instruction itself, exactly like any other opcode - **YES**.
+- Callee opcodes consume their own Steps once execution resumes inside the
+  new frame - **YES** (this falls out automatically: the shared loop
+  charges every iteration uniformly, regardless of which frame is on top).
+- `RET` consumes one Step - **YES** (an ordinary opcode in the same match).
+- `JMP` consumes one Step on every visit, including every iteration of a
+  backward branch - **YES**. This is the property that makes the quota real
+  fuel rather than a statistic: a closed loop cannot iterate without
+  spending fuel.
+- A runtime-failing opcode (e.g. a trap fires partway through the match
+  arm) still counts its Step - **YES, no refund**. The Step was already
+  charged before the match began; nothing after that point can un-charge
+  it. This matches the existing, unrelated `RuntimeQuotas::exceed`
+  convention of never reversing a charge.
+- A malformed/undecodable opcode byte does **not** count as a Step - **NO**,
+  by construction: `Opcode::from_byte`'s failure returns via `?` before the
+  proposed charge point is ever reached. This requires no special-casing;
+  it is a structural consequence of where the charge sits.
+- Host/effect operations consume a Step **in addition to** `EffectCalls` -
+  **YES**. `GateRead`/`GateWrite`/etc. are ordinary opcodes in the same
+  dispatch loop; the generic per-instruction Step charge and the
+  opcode-specific `EffectCalls` charge are two orthogonal resource domains
+  measuring different things (raw instruction fuel vs. a specific
+  operation-class budget), exactly the same relationship item 7 asks to be
+  frozen for Steps vs. Calls, generalized.
+
+**Falsification attempted (candidate B, "successfully completed opcode"):**
+rejected. Charging only on successful completion would mean an opcode that
+traps partway through (say, a division that fails) consumes *zero* Steps -
+an attacker (or a buggy program) could then loop `DivisionByZero`-triggering
+attempts... except that path terminates in an error, not a loop, so the
+real counterexample is subtler: a `JMP` whose *target* is out of range would
+be rejected at verification, not runtime, so this specific case cannot
+arise for verified code - but the general principle (fuel must be spent on
+*attempt*, not *success*, or a program that reliably fails a semantic check
+without terminating could starve the counter) is the deciding argument, and
+it generalizes to any future opcode with a fallible-but-repeatable failure
+mode. Candidate A ("opcode fetch attempt," charging even on a decode
+failure) was also rejected: it would make quota exhaustion indistinguishable
+from - and interleaved with - `BadFormat`, contaminating a resource-budget
+signal with what is actually a decode-admission bug category, since decode
+failures should never occur for admitted (verified) SemCode in the first
+place.
+
+## 3. Step charge timing and error precedence
+
+**Frozen ordering:** decode opcode → charge one Step → if exhausted, return
+`RuntimeError::QuotaExceeded(Steps, limit, used)` immediately, before any
+opcode-specific check or effect (including `check_write_execution_site` and
+the `match` body) → otherwise proceed normally.
+
+**Consequence, explicit:** with `max_steps = N`, exactly `N` opcode
+dispatches may proceed. Attempted dispatch `N+1` reports
+`QuotaExceeded { kind: Steps, limit: N, used: N+1 }` and performs **no**
+opcode-specific mutation or effect for that attempted instruction - this
+uses the existing `RuntimeQuotas::exceed`'s own `used > limit` convention
+verbatim (`(used > limit).then_some(...)`), not a new one; #1759 does not
+change that shared convention.
+
+**Precedence, frozen:**
+- Steps exhaustion vs. `BorrowWriteConflict`: **Steps wins.** If there is no
+  fuel for this instruction, it does not semantically execute at all, so
+  `check_write_execution_site` (which runs after the proposed charge point)
+  never gets a chance to fire in the same dispatch.
+- Steps exhaustion vs. `DivisionByZero`/other semantic traps: **Steps
+  wins**, for the identical reason - the arithmetic never runs.
+- Steps exhaustion vs. a host effect: **Steps wins** - `bump_effect_calls`
+  and the host call both live inside the match body, downstream of the
+  proposed charge point.
+- Steps exhaustion vs. Calls quota (on a `CALL`/`ClosureCall` instruction
+  specifically): **Steps wins.** The `CALL` opcode's own Step charge fires
+  at dispatch time, before the match arm that would eventually call
+  `push_frame` (and therefore the Calls charge, §5) ever runs. A `CALL`
+  instruction that cannot even be dispatched for lack of Step fuel never
+  reaches the point where a Calls charge would apply.
+
+This ordering is the direct, mechanical consequence of the loop structure
+in §1 - it is not an arbitrary policy layered on top of it.
+
+## 4. Decision B — Call definition
+
+**Frozen: Call = one admitted, non-root Semantic function invocation - a
+`push_frame` call that occurs while `vm.callstack` is already non-empty.**
+
+- `Opcode::Call` targeting a real internal function → counts, via
+  `push_frame`.
+- `Opcode::ClosureCall` → counts, via `push_frame`.
+- Recursive invocation (direct or mutual) → counts identically to any other
+  nested call; the counter does not distinguish recursion from ordinary
+  nesting.
+- **Root/entry invocation does NOT count.** This is not a design choice
+  layered on top of `push_frame` - it is a falsification finding from §1:
+  `push_frame` is the *only* place any frame is ever constructed, including
+  the very first one, so a Calls charge placed unconditionally inside it
+  would also charge the entry frame, directly contradicting the intended
+  "`max_calls = 0` still runs the entry" semantic (§10). The correct,
+  already-available discriminator is the same `next_depth`/
+  `vm.callstack.len()` value `push_frame` already computes for the Frames
+  quota: charge Calls **only when `vm.callstack.len() > 0` at the moment
+  `push_frame` is invoked** (equivalently, `next_depth > 1`) - the root
+  invocation is uniquely the one `push_frame` call where the stack was
+  empty beforehand, confirmed exhaustively against every call site in §1,
+  not merely plausible by construction.
+- Host ABI operations and effect opcodes (`GateRead`/`GateWrite`/`PulseEmit`/etc.)
+  do **not** count as Calls - confirmed structurally: none of them call
+  `push_frame` (§1); they are charged against `EffectCalls` instead, an
+  already-separate, already-enforced resource.
+- A builtin call resolved via `try_eval_builtin_call` does **not** count -
+  confirmed structurally: this path is explicitly `push_frame`-free (§1).
+- A failed invocation attempt (signature/arity mismatch, or a Frames/
+  StackDepth/Registers quota failure) does **not** count as a Call - see §6
+  for the exact ordering and rationale.
+
+**Falsification attempted:**
+- *Root-inclusive* (root counts): rejected per the structural finding
+  above - it collapses "no nested calls allowed" and "no code at all may
+  run" into the same `max_calls = 0` behavior, which contradicts
+  `docs/spec/quotas.md`'s own framing of quotas as bounding *execution*,
+  not *admission of the selected entry itself* (entry selection is a
+  verifier/token concern, per `docs/spec/vm.md`'s "Standard Execution
+  Rule," not a runtime quota concern).
+- *Attempt-based* (every `push_frame` invocation counts, success or
+  failure): rejected - see §6's own falsification for why charging before
+  validation would make the Calls counter measure something other than
+  "invocations that actually happened."
+- *Successful-entry-based, but counting root* was not considered separately
+  from root-inclusive, since it is the same claim under a different name.
+
+## 5. Calls vs. Steps are orthogonal
+
+**Frozen:** a `CALL`/`ClosureCall` instruction legitimately charges **both**
+domains on a successful nested invocation - one Step (§2, the instruction
+itself was dispatched) and one Call (§4, a new admitted invocation was
+created). This is not double-counting: Steps measures raw instruction fuel
+(would exhaust even on a program with zero calls, via a pure loop); Calls
+measures invocation-nesting budget (would exhaust even on a program with a
+single, cheap, repeatedly-invoked helper that costs almost no Steps per
+call). A program can exhaust one without approaching the other in either
+direction, which is the proof that they are measuring genuinely different
+physical quantities, not the same one twice.
+
+**Falsification attempted:** could Calls be defined as a subset/count
+derived from Steps (e.g. "the number of Step-charging `CALL` opcodes seen
+so far") rather than its own independent counter? Rejected - this would
+conflate a `CALL` opcode that resolves to a *builtin* (no `push_frame`, no
+real invocation, §4) with one that resolves to a real function, since both
+charge a Step identically at dispatch time. Only counting at the
+`push_frame` choke point correctly excludes builtin/host calls.
+
+## 6. Call admission timing
+
+**Frozen ordering, preserving every existing check's own relative order and
+adding Calls as the last gate before the frame is actually constructed:**
+
+```
+1. resolve function name (existing - UnknownFunction on failure)
+2. validate_call_arguments (existing - signature/arity)
+3. enforce_quota(Frames, next_depth)          (existing, unchanged)
+4. enforce_quota(StackDepth, next_depth)       (existing, unchanged;
+                                                 remapped to StackOverflow)
+5. enforce_quota(Registers, initial_reg_count) (existing, unchanged)
+6. enforce_quota(Calls, next_calls) IF vm.callstack.len() > 0 before
+   this push (new - §4's root-exemption test)
+7. construct frame, push onto vm.callstack     (existing, unchanged)
+```
+
+**Required final statement: does a failed call attempt consume Calls? NO.**
+"Failed" means any of steps 1-5 above rejecting the invocation. Calls is
+charged only once every other admission check has already succeeded,
+immediately before the frame is actually constructed - meaning the Calls
+counter's `used` value always equals the number of frames that *were
+actually pushed* as non-root invocations, never an attempt count inflated
+by rejected calls for unrelated reasons.
+
+**Falsification attempted (charge Calls first, before Frames/StackDepth/
+Registers):** rejected. If Calls were charged before the structural
+resource checks, a caller near the Frames/StackDepth ceiling could be
+charged a Call for an invocation that never actually produced a frame (it
+failed StackOverflow immediately after) - meaning `used` for Calls would
+count invocations that structurally never happened, contradicting the
+"admitted... invocation" framing in §4's own definition. Charging last
+avoids this by construction: every increment to the Calls counter
+corresponds 1:1 to a frame that genuinely exists on `vm.callstack` after
+the operation completes.
+
+**CALL_ATTEMPT vs. SUCCESSFULLY-ADMITTED-FRAME-ENTRY (item 6's own explicit
+question):** the frozen semantic is SUCCESSFULLY-ADMITTED-FRAME-ENTRY,
+non-root - not raw attempt count, per the falsification immediately above.
+
+## 7. Counter scope
+
+**Frozen: both counters are execution-wide, not per-frame or per-function.**
+`vm.steps`/`vm.calls` (or equivalent field names, left to the implementation
+checkpoint) live on the shared `VM` struct itself, alongside the existing
+`vm.effect_calls` field this decision explicitly mirrors (`bump_effect_calls`
+already reads and writes a single execution-wide counter, not a per-frame
+one - the same pattern generalizes directly). Required invariants, all
+falling out of "one counter per `VM` instance, incremented in the one shared
+dispatch loop / the one shared `push_frame`":
+- Entering a callee does not reset Steps - true by construction, since the
+  charge point lives in the single shared loop, not inside any per-function
+  state.
+- Returning from a callee does not reset Calls - true by construction, same
+  reasoning applied to `push_frame`.
+- Recursion shares the same counters as any other nesting - true, since the
+  counter has no per-function identity at all.
+- Sibling calls share the same counters - true, for the identical reason.
+
+This matches `docs/spec/quotas.md`'s own framing precisely: the quotas
+belong to the *execution envelope* (one `ExecutionConfig`, one `VM`
+instance, one call to a `run_verified_*` entrypoint), not to any smaller
+unit inside it.
+
+## 8. Trusted vs. raw execution paths
+
+**Frozen: YES - the counters live in the shared VM engine (`exec_loop_with_profile`
+and `push_frame`), so every execution path that constructs a `VM` with an
+`ExecutionConfig` is mechanically quota-bound, including raw/diagnostic
+helpers that intentionally bypass `sm-verify` admission.**
+
+**Why:** `docs/spec/vm.md`'s own "Compatibility Rule" and the existing
+precedent for every other quota kind (`Frames`/`StackDepth`/`Registers`/
+`EffectCalls` are already enforced identically regardless of which
+`run_*`/`run_verified_*` entrypoint constructed the `VM`) already establish
+that quota enforcement is a property of the shared engine, not of the trust
+route. A raw/test helper deliberately bypassing verifier admission must not
+also silently acquire a *second*, weaker fuel model - that would mean a
+test harness could "prove" a program terminates under the raw path while
+the verified path (the actual public trust contract) enforces different
+timing, an inconsistency with no current precedent anywhere else in the
+quota system. This does not expand the public trust claim for raw bytecode
+execution itself (§9's own scope: `docs/spec/vm.md`'s "Standard Execution
+Rule" is unchanged by this decision) - it only means the *fuel* is uniform
+across both routes, which is a resource-safety property, not an admission
+one.
+
+## 9. Zero-limit semantics
+
+**Frozen, matching the mechanisms in §3 and §6 exactly, not as a separate
+special case:**
+
+- `max_steps = 0`: the entry function is selected and its frame is
+  constructed (root `push_frame` is unaffected by Steps at all - Steps is
+  charged per *instruction dispatch*, not per frame construction), but its
+  very first opcode cannot be dispatched: `QuotaExceeded { kind: Steps,
+  limit: 0, used: 1 }` fires at the first iteration of the shared loop.
+- `max_calls = 0`: the root entry executes normally (root is exempt, §4),
+  and its own instructions run under whatever Step budget applies; the
+  first nested `Opcode::Call`/`Opcode::ClosureCall` that would produce a
+  non-root `push_frame` fails with `QuotaExceeded { kind: Calls, limit: 0,
+  used: 1 }` at step 6 of §6's ordering, after the callee's signature and
+  the caller's Frames/StackDepth/Registers have already been validated for
+  that specific attempted frame (§6 - Calls is charged last, so those
+  checks still run and could theoretically fail first for an unrelated
+  reason, which is consistent, not a special case).
+
+Both are direct applications of the already-frozen general rules, not
+additional policy - this is the conceptual-consistency check item 10 asks
+for, and it passes: no new mechanism is invoked for the boundary value 0.
+
+## 10. Counter overflow / `usize::MAX` audit
+
+**Finding (in-scope contract rule, not deferred):** `RuntimeQuotas::exceed`
+itself (`(used > limit).then_some(...)`) never overflows - it only compares
+two already-computed `usize` values. The risk lives entirely in how a
+*caller* computes the incremented `used` value before passing it in - the
+existing precedent, `bump_effect_calls`'s `let next = vm.effect_calls + 1;`,
+uses a bare `+`, which **wraps silently in a release build** (Rust's
+default, non-panicking release behavior for integer overflow) rather than
+erroring. A custom `ExecutionConfig` supplying `max_steps = usize::MAX` (or
+any caller-controlled quota field near that ceiling) combined with a
+sufficiently long-running program would eventually drive the counter's own
+`+ 1` increment past `usize::MAX`, wrapping to `0` - at which point `next
+(0) > limit (usize::MAX)` is false, and the quota silently stops
+functioning as fuel, defeating the entire bounded-termination guarantee
+this checkpoint exists to establish. This is a real, currently-latent
+pattern already present for `EffectCalls` today, not a new concern this
+decision invents, but #1759 must not repeat it for Steps/Calls given that
+Steps is specifically the bounded-*termination* promise.
+
+**Frozen rule for the implementation checkpoint (not implemented here):**
+Steps/Calls counters must increment via `checked_add` (or equivalent),
+returning a deterministic error if the increment itself would overflow -
+never a silent wraparound, and never a `wrapping_add`. This mirrors the
+exact discipline `docs/spec/semcode.md`'s own "Offset Arithmetic Must Stay
+Inside The Result Model" section already mandates for decode-time
+cursor/length arithmetic, generalized to runtime counters for the identical
+reason: an attacker- or misconfiguration-controlled value must never be
+able to wrap a safety-relevant counter back into an apparently-valid range.
+This audit does not extend the same requirement to the pre-existing
+`EffectCalls` counter's own `+ 1` - that is a `#1760`-or-later-adjacent
+finding outside #1759's own scope, recorded here for visibility only.
+
+## 11. Failure taxonomy boundary
+
+**Frozen: #1759 uses `RuntimeError::QuotaExceeded(QuotaExceeded { kind,
+limit, used })` exclusively - the existing, already-live, top-level
+channel every other quota kind already uses.** #1759 does **not** route
+through `RuntimeTrap::QuotaExceeded(QuotaExceeded)`, which is never
+constructed today (confirmed fresh in the Lane 5 audit) and whose fate is
+explicitly `#1763`'s own, later question. #1759 must not pre-empt that
+decision by choosing a channel for it as a side effect.
+
+## 12. Reproduction matrix (evidence design only, not implemented)
+
+**Steps:** a flat, verified, real-source backward loop (a `Stmt::Loop` or
+equivalent lowering to a backward `JMP`) with no calls, no effect opcodes,
+no register growth, and no frame growth - isolates Steps from every other
+quota so only it can be the failing one. Boundary cases: a program whose
+natural instruction count is exactly `limit - 1` (must complete normally),
+exactly `limit` (must complete normally - `used == limit` is not
+exhaustion, only `used > limit` is), `limit + 1` (must fail with
+`QuotaExceeded { kind: Steps, limit, used: limit + 1 }`), and `limit = 0`
+(must fail on the very first opcode, `used = 1`).
+
+**Calls:** an *iterative* (not recursive) caller that repeatedly invokes a
+tiny helper and returns after each call, deliberately avoiding growing
+stack depth so that `Frames`/`StackDepth` cannot become the first quota to
+fire and mask the Calls result - matching item 13's own explicit warning
+that a recursive-calls test is a poor primary proof for this reason.
+Boundary cases mirror Steps exactly: `limit - 1`, `limit`, `limit + 1`,
+and `limit = 0` invocations, with the same `used > limit` exhaustion
+convention and the same expected `QuotaExceeded { kind: Calls, ... }`
+shape. A root-entry-only program (zero nested calls) run under
+`max_calls = 0` must succeed, proving the root-exemption from §4/§9
+empirically, not just by code reading.
+
+## 13. Strongest falsification attempt overall
+
+The single strongest challenge to this whole contract is the one already
+surfaced in §1/§4: **`push_frame` is architecturally a single, undifferentiated
+choke point for both root and nested invocations**, which could have led to
+a naive, convenient-but-wrong implementation charging Calls unconditionally
+inside it. This decision survives that challenge only because `push_frame`
+already computes `next_depth` (equivalently, `vm.callstack.len()` before the
+push) for the Frames quota - a signal that already, for free, distinguishes
+"this is the first frame" from "this is a nested one." Had that signal not
+already existed for an unrelated reason, root-exemption would have required
+either a new boolean parameter threaded through every `push_frame` call site
+(a larger, more invasive change than this decision currently implies) or a
+weaker, less-precise heuristic. This is recorded explicitly because the
+*next* (implementation) checkpoint must not silently reach for a different,
+newly-invented signal instead of the one already justified here.
+
+## 14. Rejected alternatives summary
+
+| Question | Rejected alternative | Why rejected |
+|---|---|---|
+| Step charge point | successful-completion-based | starves the counter on any program that reliably fails a semantic check without terminating (§2) |
+| Step charge point | fetch-attempt-based (charges even on decode failure) | conflates quota exhaustion with decode/verification-admission bugs, which cannot occur for genuinely verified code (§2) |
+| Call definition | root-inclusive | collapses "no nested calls" and "no execution at all" into one `max_calls = 0` behavior, contradicting quotas.md's execution-bounding framing (§4) |
+| Call definition | attempt-based (charge on every `push_frame` call regardless of outcome) | conflates real invocations with ones rejected for unrelated resource reasons (§6) |
+| Call charge order | before Frames/StackDepth/Registers | counts invocations that never actually produced a frame (§6) |
+| Call charge order | as a derived count from Step-charged `CALL` opcodes | conflates builtin-resolved `CALL`s (no real invocation) with real ones (§5) |
+| Counter overflow | silent wraparound (bare `+`, matching existing `EffectCalls` precedent) | defeats the bounded-termination guarantee itself for a caller-controlled near-`usize::MAX` limit (§10) |
+| Failure channel | `RuntimeTrap::QuotaExceeded` | pre-empts `#1763`'s own, later, independent taxonomy decision (§11) |
+
+## 15. Effect on Lane 5 / AC4
+
+`#1759` remains **OPEN** after this document - a contract was decided, not
+implemented. AC4.a is **NOT SATISFIED**: no counter exists yet, so "every
+quota advertised as an active runtime bound has an authoritative resource"
+still fails for `Steps`/`Calls`. The next checkpoint is implementation,
+gated on a separate, explicit GO, covering: the two counters on `VM`, the
+charge points and root-exemption test frozen in §2-§9, `checked_add`
+overflow discipline per §10, the `RuntimeError::QuotaExceeded` channel per
+§11, and the reproduction matrix in §12 as permanent regression tests.
+
+**Wait for explicit GO before implementation.**

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -129,12 +129,18 @@ execution; Call = one admitted, non-root `push_frame` invocation (charged
 last, after signature/Frames/StackDepth/Registers admission, using the
 already-existing `vm.callstack.len() > 0` signal `push_frame` computes for
 its own Frames check to exempt the root/entry frame); exhaustion keeps the
-existing `used > limit` convention unchanged; failure channel is
-`RuntimeError::QuotaExceeded`, explicitly not `RuntimeTrap::QuotaExceeded`
-(that remains #1763's own, independent question - this decision does not
-resolve it). **This is a contract decision only. #1759 remains OPEN. No
-counter, no `enforce_quota` call site, and no test were added by this
-update - AC4.a remains not satisfied for `Steps`/`Calls` until a separately
+existing `used > limit` convention unchanged; overflow at the `usize::MAX`
+ceiling is fully frozen as a `checked_add`-based fail-closed rule with
+saturated-`usize::MAX` reporting on the single unrepresentable case, no new
+error channel; failure channel is `RuntimeError::QuotaExceeded`, explicitly
+not `RuntimeTrap::QuotaExceeded` (that remains #1763's own, independent
+question - this decision does not resolve it). This same pass also
+surfaced a new residual finding outside #1759's own scope - `EffectCalls`
+shares the pre-existing unchecked-overflow defect this decision closes for
+`Steps`/`Calls` - recorded in §8, finding 4. **This is a contract decision
+only. #1759 remains OPEN. No counter, no `enforce_quota` call site, and no
+test were added by this update - AC4.a remains not satisfied for `Steps`/
+`Calls` until a separately
 authorized implementation checkpoint lands.**
 
 ## 4. #1760 — `trace_enabled` / `max_trace_entries`
@@ -465,9 +471,28 @@ the five filed issues rather than silently expanding implementation scope:
    is not a safety gap (the quota genuinely is enforced, just not by the
    crate the spec names), but it is a documentation-precision gap worth
    fixing alongside whatever else touches `quotas.md`.
+4. **`EffectCalls` — an already-ACTIVE, already-enforced runtime quota — uses
+   unchecked `vm.effect_calls + 1` in `bump_effect_calls`, which wraps
+   silently (rather than erroring) in a release build if the counter is ever
+   driven near `usize::MAX`.** Discovered during the #1759 Steps/Calls
+   contract-decision pass while auditing overflow discipline for the two new
+   counters (see
+   `docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md`
+   §10.1) - not discovered by, and not part of, this document's own original
+   fresh-check pass. **Classification: FAIL-OPEN EDGE / QUALIFICATION GAP.**
+   **AC impact: AC4.a** - an active, enforced quota's counter is not
+   qualified to be fail-closed at its own numeric ceiling, which the #1759
+   decision now requires of `Steps`/`Calls` but does not itself apply to
+   `EffectCalls`. **This is not `#1760`** (`#1760` is `TraceEntries`/
+   `trace_enabled`) **and is not repaired by `#1759`** (`Steps`/`Calls` are
+   new counters; `EffectCalls` is a separate, pre-existing one) - `#1759`'s
+   implementation scope is explicitly not expanded to fix it. **Tracking
+   issue: not yet allocated** - whether this warrants its own filed issue is
+   a separate decision to make after the #1759 contract PR lands, not one
+   made by this audit.
 
-Neither of these three is added to Lane 5's implementation scope by this
-audit. They are recorded for a future, explicitly-scoped decision, per the
+None of these four is added to Lane 5's implementation scope by this audit.
+They are recorded for a future, explicitly-scoped decision, per the
 governing brief's own instruction not to silently expand scope.
 
 ## 9. Cross-issue interaction audit
@@ -531,7 +556,7 @@ specifically and only on `#1759`, as stated in §6.
 | `Frames` | `max_frames` | 256/256/256 | Call-stack frame count | `sm-vm` (`push_frame`) | frame push | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
 | `StackDepth` | `max_stack_depth` | 256/256/256 | Effective stack depth | `sm-vm` (`push_frame`) | frame push | `RuntimeError::StackOverflow` (compat: surfaced as `StackOverflow`, not `QuotaExceeded`, per `quotas.md`'s own documented compatibility note) | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
 | `Registers` | `max_registers` | 4096/4096/8192 | Register vector growth | `sm-vm` (frame init + growth) | register write | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
-| `EffectCalls` | `max_effect_calls` | 1024/0/4096 | Effect-opcode invocation count | `sm-vm` (`bump_effect_calls`) | effect opcode dispatch | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
+| `EffectCalls` | `max_effect_calls` | 1024/0/4096 | Effect-opcode invocation count | `sm-vm` (`bump_effect_calls`) | effect opcode dispatch | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE, numeric-ceiling overflow discipline not yet qualified** (§8 finding 4) |
 | `SymbolTable` | `max_symbol_table` | 16384 (all profiles) | Program-wide unique runtime symbol count | **`sm-verify`** (not `sm-vm` - see §12) | pre-execution, at admission | verifier `RejectReport` | yes | yes (#1820 suite) | `quotas.md` (ownership line inaccurate, §8) | **ACTIVE, wrong layer documented** |
 | `Steps` | `max_steps` | 100000/100000/250000 | *none* | *none* | *none* | *none* | no | no | `quotas.md` | **INERT** (#1759) |
 | `Calls` | `max_calls` | 16384/16384/32768 | *none* | *none* | *none* | *none* | no | no | `quotas.md` | **INERT** (#1759) |

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -121,6 +121,22 @@ point per `docs/spec/vm.md`'s "Callable Runtime Family Enforcement" section;
 the instruction-dispatch loop for steps), with both a finite-backward-loop
 and a repeated-call regression test.
 
+**Decision update (contract frozen, no implementation):** the three
+contract questions above have been frozen in
+`docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md` -
+Step = one decoded-opcode dispatch attempt, charged before semantic
+execution; Call = one admitted, non-root `push_frame` invocation (charged
+last, after signature/Frames/StackDepth/Registers admission, using the
+already-existing `vm.callstack.len() > 0` signal `push_frame` computes for
+its own Frames check to exempt the root/entry frame); exhaustion keeps the
+existing `used > limit` convention unchanged; failure channel is
+`RuntimeError::QuotaExceeded`, explicitly not `RuntimeTrap::QuotaExceeded`
+(that remains #1763's own, independent question - this decision does not
+resolve it). **This is a contract decision only. #1759 remains OPEN. No
+counter, no `enforce_quota` call site, and no test were added by this
+update - AC4.a remains not satisfied for `Steps`/`Calls` until a separately
+authorized implementation checkpoint lands.**
+
 ## 4. #1760 — `trace_enabled` / `max_trace_entries`
 
 **Fresh trace.** Repository-wide (`grep -rn "trace_enabled"`, all `.rs`


### PR DESCRIPTION
## Summary

CONTRACT DECISION ONLY. NO PRODUCTION BEHAVIOR CHANGE.

Freezes the exact Steps/Calls bounded-execution contract ahead of any
implementation:

- Step = one decoded-opcode dispatch attempt, charged before that
  instruction's semantic body executes (precedence over BorrowWriteConflict,
  semantic traps, host effects, and a same-instruction Calls charge).
- Call = one admitted, non-root `push_frame` invocation - charged last,
  after signature/Frames/StackDepth/Registers admission - using the
  `vm.callstack.len() > 0` signal `push_frame` already computes for its own
  Frames check to exempt the root/entry frame.
- Steps and Calls are orthogonal (a `CALL` opcode legitimately spends one of
  each).
- Both counters are execution-wide (not per-frame), shared across recursion
  and sibling calls.
- Raw/unverified execution paths share the same quota-bound VM engine.
- Zero-limit semantics for both quotas are frozen as direct applications of
  the general rules above, not special cases.
- **`usize::MAX` overflow is fully frozen**: a `checked_add`-based charge
  primitive, unconditionally fail-closed, with the externally reported
  `used` saturating at `usize::MAX` only for the single unrepresentable
  attempted-usage case (reporting-only - no wrap, no new error variant, no
  `RuntimeTrap` involvement). A future helper-level unit test design is
  specified that exercises this without executing `usize::MAX`
  instructions/calls.
- Failure channel is `RuntimeError::QuotaExceeded` (top-level) - explicitly
  not `RuntimeTrap::QuotaExceeded`, which stays a separate, independent,
  later question for the RuntimeTrap/RuntimeError taxonomy track.
- A reproduction-test design (non-recursive iterative Calls proof, flat
  backward-loop Steps proof) is specified, not implemented.

Full falsification-against-alternatives record is in the artifact.

**New residual finding surfaced during this pass (recorded, not fixed, not
in this issue's scope):** `EffectCalls` - an already-active, already-
enforced runtime quota - shares the same unchecked `+ 1` overflow defect
this decision closes for the new Steps/Calls counters. Classified FAIL-OPEN
EDGE / QUALIFICATION GAP against AC4.a. Not the trace-entries issue, not
repaired by this track, no tracking issue allocated yet.

Addresses issue tracked under the number one thousand seven hundred
fifty-nine (SSF-08 Lane 5). SSF-08 umbrella tracking issue in the one
thousand five hundreds remains OPEN - this PR does not close it or the
issue this PR addresses.

## Changes

- Add `docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md`
- Update `docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md`
  §3 (decision result), §8 (new EffectCalls residual finding), §10
  (inventory row) - decision result and residual finding only, does not
  mark the issue repaired or AC4.a satisfied

## Explicitly out of scope

- No VM step/call counter
- No `enforce_quota` call site changes
- No `RuntimeError`/`RuntimeTrap` restructuring
- No repair of the other Lane 5 findings
- No repair of the newly-found `EffectCalls` overflow residual

## Test plan

- [x] `git diff --check` (docs-only, clean)
- [x] Hosted CI - green at HEAD `aedd175e`
- [x] Fresh Codex review at exact HEAD `aedd175e`

**Wait for explicit GO before implementation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)