### PR TITLE
fix(vm): make EffectCalls accounting fail closed on overflow

### DIFF
--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1857,10 +1857,19 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> ApplicationVmHost<'a, H, C
     /// Charges one effect-call quota unit for an application host operation that
     /// already passed its capability check. Must run after `require`/`require_observation`
     /// and before the actual host dispatch, so quota exhaustion blocks the effect itself.
+    ///
+    /// #1900 (FA-08-011): reuses the shared `charge_counter` primitive - the
+    /// application-builtin boundary's own `EffectCalls` counter, independent
+    /// of the free-function `bump_effect_calls(vm)` used by Gate/Pulse/
+    /// State/Event/Clock opcodes, but charging the identical `QuotaKind`.
+    /// Both must share one arithmetic authority; this was the sibling
+    /// unchecked increment discovered while repairing the other.
     fn bump_effect_calls(&mut self) -> Result<(), RuntimeError> {
-        let next = self.effect_calls + 1;
-        enforce_quota(&self.quotas, QuotaKind::EffectCalls, next)?;
-        self.effect_calls = next;
+        self.effect_calls = charge_counter(
+            self.effect_calls,
+            self.quotas.max_effect_calls,
+            QuotaKind::EffectCalls,
+        )?;
         Ok(())
     }
 }
@@ -6973,6 +6982,125 @@ mod tests {
             host.reads.is_empty(),
             "the host must never be called once the quota rejects the charge"
         );
+    }
+
+    /// A minimal `ApplicationHostAbi` implementor for the sibling
+    /// `ApplicationVmHost::bump_effect_calls` tests below - never actually
+    /// invoked, since those tests call `bump_effect_calls` directly rather
+    /// than dispatching a real application builtin.
+    struct UnusedApplicationHost;
+
+    impl ApplicationHostAbi for UnusedApplicationHost {
+        fn args_read(&mut self, _index: u32) -> Result<String, AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+        fn stdin_read_text(&mut self) -> Result<String, AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+        fn stdout_write(&mut self, _text: &str) -> Result<(), AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+        fn stderr_write(&mut self, _text: &str) -> Result<(), AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+        fn path_inspect(&mut self, _path: &str) -> Result<bool, AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+        fn fs_read_text(&mut self, _path: &str) -> Result<String, AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+        fn fs_write_text(&mut self, _path: &str, _text: &str) -> Result<(), AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+        fn time_duration_millis(&mut self) -> Result<u32, AbiError> {
+            unimplemented!("not exercised by direct bump_effect_calls tests")
+        }
+    }
+
+    fn application_vm_host_for_test<'a>(
+        host: &'a mut UnusedApplicationHost,
+        capabilities: &'a prom_cap::CapabilityManifest,
+        effect_calls: usize,
+        max_effect_calls: usize,
+    ) -> ApplicationVmHost<'a, UnusedApplicationHost, prom_cap::CapabilityManifest> {
+        let mut quotas = RuntimeQuotas::verified_local();
+        quotas.max_effect_calls = max_effect_calls;
+        ApplicationVmHost {
+            host,
+            capabilities,
+            observed: false,
+            quotas,
+            effect_calls,
+        }
+    }
+
+    // --- #1900 (FA-08-011), owner-authorized scope expansion: the sibling
+    // `ApplicationVmHost::bump_effect_calls` charge path shares the exact
+    // same `QuotaKind::EffectCalls` resource and had the identical
+    // unchecked-increment defect - discovered while repairing the
+    // free-function path above, repaired here in the same checkpoint
+    // rather than deferred to a second issue, since both are production
+    // charge sites for one quota resource, not two separate features.
+
+    #[test]
+    fn application_vm_host_bump_effect_calls_admits_under_limit() {
+        let mut host = UnusedApplicationHost;
+        let capabilities = prom_cap::CapabilityManifest::for_application_profile(
+            prom_cap::ApplicationCapabilityProfile::Pure,
+        );
+        let mut bridge = application_vm_host_for_test(&mut host, &capabilities, 2, 4);
+        bridge.bump_effect_calls().expect("must admit");
+        assert_eq!(bridge.effect_calls, 3);
+    }
+
+    /// The #1900 edge itself, for the sibling counter: `effect_calls`
+    /// already at `usize::MAX` with a `usize::MAX` limit too, so the
+    /// ordinary `next > limit` comparison could never fire - only
+    /// `checked_add` failing closed on the increment itself catches this.
+    #[test]
+    fn application_vm_host_bump_effect_calls_fails_closed_at_usize_max_with_usize_max_limit() {
+        let mut host = UnusedApplicationHost;
+        let capabilities = prom_cap::CapabilityManifest::for_application_profile(
+            prom_cap::ApplicationCapabilityProfile::Pure,
+        );
+        let mut bridge =
+            application_vm_host_for_test(&mut host, &capabilities, usize::MAX, usize::MAX);
+        let err = bridge.bump_effect_calls().unwrap_err();
+        assert_eq!(
+            err,
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::EffectCalls,
+                limit: usize::MAX,
+                used: usize::MAX,
+            })
+        );
+        assert_eq!(
+            bridge.effect_calls,
+            usize::MAX,
+            "the counter must remain at usize::MAX, never wrap to 0"
+        );
+    }
+
+    /// Same ceiling case with a small, distinct configured limit - proves
+    /// saturation applies only to the unrepresentable attempted usage
+    /// (`used`), never to the caller's real configured `limit`.
+    #[test]
+    fn application_vm_host_bump_effect_calls_fails_closed_at_usize_max_with_distinct_limit() {
+        let mut host = UnusedApplicationHost;
+        let capabilities = prom_cap::CapabilityManifest::for_application_profile(
+            prom_cap::ApplicationCapabilityProfile::Pure,
+        );
+        let mut bridge = application_vm_host_for_test(&mut host, &capabilities, usize::MAX, 5);
+        let err = bridge.bump_effect_calls().unwrap_err();
+        assert_eq!(
+            err,
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::EffectCalls,
+                limit: 5,
+                used: usize::MAX,
+            })
+        );
+        assert_eq!(bridge.effect_calls, usize::MAX);
     }
 
     // --- #1771 (FA-09-003, umbrella #1617) regression matrix ---------------

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -3229,14 +3229,18 @@ fn enforce_quota(quotas: &RuntimeQuotas, kind: QuotaKind, used: usize) -> Result
     Ok(())
 }
 
-/// #1759: shared charge primitive for the `Steps`/`Calls` execution-wide
-/// counters, per `ssf08_1759_steps_calls_contract_decision.md` §10 - the
-/// only place either counter is incremented. Overflow-safe by construction:
-/// `used.checked_add(1)` never wraps. When the increment itself would
-/// overflow (`used` was already `usize::MAX`), this fails closed with the
-/// same `RuntimeError::QuotaExceeded` channel, reporting `used: usize::MAX`
-/// as SATURATED REPORTING for that one unrepresentable attempted-usage case
-/// only - never a silent wraparound, never a new error channel.
+/// Shared execution-counter charging primitive (originally #1759, now also
+/// #1900): the one place any of `sm-vm`'s execution-wide quota counters is
+/// incremented. Overflow-safe by construction: `used.checked_add(1)` never
+/// wraps. When the increment itself would overflow (`used` was already
+/// `usize::MAX`), this fails closed with the same `RuntimeError::
+/// QuotaExceeded` channel, reporting `used: usize::MAX` as SATURATED
+/// REPORTING for that one unrepresentable attempted-usage case only - never
+/// a silent wraparound, never a new error channel.
+///
+/// Currently used by: `Steps`, `Calls` (#1759), `EffectCalls` (#1900).
+/// VM execution mechanics, not public quota vocabulary - stays private here
+/// rather than moving to `sm-runtime-core`.
 fn charge_counter(used: usize, limit: usize, kind: QuotaKind) -> Result<usize, RuntimeError> {
     match used.checked_add(1) {
         Some(next) if next > limit => Err(RuntimeError::QuotaExceeded(QuotaExceeded {
@@ -3253,10 +3257,14 @@ fn charge_counter(used: usize, limit: usize, kind: QuotaKind) -> Result<usize, R
     }
 }
 
+/// #1900 (FA-08-011): reuses the shared `charge_counter` primitive instead
+/// of an unchecked `vm.effect_calls + 1`, which wrapped silently in release
+/// builds once the counter neared `usize::MAX`. Call sites, ordering
+/// relative to capability checks, and host dispatch are unchanged - this
+/// only replaces how the counter itself is incremented.
 fn bump_effect_calls(vm: &mut VM) -> Result<(), RuntimeError> {
-    let next = vm.effect_calls + 1;
-    enforce_quota(&vm.config.quotas, QuotaKind::EffectCalls, next)?;
-    vm.effect_calls = next;
+    let limit = vm.config.quotas.max_effect_calls;
+    vm.effect_calls = charge_counter(vm.effect_calls, limit, QuotaKind::EffectCalls)?;
     Ok(())
 }
 
@@ -6772,6 +6780,27 @@ mod tests {
         host: &mut H,
         capabilities: &C,
     ) -> (VM, Result<Value, RuntimeError>) {
+        run_prometheus_program_with_config_returning_vm(
+            instrs,
+            host,
+            capabilities,
+            ExecutionConfig::for_context(ExecutionContext::KernelBound),
+        )
+    }
+
+    /// Same as `run_prometheus_program_returning_vm`, but with an explicit
+    /// `ExecutionConfig` - needed by #1900's own EffectCalls-exhaustion test,
+    /// which requires a `max_effect_calls` tighter than `KernelBound`'s
+    /// default.
+    fn run_prometheus_program_with_config_returning_vm<
+        H: PrometheusHostAbi,
+        C: CapabilityChecker,
+    >(
+        instrs: Vec<IrInstr>,
+        host: &mut H,
+        capabilities: &C,
+        config: ExecutionConfig,
+    ) -> (VM, Result<Value, RuntimeError>) {
         let bytes = emit_ir_to_semcode(
             &[IrFunction {
                 name: "main".to_string(),
@@ -6782,7 +6811,6 @@ mod tests {
             false,
         )
         .expect("emit test program");
-        let config = ExecutionConfig::for_context(ExecutionContext::KernelBound);
         let token = verify_semcode_token_with_quotas(&bytes, config.quotas)
             .expect("test program must admit");
         let entry_token = token.require_entry("main").expect("main entry");
@@ -6821,6 +6849,129 @@ mod tests {
         assert_eq!(
             vm.calls, 0,
             "an effect opcode must not consume the Calls quota"
+        );
+    }
+
+    // --- #1900 (FA-08-011) EffectCalls numeric-ceiling fail-closed repair --
+    //
+    // `bump_effect_calls` is a private free function in this module, so
+    // these call it directly against a minimally constructed `VM` rather
+    // than driving a full compiled program - the same "test the extracted
+    // policy function directly" pattern already used for `charge_counter`
+    // itself. `tests/ssf04_effect_quota.rs`'s existing ordinary-case
+    // coverage (exact boundary, limit=0, capability-denied non-charge,
+    // quota-blocks-host) exercises `ApplicationVmHost::bump_effect_calls` -
+    // an architecturally separate counter for the application-host trust
+    // boundary, not this one. It stays green because this repair does not
+    // touch it, but it is not itself evidence for the function repaired
+    // here; the direct tests below are.
+
+    fn vm_for_effect_calls_test(effect_calls: usize, max_effect_calls: usize) -> VM {
+        let mut config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
+        config.quotas.max_effect_calls = max_effect_calls;
+        VM {
+            functions: HashMap::new(),
+            callstack: Vec::new(),
+            config,
+            effect_calls,
+            steps: 0,
+            calls: 0,
+            symbols: RuntimeSymbolTable::new(),
+            prng_state: 0,
+        }
+    }
+
+    #[test]
+    fn bump_effect_calls_admits_under_limit() {
+        let mut vm = vm_for_effect_calls_test(2, 4);
+        bump_effect_calls(&mut vm).expect("must admit");
+        assert_eq!(vm.effect_calls, 3);
+    }
+
+    #[test]
+    fn bump_effect_calls_rejects_at_zero_limit() {
+        let mut vm = vm_for_effect_calls_test(0, 0);
+        let err = bump_effect_calls(&mut vm).unwrap_err();
+        assert_eq!(
+            err,
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::EffectCalls,
+                limit: 0,
+                used: 1,
+            })
+        );
+        assert_eq!(vm.effect_calls, 0, "the rejected charge must not persist");
+    }
+
+    /// The #1900 edge itself: `effect_calls` already at `usize::MAX` with a
+    /// `usize::MAX` limit too, so the ordinary `next > limit` comparison
+    /// could never fire even in principle - only `checked_add` failing
+    /// closed on the increment itself catches this.
+    #[test]
+    fn bump_effect_calls_fails_closed_at_usize_max_with_usize_max_limit() {
+        let mut vm = vm_for_effect_calls_test(usize::MAX, usize::MAX);
+        let err = bump_effect_calls(&mut vm).unwrap_err();
+        assert_eq!(
+            err,
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::EffectCalls,
+                limit: usize::MAX,
+                used: usize::MAX,
+            })
+        );
+        assert_eq!(
+            vm.effect_calls,
+            usize::MAX,
+            "the counter must remain at usize::MAX, never wrap to 0"
+        );
+    }
+
+    /// Same ceiling case with a small, distinct configured limit - proves
+    /// saturation applies only to the unrepresentable *attempted usage*
+    /// (`used`), never to the caller's real configured `limit`.
+    #[test]
+    fn bump_effect_calls_fails_closed_at_usize_max_with_distinct_limit() {
+        let mut vm = vm_for_effect_calls_test(usize::MAX, 5);
+        let err = bump_effect_calls(&mut vm).unwrap_err();
+        assert_eq!(
+            err,
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::EffectCalls,
+                limit: 5,
+                used: usize::MAX,
+            })
+        );
+        assert_eq!(vm.effect_calls, usize::MAX);
+    }
+
+    /// End-to-end proof that an exhausted EffectCalls quota still blocks the
+    /// real `GateRead` opcode's host dispatch itself (unchanged call-site
+    /// ordering - #1900 only repairs the counter's own arithmetic, not when
+    /// it is charged relative to the host call).
+    #[test]
+    fn gate_read_blocked_by_effect_calls_quota_never_reaches_host() {
+        let mut host = prom_abi::RecordingHostAbi::with_read_value(AbiValue::Quad(1));
+        let capabilities = gate_read_capabilities();
+        let mut config = ExecutionConfig::for_context(ExecutionContext::KernelBound);
+        config.quotas.max_effect_calls = 0;
+        let (vm, result) = run_prometheus_program_with_config_returning_vm(
+            gate_read_into_return_program(),
+            &mut host,
+            &capabilities,
+            config,
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::EffectCalls,
+                limit: 0,
+                used: 1,
+            })
+        );
+        assert_eq!(vm.effect_calls, 0, "the rejected charge must not persist");
+        assert!(
+            host.reads.is_empty(),
+            "the host must never be called once the quota rejects the charge"
         );
     }
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -6867,13 +6867,14 @@ mod tests {
     // these call it directly against a minimally constructed `VM` rather
     // than driving a full compiled program - the same "test the extracted
     // policy function directly" pattern already used for `charge_counter`
-    // itself. `tests/ssf04_effect_quota.rs`'s existing ordinary-case
-    // coverage (exact boundary, limit=0, capability-denied non-charge,
-    // quota-blocks-host) exercises `ApplicationVmHost::bump_effect_calls` -
-    // an architecturally separate counter for the application-host trust
-    // boundary, not this one. It stays green because this repair does not
-    // touch it, but it is not itself evidence for the function repaired
-    // here; the direct tests below are.
+    // itself. The #1900 regression matrix covers both independent
+    // `EffectCalls` charge paths: this free VM effect-opcode counter is
+    // tested directly below; `ApplicationVmHost` (a separate counter for
+    // the application-builtin trust boundary) has its own direct
+    // numeric-ceiling tests later in this block; and
+    // `tests/ssf04_effect_quota.rs` independently preserves the ordinary
+    // application-builtin semantics (exact boundary, zero limit,
+    // capability-denied non-charge, quota-blocks-host) across both.
 
     fn vm_for_effect_calls_test(effect_calls: usize, max_effect_calls: usize) -> VM {
         let mut config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -507,6 +507,20 @@ the five filed issues rather than silently expanding implementation scope:
    new counters; `EffectCalls` is a separate, pre-existing one) - `#1759`'s
    implementation scope is explicitly not expanded to fix it. **Tracking
    issue: #1900 (FA-08-011)**, filed after the contract PR landed.
+   **Partially repaired in this checkpoint** - the free-function
+   `bump_effect_calls(vm: &mut VM)` site (Gate/Pulse/State/Event/Clock
+   opcodes) now reuses the shared `charge_counter` primitive #1759 landed
+   (generalized beyond `Steps`/`Calls` to cover all three execution
+   counters), fails closed at the `usize::MAX` ceiling with saturated-`used`
+   reporting only, and was verified by release-mode mutation proofs (a
+   restored bare `+ 1` wraps silently in `--release` and fails the ceiling
+   test; a `saturating_add` substitute lets the ceiling case through as
+   `Ok`, masking exhaustion). Call-site ordering relative to capability
+   checks and host dispatch is unchanged. A second, independent site,
+   `ApplicationVmHost::bump_effect_calls`, was found during this same
+   checkpoint to share the identical defect and remains unrepaired - see
+   §8 finding 6. This does not satisfy AC4.a for `EffectCalls`, nor AC4
+   globally - see §12.
 5. **`examples/benchmarks/snake_learning.sm` exceeds the already-published
    `VerifiedLocal` `max_steps = 100000` baseline by exactly one opcode
    (`QuotaExceeded { kind: Steps, limit: 100000, used: 100001 }`).**
@@ -529,8 +543,30 @@ the five filed issues rather than silently expanding implementation scope:
    silently patched. **Tracking issue: #1902 (FA-08-012)** - independent of
    #1759, so the ignore annotation does not cite an issue that will itself
    close once #1759's implementation lands.
+6. **`EffectCalls` has two architecturally independent enforcement sites,
+   and #1900 repaired only one of them.** `bump_effect_calls(vm: &mut VM)`
+   (the free function, called from `Opcode::GateRead`/`GateWrite`/
+   `PulseEmit`/`StateQuery`/`StateUpdate`/`EventPost`/`ClockRead` - the
+   PROMETHEUS/Gate-opcode host boundary) is now fail-closed via the shared
+   `charge_counter` primitive. `ApplicationVmHost::bump_effect_calls(&mut
+   self)` (a separate `effect_calls: usize` field on a separate host-bridge
+   type, called from the `args_read`/`fs_read_text`/`fs_write_text`/etc.
+   application-builtin boundary and exercised by
+   `tests/ssf04_effect_quota.rs`) still contains the identical unchecked
+   `let next = self.effect_calls + 1;`. #1900's own issue text and the
+   checkpoint that repaired it named only the free-function signature
+   verbatim, so this sibling was correctly left untouched rather than
+   fixed as an unauthorized scope expansion - but it means `EffectCalls` as
+   a whole quota kind is not yet uniformly fail-closed: one of its two real
+   charge sites still wraps silently in release builds under the same
+   `usize::MAX`-proximity condition #1900 exists to close. **Classification:
+   SIBLING FAIL-OPEN EDGE, DISCOVERED DURING #1900's OWN IMPLEMENTATION.**
+   **AC impact: AC4.a** - the criterion cannot be marked satisfied for
+   `EffectCalls` until this second site is repaired too. **Tracking issue:
+   not yet allocated** - a decision for after this checkpoint, not one this
+   checkpoint is authorized to make.
 
-None of these five is added to Lane 5's implementation scope by this audit.
+None of these six is added to Lane 5's implementation scope by this audit.
 They are recorded for a future, explicitly-scoped decision, per the
 governing brief's own instruction not to silently expand scope.
 
@@ -595,7 +631,7 @@ specifically and only on `#1759`, as stated in §6.
 | `Frames` | `max_frames` | 256/256/256 | Call-stack frame count | `sm-vm` (`push_frame`) | frame push | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
 | `StackDepth` | `max_stack_depth` | 256/256/256 | Effective stack depth | `sm-vm` (`push_frame`) | frame push | `RuntimeError::StackOverflow` (compat: surfaced as `StackOverflow`, not `QuotaExceeded`, per `quotas.md`'s own documented compatibility note) | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
 | `Registers` | `max_registers` | 4096/4096/8192 | Register vector growth | `sm-vm` (frame init + growth) | register write | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
-| `EffectCalls` | `max_effect_calls` | 1024/0/4096 | Effect-opcode invocation count | `sm-vm` (`bump_effect_calls`) | effect opcode dispatch | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE, numeric-ceiling overflow discipline not yet qualified** (§8 finding 4) |
+| `EffectCalls` | `max_effect_calls` | 1024/0/4096 | Effect-opcode invocation count | `sm-vm`, two independent sites: `bump_effect_calls(vm)` (Gate/Pulse/State/Event/Clock) and `ApplicationVmHost::bump_effect_calls` (application builtins) | effect opcode / builtin dispatch | `RuntimeError::QuotaExceeded` | yes | yes (existing suite + #1900 numeric-ceiling suite) | `quotas.md` | **ACTIVE; free-function site numeric-ceiling fail-closed and qualified (#1900); `ApplicationVmHost` site still unchecked** (§8 findings 4 and 6) |
 | `SymbolTable` | `max_symbol_table` | 16384 (all profiles) | Program-wide unique runtime symbol count | **`sm-verify`** (not `sm-vm` - see §12) | pre-execution, at admission | verifier `RejectReport` | yes | yes (#1820 suite) | `quotas.md` (ownership line inaccurate, §8) | **ACTIVE, wrong layer documented** |
 | `Steps` | `max_steps` | 100000/100000/250000 | Opcode-dispatch fuel counter | `sm-vm` (`exec_loop_with_profile`) | opcode decode succeeds | `RuntimeError::QuotaExceeded` | yes | yes (incl. backward-loop regression) | `quotas.md`, `vm.md` | **ACTIVE** (#1759, implemented, checked-add overflow discipline) |
 | `Calls` | `max_calls` | 16384/16384/32768 | Admitted non-root Semantic invocation count | `sm-vm` (`push_frame`) | frame push, root-exempt | `RuntimeError::QuotaExceeded` | yes | yes (incl. root-exemption + boundary suite) | `quotas.md`, `vm.md` | **ACTIVE** (#1759, implemented, checked-add overflow discipline) |
@@ -652,8 +688,10 @@ target contract for over-strengthening:
   authoritative resource, charge point, deterministic exhaustion behavior,
   and test. *(Satisfied for `Frames`/`StackDepth`/`Registers`/`SymbolTable`
   and, as of #1759's implementation, `Steps`/`Calls`; not satisfied for
-  `EffectCalls`, whose counter increment is not yet fail-closed at its own
-  numeric ceiling - §8 finding 4 / #1900.)*
+  `EffectCalls` - #1900 made its `bump_effect_calls(vm)` (Gate-opcode) site
+  fail-closed at the numeric ceiling, but its second, architecturally
+  independent site, `ApplicationVmHost::bump_effect_calls`, still uses the
+  identical unchecked increment - §8 findings 4 and 6.)*
 - **AC4.b** — Inert/deferred resource concepts are not presented as
   enforced runtime quotas. *(Not satisfied: `ConstPool` and, pending a
   decision, `TraceEntries` are presented as enforced quota kinds in

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -507,7 +507,7 @@ the five filed issues rather than silently expanding implementation scope:
    new counters; `EffectCalls` is a separate, pre-existing one) - `#1759`'s
    implementation scope is explicitly not expanded to fix it. **Tracking
    issue: #1900 (FA-08-011)**, filed after the contract PR landed.
-   **Partially repaired in this checkpoint** - the free-function
+   **Fully repaired in this checkpoint** - the free-function
    `bump_effect_calls(vm: &mut VM)` site (Gate/Pulse/State/Event/Clock
    opcodes) now reuses the shared `charge_counter` primitive #1759 landed
    (generalized beyond `Steps`/`Calls` to cover all three execution
@@ -518,9 +518,11 @@ the five filed issues rather than silently expanding implementation scope:
    `Ok`, masking exhaustion). Call-site ordering relative to capability
    checks and host dispatch is unchanged. A second, independent site,
    `ApplicationVmHost::bump_effect_calls`, was found during this same
-   checkpoint to share the identical defect and remains unrepaired - see
-   §8 finding 6. This does not satisfy AC4.a for `EffectCalls`, nor AC4
-   globally - see §12.
+   checkpoint to share the identical defect; owner-authorized scope
+   expansion repaired it too, before merge, with its own release-mode
+   mutation proof - see §8 finding 6. AC4.a is now satisfied for
+   `EffectCalls` as a whole quota kind; AC4 remains not satisfied globally
+   - see §12.
 5. **`examples/benchmarks/snake_learning.sm` exceeds the already-published
    `VerifiedLocal` `max_steps = 100000` baseline by exactly one opcode
    (`QuotaExceeded { kind: Steps, limit: 100000, used: 100001 }`).**
@@ -543,32 +545,36 @@ the five filed issues rather than silently expanding implementation scope:
    silently patched. **Tracking issue: #1902 (FA-08-012)** - independent of
    #1759, so the ignore annotation does not cite an issue that will itself
    close once #1759's implementation lands.
-6. **`EffectCalls` has two architecturally independent enforcement sites,
-   and #1900 repaired only one of them.** `bump_effect_calls(vm: &mut VM)`
-   (the free function, called from `Opcode::GateRead`/`GateWrite`/
-   `PulseEmit`/`StateQuery`/`StateUpdate`/`EventPost`/`ClockRead` - the
-   PROMETHEUS/Gate-opcode host boundary) is now fail-closed via the shared
-   `charge_counter` primitive. `ApplicationVmHost::bump_effect_calls(&mut
-   self)` (a separate `effect_calls: usize` field on a separate host-bridge
-   type, called from the `args_read`/`fs_read_text`/`fs_write_text`/etc.
-   application-builtin boundary and exercised by
-   `tests/ssf04_effect_quota.rs`) still contains the identical unchecked
-   `let next = self.effect_calls + 1;`. #1900's own issue text and the
-   checkpoint that repaired it named only the free-function signature
-   verbatim, so this sibling was correctly left untouched rather than
-   fixed as an unauthorized scope expansion - but it means `EffectCalls` as
-   a whole quota kind is not yet uniformly fail-closed: one of its two real
-   charge sites still wraps silently in release builds under the same
-   `usize::MAX`-proximity condition #1900 exists to close. **Classification:
-   SIBLING FAIL-OPEN EDGE, DISCOVERED DURING #1900's OWN IMPLEMENTATION.**
-   **AC impact: AC4.a** - the criterion cannot be marked satisfied for
-   `EffectCalls` until this second site is repaired too. **Tracking issue:
-   not yet allocated** - a decision for after this checkpoint, not one this
-   checkpoint is authorized to make.
+6. **`EffectCalls` had two architecturally independent enforcement sites
+   sharing one `QuotaKind`, and both are now repaired.**
+   `bump_effect_calls(vm: &mut VM)` (the free function, called from
+   `Opcode::GateRead`/`GateWrite`/`PulseEmit`/`StateQuery`/`StateUpdate`/
+   `EventPost`/`ClockRead` - the PROMETHEUS/Gate-opcode host boundary) and
+   `ApplicationVmHost::bump_effect_calls(&mut self)` (a separate
+   `effect_calls: usize` field on a separate host-bridge type introduced by
+   #1600 specifically so application builtins would also consume
+   `max_effect_calls`, called from the `args_read`/`fs_read_text`/
+   `fs_write_text`/etc. boundary and exercised by
+   `tests/ssf04_effect_quota.rs`) both had the identical unchecked
+   `+ 1` increment. Fresh implementation inspection during #1900 discovered
+   the sibling only after the free-function site was already repaired;
+   since both are production charge paths for the one `EffectCalls`
+   resource - not two separate features - the owner authorized expanding
+   #1900's own PR rather than filing a second issue. Both sites now reuse
+   the shared `charge_counter` primitive, and both were independently
+   proven load-bearing by their own release-mode mutation proof (the
+   sibling's own bare `+ 1` wraps silently under `--release`, exactly like
+   the free-function's did). **Classification: SIBLING FAIL-OPEN EDGE,
+   DISCOVERED AND REPAIRED WITHIN #1900's OWN IMPLEMENTATION CHECKPOINT,
+   BEFORE MERGE.** **AC impact: AC4.a** - now satisfied for `EffectCalls`
+   as a whole quota kind (both real charge sites are fail-closed and
+   tested); AC4 remains not satisfied globally, since AC4.b-e and
+   #1760-#1763 are unaffected. **Tracking issue: none allocated** - by
+   owner decision, this was resolved within #1900 rather than split into a
+   separate issue.
 
-None of these six is added to Lane 5's implementation scope by this audit.
-They are recorded for a future, explicitly-scoped decision, per the
-governing brief's own instruction not to silently expand scope.
+None of these six is added to Lane 5's implementation scope by this audit
+beyond #1900's own now-completed repair.
 
 ## 9. Cross-issue interaction audit
 
@@ -631,7 +637,7 @@ specifically and only on `#1759`, as stated in §6.
 | `Frames` | `max_frames` | 256/256/256 | Call-stack frame count | `sm-vm` (`push_frame`) | frame push | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
 | `StackDepth` | `max_stack_depth` | 256/256/256 | Effective stack depth | `sm-vm` (`push_frame`) | frame push | `RuntimeError::StackOverflow` (compat: surfaced as `StackOverflow`, not `QuotaExceeded`, per `quotas.md`'s own documented compatibility note) | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
 | `Registers` | `max_registers` | 4096/4096/8192 | Register vector growth | `sm-vm` (frame init + growth) | register write | `RuntimeError::QuotaExceeded` | yes | yes (existing suite) | `quotas.md` | **ACTIVE** |
-| `EffectCalls` | `max_effect_calls` | 1024/0/4096 | Effect-opcode invocation count | `sm-vm`, two independent sites: `bump_effect_calls(vm)` (Gate/Pulse/State/Event/Clock) and `ApplicationVmHost::bump_effect_calls` (application builtins) | effect opcode / builtin dispatch | `RuntimeError::QuotaExceeded` | yes | yes (existing suite + #1900 numeric-ceiling suite) | `quotas.md` | **ACTIVE; free-function site numeric-ceiling fail-closed and qualified (#1900); `ApplicationVmHost` site still unchecked** (§8 findings 4 and 6) |
+| `EffectCalls` | `max_effect_calls` | 1024/0/4096 | Effect-opcode invocation count | `sm-vm`, two independent sites: `bump_effect_calls(vm)` (Gate/Pulse/State/Event/Clock) and `ApplicationVmHost::bump_effect_calls` (application builtins) | effect opcode / builtin dispatch | `RuntimeError::QuotaExceeded` | yes | yes (existing suite + #1900 numeric-ceiling suite, both sites) | `quotas.md` | **ACTIVE; both production charge paths overflow-safe, numeric-ceiling fail-closed, qualified** (§8 findings 4 and 6 - both repaired by #1900) |
 | `SymbolTable` | `max_symbol_table` | 16384 (all profiles) | Program-wide unique runtime symbol count | **`sm-verify`** (not `sm-vm` - see §12) | pre-execution, at admission | verifier `RejectReport` | yes | yes (#1820 suite) | `quotas.md` (ownership line inaccurate, §8) | **ACTIVE, wrong layer documented** |
 | `Steps` | `max_steps` | 100000/100000/250000 | Opcode-dispatch fuel counter | `sm-vm` (`exec_loop_with_profile`) | opcode decode succeeds | `RuntimeError::QuotaExceeded` | yes | yes (incl. backward-loop regression) | `quotas.md`, `vm.md` | **ACTIVE** (#1759, implemented, checked-add overflow discipline) |
 | `Calls` | `max_calls` | 16384/16384/32768 | Admitted non-root Semantic invocation count | `sm-vm` (`push_frame`) | frame push, root-exempt | `RuntimeError::QuotaExceeded` | yes | yes (incl. root-exemption + boundary suite) | `quotas.md`, `vm.md` | **ACTIVE** (#1759, implemented, checked-add overflow discipline) |
@@ -686,12 +692,12 @@ target contract for over-strengthening:
 
 - **AC4.a** — Every quota advertised as an active runtime bound has an
   authoritative resource, charge point, deterministic exhaustion behavior,
-  and test. *(Satisfied for `Frames`/`StackDepth`/`Registers`/`SymbolTable`
-  and, as of #1759's implementation, `Steps`/`Calls`; not satisfied for
-  `EffectCalls` - #1900 made its `bump_effect_calls(vm)` (Gate-opcode) site
-  fail-closed at the numeric ceiling, but its second, architecturally
-  independent site, `ApplicationVmHost::bump_effect_calls`, still uses the
-  identical unchecked increment - §8 findings 4 and 6.)*
+  and test. *(Satisfied for `Frames`/`StackDepth`/`Registers`/`SymbolTable`,
+  as of #1759's implementation `Steps`/`Calls`, and as of #1900's
+  implementation `EffectCalls` - both of its independent charge sites,
+  `bump_effect_calls(vm)` (Gate-opcode) and
+  `ApplicationVmHost::bump_effect_calls` (application builtins), are now
+  fail-closed at the numeric ceiling - §8 findings 4 and 6.)*
 - **AC4.b** — Inert/deferred resource concepts are not presented as
   enforced runtime quotas. *(Not satisfied: `ConstPool` and, pending a
   decision, `TraceEntries` are presented as enforced quota kinds in

--- a/docs/spec/quotas.md
+++ b/docs/spec/quotas.md
@@ -118,11 +118,12 @@ Current compatibility note:
 `Steps`/`Calls` semantics (charge point, root-frame exemption, exhaustion
 timing, and `usize::MAX` overflow discipline) are frozen in
 `docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md`.
-Their counter increments use a `checked_add`-based primitive that fails
-closed at the `usize::MAX` ceiling (saturated `used` reporting only, never a
-silent wrap) - `EffectCalls`' own increment does not yet follow this same
-discipline (tracked separately, `docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md`
-§8 finding 4).
+`Steps` / `Calls` / `EffectCalls` execution counters use overflow-safe
+fail-closed charging (a shared `checked_add`-based primitive): ordinary
+usage reports the exact attempted value, and the single unrepresentable
+case (the increment itself would overflow `usize::MAX`) fails closed with
+`used` SATURATED at `usize::MAX` for reporting only - never a silent wrap,
+never continued execution.
 
 ## Determinism Rule
 


### PR DESCRIPTION
## Summary

Closes #1900
SSF-08 umbrella #1579 remains OPEN

#1900 covers the EffectCalls numeric-ceiling invariant across both
production charge paths:

- `bump_effect_calls(vm: &mut VM)` (the free function - `VM` dedicated
  effect opcodes: `GateRead`/`GateWrite`/`PulseEmit`/`StateQuery`/
  `StateUpdate`/`EventPost`/`ClockRead`)
- `ApplicationVmHost::bump_effect_calls(&mut self)` (application builtins:
  `args_read`/`fs_read_text`/`fs_write_text`/etc.)

Both now reuse the shared `charge_counter` primitive landed by #1759.
No quota baseline, taxonomy, context, trace, ConstPool, or snake benchmark
changes.

- `charge_counter`'s own doc comment generalized: no longer documented as
  Steps/Calls-only, now explicitly "currently used by: Steps, Calls,
  EffectCalls" (both charge sites).
- Ordinary limit behavior, exhaustion timing, and call-site ordering
  relative to capability/observation checks and host dispatch are
  byte-for-byte unchanged in both sites - this repairs only how each
  counter is incremented.
- `usize::MAX` ceiling: `used: usize::MAX` is SATURATED REPORTING only in
  both sites - never a silent wrap, never continued execution, never a new
  error variant, never `RuntimeTrap::QuotaExceeded`.

## Why both sites, one PR

Fresh implementation inspection discovered a second, architecturally
independent `EffectCalls` counter in `ApplicationVmHost` after the
free-function site was already repaired. Since both are production charge
paths for the *one* `EffectCalls` resource - not two separate features -
the owner authorized expanding this PR's own scope rather than filing a
second issue: splitting one arithmetic invariant across two issues would
have been artificial bureaucracy, and merging with only one site repaired
would have been a "#1900 CLOSED" claim that was formally false for half of
the resource it names.

## Tests

Direct regression coverage for **both** `bump_effect_calls` functions:
ordinary admit under limit, zero-limit reject (counter unmoved),
`usize::MAX` ceiling with both a `usize::MAX` limit and a small distinct
configured limit (proving saturation applies only to reported `used`,
never to `limit`) - plus an end-to-end `GateRead`-blocked-by-exhausted-
quota proof that the host is never reached for the free-function site.

`tests/ssf04_effect_quota.rs`'s existing 6 tests (exact boundary,
`limit=0`, capability-denied non-charge, quota-blocks-host, all eight
application builtins charged) remain green and unmodified - they exercise
`ApplicationVmHost`'s ordinary-case semantics directly and now also
validate the repaired path end-to-end.

## Mutation proofs (release-mode, all applied, confirmed predicted failure, fully reverted)

- **M1** (restore `vm.effect_calls + 1` in the free function): under
  `cargo test -p sm-vm --release`, wraps silently to `0` - both
  `usize::MAX`-ceiling tests for the free function fail.
- **M2** (`saturating_add(1)` in the free function instead of
  `checked_add`): the `limit == usize::MAX` ceiling test fails (saturation
  masks exhaustion); the distinct-small-limit test correctly still passes,
  exactly as expected for this specific masking case.
- **M3** (restore `self.effect_calls + 1` in `ApplicationVmHost`): under
  `--release`, wraps silently - both `usize::MAX`-ceiling tests for the
  sibling fail, while the free-function's own (unmutated) tests correctly
  stay green, confirming the two mutations are fully isolated from each
  other.

`grep -rn "MUTATION-"` returns zero matches on the final diff. Repository-
wide search confirms one arithmetic authority: no bare `effect_calls + 1`,
no `wrapping_add`, no `saturating_add` for `EffectCalls` execution
accounting remains anywhere outside `charge_counter`.

## Docs

Narrow updates only: `docs/spec/quotas.md` (from the prior commit - Steps/
Calls/EffectCalls share one overflow-safe fail-closed rule) and the Lane 5
audit doc (§3, §8 finding 6 - now "discovered and repaired within this
same checkpoint, before merge" rather than an open residual - §10
inventory row, §12 AC4.a text). **AC4.a is now satisfied for `EffectCalls`
as a whole quota kind; AC4 remains not satisfied globally** - the
remaining Lane 5 findings (`#1760`-`#1763`) are unaffected.

## Explicitly out of scope

- `#1760`-`#1763`, `#1902`
- `RuntimeTrap` taxonomy, quota baseline values, `ExecutionContext`
  semantics
- `sm-runtime-core` production code (unchanged)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clean` + `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p sm-vm --all-features`
- [x] `cargo test --test ssf04_effect_quota` (6/6, unchanged)
- [x] `cargo test -p sm-vm --release effect_calls` (8/8, incl. both sites)
- [x] `cargo test --workspace --no-fail-fast` (exit 0, zero failures)
- [x] `git diff --check`
- [x] Hosted CI green at exact HEAD `67e1b04c6597bbb040db0530d280a8dc71f4846d`
- [x] Fresh Codex review clean at exact HEAD `67e1b04c65`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
