### PR TITLE
fix(quota): remove false trace contract and preserve debug-symbol limit

### DIFF
--- a/crates/sm-runtime-core/src/lib.rs
+++ b/crates/sm-runtime-core/src/lib.rs
@@ -140,7 +140,6 @@ pub enum QuotaKind {
     Registers,
     SymbolTable,
     EffectCalls,
-    TraceEntries,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -176,7 +175,12 @@ pub struct RuntimeQuotas {
     pub max_registers: usize,
     pub max_symbol_table: usize,
     pub max_effect_calls: usize,
-    pub max_trace_entries: usize,
+    /// Per-function debug-symbol-table admission limit, enforced by
+    /// `sm-verify::verify_function_code` against `env.debug_symbols.len()`.
+    /// Not a `QuotaKind` member: never charged by `sm-vm`, never surfaces
+    /// as `RuntimeError::QuotaExceeded`. Kept on `RuntimeQuotas` only for
+    /// compatibility with existing per-profile admission plumbing (#1760).
+    pub max_debug_symbols_per_function: usize,
 }
 
 impl RuntimeQuotas {
@@ -189,7 +193,7 @@ impl RuntimeQuotas {
             max_registers: 4_096,
             max_symbol_table: 16_384,
             max_effect_calls: 1_024,
-            max_trace_entries: 8_192,
+            max_debug_symbols_per_function: 8_192,
         }
     }
 
@@ -202,7 +206,7 @@ impl RuntimeQuotas {
             max_registers: 4_096,
             max_symbol_table: 16_384,
             max_effect_calls: 0,
-            max_trace_entries: 4_096,
+            max_debug_symbols_per_function: 4_096,
         }
     }
 
@@ -215,7 +219,7 @@ impl RuntimeQuotas {
             max_registers: 8_192,
             max_symbol_table: 16_384,
             max_effect_calls: 4_096,
-            max_trace_entries: 16_384,
+            max_debug_symbols_per_function: 16_384,
         }
     }
 
@@ -228,7 +232,6 @@ impl RuntimeQuotas {
             QuotaKind::Registers => self.max_registers,
             QuotaKind::SymbolTable => self.max_symbol_table,
             QuotaKind::EffectCalls => self.max_effect_calls,
-            QuotaKind::TraceEntries => self.max_trace_entries,
         };
         (used > limit).then_some(QuotaExceeded { kind, limit, used })
     }
@@ -244,16 +247,11 @@ impl Default for RuntimeQuotas {
 pub struct ExecutionConfig {
     pub context: ExecutionContext,
     pub quotas: RuntimeQuotas,
-    pub trace_enabled: bool,
 }
 
 impl ExecutionConfig {
     pub const fn new(context: ExecutionContext, quotas: RuntimeQuotas) -> Self {
-        Self {
-            context,
-            quotas,
-            trace_enabled: false,
-        }
+        Self { context, quotas }
     }
 
     pub const fn for_context(context: ExecutionContext) -> Self {
@@ -435,7 +433,7 @@ mod tests {
         assert_eq!(verified_local.max_registers, 4_096);
         assert_eq!(verified_local.max_symbol_table, 16_384);
         assert_eq!(verified_local.max_effect_calls, 1_024);
-        assert_eq!(verified_local.max_trace_entries, 8_192);
+        assert_eq!(verified_local.max_debug_symbols_per_function, 8_192);
 
         let pure_compute = RuntimeQuotas::pure_compute();
         assert_eq!(pure_compute.max_steps, 100_000);
@@ -445,7 +443,7 @@ mod tests {
         assert_eq!(pure_compute.max_registers, 4_096);
         assert_eq!(pure_compute.max_symbol_table, 16_384);
         assert_eq!(pure_compute.max_effect_calls, 0);
-        assert_eq!(pure_compute.max_trace_entries, 4_096);
+        assert_eq!(pure_compute.max_debug_symbols_per_function, 4_096);
 
         let kernel_bound = RuntimeQuotas::kernel_bound();
         assert_eq!(kernel_bound.max_steps, 250_000);
@@ -455,7 +453,7 @@ mod tests {
         assert_eq!(kernel_bound.max_registers, 8_192);
         assert_eq!(kernel_bound.max_symbol_table, 16_384);
         assert_eq!(kernel_bound.max_effect_calls, 4_096);
-        assert_eq!(kernel_bound.max_trace_entries, 16_384);
+        assert_eq!(kernel_bound.max_debug_symbols_per_function, 16_384);
     }
 
     #[test]

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -1356,14 +1356,14 @@ fn verify_function_code(
     let string_count = env.strings.len();
 
     let debug_symbol_count = env.debug_symbols.len();
-    if debug_symbol_count > quotas.max_trace_entries {
+    if debug_symbol_count > quotas.max_debug_symbols_per_function {
         return Err(reject_one(
             name,
             VerificationCode::ResourceLimitExceeded,
             0,
             format!(
-                "debug section uses {} entries, exceeding the trace budget of {}",
-                debug_symbol_count, quotas.max_trace_entries
+                "debug section uses {} entries, exceeding the per-function debug-symbol limit of {}",
+                debug_symbol_count, quotas.max_debug_symbols_per_function
             ),
         ));
     }
@@ -6784,6 +6784,80 @@ mod tests {
             report.diagnostics[0].message,
             "debug symbol pc points past the instruction stream"
         );
+    }
+
+    /// #1760 (FA-08-002) test helper: builds a single-function artifact with
+    /// exactly `n` genuine debug symbols, one per instruction (matching
+    /// `emit_ir_to_semcode`'s real emission - each instruction contributes
+    /// exactly one `(pc, line, col)` entry, see `legacy_lowering.rs`'s `dbg.push`
+    /// call site). The last instruction is `Ret`; every earlier instruction is
+    /// a harmless repeated `LoadI32 { dst: 0, val: 0 }`, so the fixture is a
+    /// real, fully-verifiable function - not a hand-crafted byte blob - and
+    /// every debug pc genuinely lands on a real instruction start.
+    fn build_function_with_n_debug_symbols(n: usize) -> Vec<u8> {
+        assert!(n >= 1, "fixture needs at least the trailing Ret");
+        let mut instrs: Vec<IrInstr> = (0..n - 1)
+            .map(|_| IrInstr::LoadI32 { dst: 0, val: 0 })
+            .collect();
+        instrs.push(IrInstr::Ret { src: None });
+        emit_ir_to_semcode(
+            &[IrFunction {
+                name: "main".to_string(),
+                instrs,
+                ownership_events: Vec::new(),
+                params: Vec::new(),
+            }],
+            true,
+        )
+        .expect("emit")
+    }
+
+    // #1760 (FA-08-002): the renamed `max_debug_symbols_per_function` must
+    // preserve `pure_compute`'s pre-rename behavior exactly - 4096 genuine
+    // debug symbols (one per instruction) must still admit under
+    // `pure_compute`, whose configured limit is exactly 4096.
+    #[test]
+    fn verify_semcode_token_with_quotas_accepts_pure_compute_at_exactly_4096_debug_symbols() {
+        let bytes = build_function_with_n_debug_symbols(4_096);
+        let (_, functions) =
+            sm_format::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        assert_eq!(functions[0].debug_symbols.len(), 4_096);
+        verify_semcode_token_with_quotas(&bytes, RuntimeQuotas::pure_compute())
+            .expect("exactly 4096 debug symbols must be admitted under pure_compute's own limit");
+    }
+
+    // #1760 (FA-08-002): the adversarial proof this checkpoint exists for.
+    // 4097 debug symbols is within `sm-format`'s independent, unrelated fixed
+    // decode-time cap (`MAX_DEBUG_SYMBOLS_PER_FUNCTION = 8192`), so this
+    // artifact decodes cleanly - the rejection must come from `sm-verify`'s
+    // own `pure_compute`-configured limit (4096), proving the rename did not
+    // silently widen `pure_compute`'s admission to the decoder's 8192 cap.
+    #[test]
+    fn verify_semcode_token_with_quotas_rejects_pure_compute_at_4097_debug_symbols() {
+        let bytes = build_function_with_n_debug_symbols(4_097);
+        let report = verify_semcode_token_with_quotas(&bytes, RuntimeQuotas::pure_compute())
+            .expect_err("4097 debug symbols must exceed pure_compute's 4096 limit");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::ResourceLimitExceeded
+        );
+        assert_eq!(
+            report.diagnostics[0].message,
+            "debug section uses 4097 entries, exceeding the per-function debug-symbol limit of 4096"
+        );
+    }
+
+    // #1760 (FA-08-002): the same 4097-debug-symbol artifact that
+    // `pure_compute` rejects must remain accepted under `verified_local`
+    // (limit 8192) - this is the "dead code for verified_local/kernel_bound"
+    // half of the decision's falsification: the check only has real
+    // authority for `pure_compute`, whose 4096 is stricter than `sm-format`'s
+    // fixed 8192 decode-time cap.
+    #[test]
+    fn verify_semcode_token_with_quotas_verified_local_accepts_4097_debug_symbols() {
+        let bytes = build_function_with_n_debug_symbols(4_097);
+        verify_semcode_token_with_quotas(&bytes, RuntimeQuotas::verified_local())
+            .expect("4097 debug symbols must remain accepted under verified_local's 8192 limit");
     }
 
     // #1731 regression matrix (7/8): a truncated DBG0 tag or count must

--- a/docs/roadmap/stable_foundation/ssf08_1760_trace_contract_decision.md
+++ b/docs/roadmap/stable_foundation/ssf08_1760_trace_contract_decision.md
@@ -396,3 +396,78 @@ implemented. This document does not delete any field, variant, or golden
 snapshot entry, and does not touch `#1762`, `#1763`, or `#1902`.
 
 **Wait for explicit owner GO before implementation.**
+
+## 14. Implementation update (post-freeze)
+
+The SPLIT disposition frozen in §5 landed exactly as specified, on top of
+`main` at `38964cbd481a358dfb142859932ee5b2a2ea6e1d` (PR #1906's merge
+commit).
+
+- `ExecutionConfig::trace_enabled` - removed (field and its `false`
+  default in `ExecutionConfig::new`). `ExecutionConfig` now carries exactly
+  `context` and `quotas`.
+- `QuotaKind::TraceEntries` - removed from the enum and from
+  `RuntimeQuotas::exceed()`'s match.
+- `RuntimeQuotas::max_trace_entries` - renamed to
+  `RuntimeQuotas::max_debug_symbols_per_function`, values unchanged
+  (`verified_local = 8192`, `pure_compute = 4096`, `kernel_bound = 16384`).
+  `crates/sm-verify/src/lib.rs`'s `verify_function_code` check now reads
+  the renamed field; the comparison, rejection code
+  (`VerificationCode::ResourceLimitExceeded`), and rejection point are
+  byte-for-byte unchanged. Only the diagnostic wording changed, from
+  "exceeding the trace budget of {}" to "exceeding the per-function
+  debug-symbol limit of {}" - the false trace-contract wording could not
+  survive this implementation without recreating the exact problem this
+  checkpoint exists to remove; the underlying rejection semantics
+  (resource, scope, threshold, code) are identical.
+- Compiler fallout after the `sm-runtime-core` edit was exactly the two
+  sites this document's own §1.3 predicted (`crates/sm-verify/src/lib.rs`,
+  the `debug_symbol_count > quotas.max_trace_entries` check and its
+  diagnostic format arguments) - no unaccounted-for production reader
+  appeared.
+- Adversarial proof (the reason §1.3's finding mattered): a real,
+  compiling function with exactly 4096 debug symbols (one per real
+  instruction, built via `emit_ir_to_semcode`, every debug pc a genuine
+  instruction start) is admitted under `pure_compute`; the same
+  construction at 4097 is rejected under `pure_compute` with
+  `VerificationCode::ResourceLimitExceeded`, while remaining **accepted**
+  under `verified_local` (limit 8192) - confirming the rename preserved
+  `pure_compute`'s stricter behavior exactly rather than silently
+  widening it to the decoder's fixed 8192 cap. Two temporary mutations
+  each turned the 4097/`pure_compute` regression RED and were fully
+  reverted: (M1) loosening `pure_compute`'s configured value to 8192, and
+  (M2) bypassing the configured value with a hardcoded 8192 comparison in
+  `sm-verify`.
+- Public API guard: `cargo test --test public_api_contracts` failed RED
+  first, with drift isolated to exactly `TraceEntries,` removed,
+  `pub max_trace_entries: usize,` → `pub max_debug_symbols_per_function:
+  usize,`, and `pub trace_enabled: bool,` removed - no unrelated drift.
+  Regenerated via `SM_UPDATE_PUBLIC_API_SNAPSHOTS=1`, diff reviewed
+  manually, then GREEN.
+- `docs/spec/quotas.md`, `docs/spec/vm.md`, and `docs/spec/verifier.md`
+  updated to active-document the new field and its verifier-admission
+  scope, remove the retired trace vocabulary, and stop claiming
+  `ExecutionConfig` binds "trace enablement." A repository-wide residue
+  audit found zero remaining active references to `trace_enabled`,
+  `QuotaKind::TraceEntries`, `max_trace_entries`, or the old "trace
+  budget" wording anywhere in `crates/**`, `docs/spec/**`, or the public
+  API golden snapshot.
+- **AC4.b, freshly re-audited against the implementation branch (not
+  assumed from this document's own prior text):** every surviving
+  `QuotaKind` variant (`Steps`, `Calls`, `StackDepth`, `Frames`,
+  `Registers`, `SymbolTable`, `EffectCalls`) has a real, current
+  enforcement owner - `Steps`/`Calls`/`StackDepth`/`Frames`/`Registers`/
+  `EffectCalls` charged/enforced in `sm-vm`, `SymbolTable` enforced
+  statically by `sm-verify` (`unique_runtime_symbol_count >
+  quotas.max_symbol_table`, program-wide, at admission). No new inert
+  quota kind or field was discovered. `max_debug_symbols_per_function`
+  itself is correctly classified as verifier-admission policy, not a
+  runtime quota: zero `QuotaKind` membership, zero `sm-vm` charge sites,
+  zero `RuntimeError::QuotaExceeded` paths. **AC4.b: SATISFIED**, pending
+  the same fresh-audit caveat this document already carried in §12 - this
+  is a point-in-time confirmation on the current branch, not a permanent
+  guarantee against future additions.
+
+`#1762`, `#1763`, and `#1902` were not touched by this implementation.
+
+**Wait for explicit owner GO before merge.**

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -258,8 +258,8 @@ remains not satisfied for `TraceEntries`/`trace_enabled` until a
 separately authorized implementation checkpoint executes this
 now-complete mechanic.**
 
-**Implementation update (SPLIT disposition executed, #1760 still OPEN
-pending merge):** `ExecutionConfig::trace_enabled` and
+**Implementation update (SPLIT disposition implemented; issue closure is
+merge-gated):** `ExecutionConfig::trace_enabled` and
 `QuotaKind::TraceEntries` are removed; `RuntimeQuotas::max_trace_entries`
 is renamed to `RuntimeQuotas::max_debug_symbols_per_function` with its
 three profile values (8192/4096/16384) and its `sm-verify` admission

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -258,6 +258,24 @@ remains not satisfied for `TraceEntries`/`trace_enabled` until a
 separately authorized implementation checkpoint executes this
 now-complete mechanic.**
 
+**Implementation update (SPLIT disposition executed, #1760 still OPEN
+pending merge):** `ExecutionConfig::trace_enabled` and
+`QuotaKind::TraceEntries` are removed; `RuntimeQuotas::max_trace_entries`
+is renamed to `RuntimeQuotas::max_debug_symbols_per_function` with its
+three profile values (8192/4096/16384) and its `sm-verify` admission
+check preserved exactly, only the diagnostic's "trace budget" wording
+corrected. A repository-wide residue audit found zero remaining active
+references to the retired names in `crates/**`, `docs/spec/**`, or the
+public API golden snapshot. The public API guard was proven RED (drift
+isolated to exactly these three surfaces) before being regenerated GREEN.
+Two adversarial mutations (loosening `pure_compute`'s configured value to
+8192; bypassing the configured value with a hardcoded 8192 comparison)
+each turned a dedicated 4097-debug-symbol/`pure_compute` regression RED
+and were fully reverted, proving the rename did not silently widen
+`pure_compute`'s admission. Full detail:
+`docs/roadmap/stable_foundation/ssf08_1760_trace_contract_decision.md`
+§14.
+
 ## 5. #1761 — `ConstPool` quota
 
 **Fresh trace.** `QuotaKind::ConstPool`/`max_const_pool`: defined,
@@ -725,32 +743,56 @@ specifically and only on `#1759`, as stated in §6.
 | `SymbolTable` | `max_symbol_table` | 16384 (all profiles) | Program-wide unique runtime symbol count | **`sm-verify`** (not `sm-vm` - see §12) | pre-execution, at admission | verifier `RejectReport` | yes | yes (#1820 suite) | `quotas.md` (ownership line corrected by #1761's implementation PR - see below) | **ACTIVE, correctly documented** |
 | `Steps` | `max_steps` | 100000/100000/250000 | Opcode-dispatch fuel counter | `sm-vm` (`exec_loop_with_profile`) | opcode decode succeeds | `RuntimeError::QuotaExceeded` | yes | yes (incl. backward-loop regression) | `quotas.md`, `vm.md` | **ACTIVE** (#1759, implemented, checked-add overflow discipline) |
 | `Calls` | `max_calls` | 16384/16384/32768 | Admitted non-root Semantic invocation count | `sm-vm` (`push_frame`) | frame push, root-exempt | `RuntimeError::QuotaExceeded` | yes | yes (incl. root-exemption + boundary suite) | `quotas.md`, `vm.md` | **ACTIVE** (#1759, implemented, checked-add overflow discipline) |
-| `TraceEntries` | `max_trace_entries` | 8192/4096/16384 | *not a trace resource - `max_trace_entries`'s raw value bounds per-function debug-symbol count in `sm-verify`, mislabeled* | `sm-verify` (`verify_function_code`, not via `enforce_quota`) | pre-execution, at admission | `VerificationCode::ResourceLimitExceeded` | no | live only for `pure_compute` (4096 < `sm-format`'s fixed 8192 decode-time cap); dead code for the other two profiles | `quotas.md` | **`trace_enabled`/`TraceEntries`-as-tracing: INERT, REMOVE disposition frozen; `max_trace_entries`: real but mislabeled, RE-SCOPE disposition frozen, not yet implemented** (#1760) |
 
-`ConstPool`/`max_const_pool` is intentionally **no longer a row above** -
-it is not a current `RuntimeQuotas`/`QuotaKind` member. #1761's REMOVE
-disposition (frozen by
+`ConstPool`/`max_const_pool` and `TraceEntries`/`max_trace_entries` are
+intentionally **no longer rows above** - neither is a current
+`RuntimeQuotas`/`QuotaKind` member. #1761's REMOVE disposition (frozen by
 `docs/roadmap/stable_foundation/ssf08_1761_constpool_contract_decision.md`)
 has been implemented: the enum variant, the struct field, all three
 baseline-profile assignments, the `exceed()` match arm, the public API
 golden snapshot entries, and the active `docs/spec/quotas.md` references
-are all removed. It remains solely as historical record in the decision
-document and in §5 above - a resolved entry, not a live quota.
+are all removed. #1760's SPLIT disposition (frozen by
+`docs/roadmap/stable_foundation/ssf08_1760_trace_contract_decision.md`)
+has also been implemented: `QuotaKind::TraceEntries` and
+`ExecutionConfig::trace_enabled` are removed the same way; unlike
+`ConstPool`, `max_trace_entries` itself was not inert - its raw numeric
+value renamed in place to `RuntimeQuotas::max_debug_symbols_per_function`,
+values and `sm-verify` admission behavior preserved exactly, and is
+therefore intentionally still present on `RuntimeQuotas` under its new
+name and new, non-quota classification (see the "Verifier admission
+policy, not a runtime quota" row-equivalent note below). Both removed
+kinds remain solely as historical record in their own decision documents
+and in §4/§5 above - resolved entries, not live quotas.
 `docs/spec/quotas.md`'s own enforcement-owner text (previously overstating
-that all quota enforcement belongs to `sm-vm`) was also narrowed in the
-same PR to name `sm-verify`'s static enforcement of `SymbolTable`
-explicitly, since that PR was already the authoritative edit point for
-this exact file and the discrepancy (§8 finding 3) was already proven.
+that all quota enforcement belongs to `sm-vm`) was also narrowed, in
+#1761's implementation PR, to name `sm-verify`'s static enforcement of
+`SymbolTable` explicitly, since that PR was already the authoritative edit
+point for this exact file and the discrepancy (§8 finding 3) was already
+proven.
+
+**Verifier admission policy, not a runtime quota:**
+`max_debug_symbols_per_function` (formerly `max_trace_entries`) | 8192/
+4096/16384 | per-function debug-symbol-table admission limit | `sm-verify`
+(`verify_function_code`, direct field read, not via `QuotaKind`/
+`enforce_quota`) | pre-execution, at admission | `VerificationCode::
+ResourceLimitExceeded` | yes (4096-accepted, 4097-rejected-under-
+`pure_compute`, 4097-accepted-under-`verified_local`) | same suite | `quotas.md`,
+`verifier.md` | **ACTIVE, correctly classified as verifier-admission
+policy rather than a `QuotaKind` member - live specifically for
+`pure_compute` (4096 < `sm-format`'s fixed 8192 decode-time cap), dead
+code for `verified_local`/`kernel_bound`** (#1760, implemented).
 
 Every `QuotaKind` variant is accounted for above; at audit time four
 inert kinds were found (`Steps`, `Calls`, `ConstPool`, `TraceEntries`) -
-`Steps`/`Calls` are now `ACTIVE` (#1759) and `ConstPool` is now removed
-entirely (#1761); `TraceEntries` (#1760) has a frozen REMOVE/RE-SCOPE
-disposition (see §4's decision update) but is not yet implemented - and,
-unlike the other three, it turned out not to be uniformly inert: its raw
-`max_trace_entries` value has one real, mislabeled, profile-inconsistent
-consumer in `sm-verify`, discovered only during the `#1760` decision pass
-itself.
+all four are now resolved: `Steps`/`Calls` are `ACTIVE` (#1759),
+`ConstPool` is removed entirely (#1761), and `TraceEntries`/
+`trace_enabled` are removed entirely with `max_trace_entries`'s real,
+mislabeled, profile-inconsistent consumer preserved under its correct
+name and classification (#1760). The seven remaining `QuotaKind`
+variants (`Frames`, `StackDepth`, `Registers`, `EffectCalls`,
+`SymbolTable`, `Steps`, `Calls`) each have a real, current enforcement
+owner, freshly re-confirmed against the `#1760` implementation branch
+(not assumed from this table's own prior text) - see §12.
 
 ## 11. Verifier limits vs runtime quotas (architecture check)
 
@@ -803,17 +845,24 @@ target contract for over-strengthening:
   `ApplicationVmHost::bump_effect_calls` (application builtins), are now
   fail-closed at the numeric ceiling - §8 findings 4 and 6.)*
 - **AC4.b** — Inert/deferred resource concepts are not presented as
-  enforced runtime quotas. *(Partially satisfied: `ConstPool`'s REMOVE
-  disposition (see
+  enforced runtime quotas. *(Satisfied, freshly re-audited against the
+  current implementation branch rather than assumed from this document's
+  own prior text: `ConstPool`'s REMOVE disposition (see
   `docs/roadmap/stable_foundation/ssf08_1761_constpool_contract_decision.md`)
-  has landed - it is no longer presented as a quota kind anywhere in
-  production code, the public API, or `docs/spec/quotas.md`. Not satisfied
-  globally: `TraceEntries`'s disposition is now decided (REMOVE for
-  `trace_enabled`/the taxonomy member, RE-SCOPE for the real but
-  mislabeled `max_trace_entries` value - see
+  and `TraceEntries`/`trace_enabled`'s REMOVE disposition (see
   `docs/roadmap/stable_foundation/ssf08_1760_trace_contract_decision.md`)
-  but not yet implemented; it is still presented as an enforced quota kind
-  in `docs/spec/quotas.md` today.)*
+  have both landed - neither is presented as a quota kind anywhere in
+  production code, the public API, or `docs/spec/quotas.md`.
+  `max_trace_entries`'s real but mislabeled consumer was RE-SCOPED, not
+  deleted: it survives as `RuntimeQuotas::max_debug_symbols_per_function`,
+  explicitly documented as verifier-admission policy rather than a
+  `QuotaKind` member (zero `QuotaKind` membership, zero `sm-vm` charge
+  sites, zero `RuntimeError::QuotaExceeded` paths). Every remaining
+  `QuotaKind` variant (`Frames`, `StackDepth`, `Registers`, `EffectCalls`,
+  `SymbolTable`, `Steps`, `Calls`) was re-enumerated against current code
+  and has a real, current enforcement owner - see §10. This is a
+  point-in-time confirmation on the current branch, not a standing
+  guarantee against a future addition reopening the same failure mode.)*
 - **AC4.c** — `ExecutionContext`/provenance does not overstate the quota
   envelope that actually governed execution. *(Not satisfied: `prom-runtime`/
   `prom-audit` record only the context label, and nothing validates

--- a/docs/spec/quotas.md
+++ b/docs/spec/quotas.md
@@ -28,7 +28,6 @@ Current quota kinds:
 - `Registers`
 - `SymbolTable`
 - `EffectCalls`
-- `TraceEntries`
 
 Current quota descriptor fields:
 
@@ -39,7 +38,10 @@ Current quota descriptor fields:
 - `max_registers`
 - `max_symbol_table`
 - `max_effect_calls`
-- `max_trace_entries`
+
+`RuntimeQuotas` also carries a field that is not part of this taxonomy -
+`max_debug_symbols_per_function` - see "Verifier Admission Compatibility
+Note" below.
 
 ## Current Baseline Profiles
 
@@ -52,7 +54,6 @@ Current quota descriptor fields:
 - `max_registers = 4096`
 - `max_symbol_table = 16384`
 - `max_effect_calls = 1024`
-- `max_trace_entries = 8192`
 
 ### `pure_compute`
 
@@ -63,7 +64,6 @@ Current quota descriptor fields:
 - `max_registers = 4096`
 - `max_symbol_table = 16384`
 - `max_effect_calls = 0`
-- `max_trace_entries = 4096`
 
 ### `kernel_bound`
 
@@ -74,7 +74,39 @@ Current quota descriptor fields:
 - `max_registers = 8192`
 - `max_symbol_table = 16384`
 - `max_effect_calls = 4096`
-- `max_trace_entries = 16384`
+
+## Verifier Admission Compatibility Note
+
+`RuntimeQuotas` also carries `max_debug_symbols_per_function`:
+
+- `verified_local = 8192`
+- `pure_compute = 4096`
+- `kernel_bound = 16384`
+
+This field:
+
+- is a verifier-side per-function debug-metadata admission limit, enforced
+  by `sm-verify::verify_function_code` against a decoded function's
+  `debug_symbols.len()`
+- is **not** a `QuotaKind` member and is not listed in the quota taxonomy
+  above
+- is **not** charged by `sm-vm` and has no runtime charge point
+- is **not** surfaced as `RuntimeError::QuotaExceeded` - a rejection under
+  this limit is a static admission failure
+  (`VerificationCode::ResourceLimitExceeded`), not a runtime quota
+  exhaustion
+- remains a field on `RuntimeQuotas` only to preserve the existing
+  per-profile admission plumbing (#1760, FA-08-002); it is intentionally
+  kept distinct from the runtime quota taxonomy above rather than merged
+  into it
+
+`sm-format` independently enforces a fixed, profile-independent decode-time
+structural cap, `MAX_DEBUG_SYMBOLS_PER_FUNCTION = 8192`, before this
+verifier-layer check ever runs. `verified_local` (8192) and `kernel_bound`
+(16384, which cannot widen the decoder's own fixed 8192 cap) make this
+verifier-layer check dead code in practice; `pure_compute` (4096) is
+strictly tighter than the decoder's 8192 cap, so this check has real,
+distinct authority only for `pure_compute`.
 
 ## Context Mapping
 

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -443,6 +443,35 @@ never be conflated:
   governing VM execution after admission (`max_steps`, `max_calls`, and so
   on).
 
+**Per-function debug-symbol admission** (#1760, FA-08-002) is a distinct
+artifact-admission check inside `verify_function_code`, separate from both
+`sm-format`'s own fixed decode-time cap and the `VerificationLimits`
+analysis budgets above:
+
+- rule: `env.debug_symbols.len()` (the decoded `DBG0` per-function
+  debug-symbol table: pc/line/col) must not exceed
+  `RuntimeQuotas::max_debug_symbols_per_function` for the active admission
+  profile; violation rejects with
+  `VerificationCode::ResourceLimitExceeded`
+- profile values: `verified_local = 8192`, `pure_compute = 4096`,
+  `kernel_bound = 16384`
+- this is independent of `sm_format::semcode_decode::MAX_DEBUG_SYMBOLS_PER_FUNCTION
+  = 8192`, a fixed, profile-independent structural cap enforced at decode
+  time, before this verifier-layer check ever runs. `verified_local`'s
+  8192 exactly matches the decoder cap, and `kernel_bound`'s 16384 cannot
+  widen it - the decoder already rejects anything above 8192 for every
+  profile - so this check is dead code for both. `pure_compute`'s 4096 is
+  strictly tighter than the decoder's 8192, so this check has real,
+  distinct admission authority only for `pure_compute`.
+- despite living on `RuntimeQuotas` and using
+  `VerificationCode::ResourceLimitExceeded` (the same code family as the
+  artifact/decode resources above), this field is **not** a `QuotaKind`
+  member, is never charged by `sm-vm`, and never surfaces as
+  `RuntimeError::QuotaExceeded` - see
+  [`quotas.md`](quotas.md#verifier-admission-compatibility-note) for the
+  full compatibility note and rationale for why it stays on `RuntimeQuotas`
+  rather than moving into `VerificationLimits`
+
 **Scope of the two `VerificationLimits` fields differs, deliberately**
 (clarified in round 14 of #1756's own review history, after Codex found
 both fields' enforcement did not yet match this intended scope):

--- a/docs/spec/vm.md
+++ b/docs/spec/vm.md
@@ -83,7 +83,6 @@ The VM consumes `ExecutionConfig`, which binds:
 
 - `ExecutionContext`
 - `RuntimeQuotas`
-- trace enablement
 
 Current execution contexts:
 

--- a/tests/golden_snapshots/public_api/sm_runtime_core_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_runtime_core_lib.txt
@@ -50,7 +50,6 @@ Frames,
 Registers,
 SymbolTable,
 EffectCalls,
-TraceEntries,
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QuotaExceeded {
 pub kind: QuotaKind,
@@ -80,7 +79,7 @@ pub max_frames: usize,
 pub max_registers: usize,
 pub max_symbol_table: usize,
 pub max_effect_calls: usize,
-pub max_trace_entries: usize,
+pub max_debug_symbols_per_function: usize,
 pub const fn verified_local() -> Self {
 pub const fn pure_compute() -> Self {
 pub const fn kernel_bound() -> Self {
@@ -89,7 +88,6 @@ pub fn exceed(self, kind: QuotaKind, used: usize) -> Option<QuotaExceeded> {
 pub struct ExecutionConfig {
 pub context: ExecutionContext,
 pub quotas: RuntimeQuotas,
-pub trace_enabled: bool,
 pub const fn new(context: ExecutionContext, quotas: RuntimeQuotas) -> Self {
 pub const fn for_context(context: ExecutionContext) -> Self {
 #[cfg(any(feature = "alloc", feature = "std"))]


### PR DESCRIPTION
## Summary

Closes #1760
SSF-08 umbrella #1579 remains OPEN

Implements the SPLIT disposition frozen by PR #1906
(`docs/roadmap/stable_foundation/ssf08_1760_trace_contract_decision.md`):

- remove `ExecutionConfig::trace_enabled`
- remove `QuotaKind::TraceEntries`
- rename `RuntimeQuotas::max_trace_entries` to
  `RuntimeQuotas::max_debug_symbols_per_function`, preserving its exact
  profile values (`verified_local = 8192`, `pure_compute = 4096`,
  `kernel_bound = 16384`) and its real `sm-verify` admission check
  byte-for-byte

Intentional public API narrowing. No runtime tracing is introduced.

## Why the third symbol was renamed, not deleted

Falsification (done at decision time, PR #1906) found `trace_enabled` and
`QuotaKind::TraceEntries` fully inert - zero readers, zero enforcement -
but `max_trace_entries`'s raw numeric value has a real, live,
non-`enforce_quota` reader in `sm-verify::verify_function_code`, bounding
a decoded function's `debug_symbols.len()`. This is dead code for
`verified_local`/`kernel_bound` (redundant with `sm-format`'s fixed
`MAX_DEBUG_SYMBOLS_PER_FUNCTION = 8192`) but genuinely live for
`pure_compute` (4096, stricter than 8192). Deleting it outright would
silently loosen `pure_compute`'s admission from 4096 to 8192 debug
symbols per function - an undisclosed policy change, not a vocabulary
cleanup. The rename preserves this behavior exactly while fixing the
misleading name and removing it from the `QuotaKind` taxonomy.

## Changes

- `crates/sm-runtime-core/src/lib.rs`: `QuotaKind::TraceEntries` and
  `ExecutionConfig::trace_enabled` removed; `RuntimeQuotas::max_trace_entries`
  renamed to `max_debug_symbols_per_function` (values unchanged); the
  `exceed()` match arm for `TraceEntries` removed.
- `crates/sm-verify/src/lib.rs`: the debug-symbol admission check now
  reads the renamed field; diagnostic wording corrected from "exceeding
  the trace budget of {}" to "exceeding the per-function debug-symbol
  limit of {}" (wording only - rejection code, scope, and threshold
  unchanged). Added three focused regression tests: exactly 4096 debug
  symbols accepted under `pure_compute`, 4097 rejected under
  `pure_compute`, and the same 4097 artifact still accepted under
  `verified_local` (proving the check's real authority is
  profile-specific, not uniform).
- `tests/golden_snapshots/public_api/sm_runtime_core_lib.txt`: updated via
  `SM_UPDATE_PUBLIC_API_SNAPSHOTS=1` after proving the guard fails RED
  first, isolated to exactly these three surfaces.
- `docs/spec/quotas.md`, `docs/spec/verifier.md`, `docs/spec/vm.md`:
  retired trace vocabulary removed from the active taxonomy;
  `max_debug_symbols_per_function` documented as verifier-admission
  policy, explicitly not a `QuotaKind` member; `ExecutionConfig`'s binding
  list corrected to drop "trace enablement."
- `docs/roadmap/stable_foundation/ssf08_1760_trace_contract_decision.md`:
  original falsification/decision text preserved unedited; §14
  implementation-status addendum appended.
- `docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md`:
  §4 implementation-complete addendum (reworded once, post-review, to a
  merge-gated framing so it can't go stale the instant this PR merges),
  §10 inventory updated (`TraceEntries` row removed,
  `max_debug_symbols_per_function` documented as verifier-admission
  policy), §12 AC4.b text updated to SATISFIED (freshly re-audited
  against this branch).

## Mutation proofs (applied and reverted, zero markers remain)

- **M1** (profile-loosening): `pure_compute.max_debug_symbols_per_function`
  temporarily changed 4096 → 8192. The 4097/`pure_compute` regression
  turned RED as predicted. Reverted.
- **M2** (verifier-bypass): the verifier comparison temporarily replaced
  with a hardcoded `8_192` limit. The same regression turned RED.
  Reverted.

## AC4.b, freshly re-audited (not assumed)

Every surviving `QuotaKind` variant has a real, current enforcement owner:

| Kind | Owner |
|---|---|
| `Steps` | `sm-vm` (`exec_loop_with_profile`) |
| `Calls` | `sm-vm` (`push_frame`) |
| `StackDepth` | `sm-vm` (`push_frame`) |
| `Frames` | `sm-vm` (`push_frame`) |
| `Registers` | `sm-vm` (frame init + growth) |
| `SymbolTable` | `sm-verify` (static, program-wide, at admission) |
| `EffectCalls` | `sm-vm` (both charge sites, #1900) |

`max_debug_symbols_per_function` is correctly classified as
verifier-admission policy: zero `QuotaKind` membership, zero `sm-vm`
charge sites, zero `RuntimeError::QuotaExceeded` paths. No new inert
kind or field was discovered. **AC4.b: SATISFIED.**

## Explicitly out of scope

- Moving `max_debug_symbols_per_function` into `VerificationLimits`
- Changing `sm-format`'s fixed `MAX_DEBUG_SYMBOLS_PER_FUNCTION = 8192`
- Loosening `pure_compute`'s 4096 debug-symbol limit
- Adding runtime tracing or any replacement tracing flag
- `#1762`, `#1763`, `#1902` - untouched

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clean` + `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p sm-runtime-core --all-features` (10/10)
- [x] `cargo test -p sm-verify --all-features` (pre-existing, baseline-confirmed
      `profile-rust` feature-isolation quirk aside - see PR discussion)
- [x] `cargo test --test public_api_contracts` (RED with stale golden,
      isolated to the three intended surfaces; GREEN after regeneration)
- [x] `cargo test --workspace --no-fail-fast` (zero failures)
- [x] `cargo check -p sm-runtime-core --no-default-features`
- [x] `git diff --check`
- [x] Focused 4096/4097 `pure_compute`/`verified_local` boundary regression
- [x] M1/M2 mutation proofs (RED, reverted)
- [x] Hosted CI green at exact HEAD 77d9697f8e4272ed2098ca19d997b1e6965bd348
- [x] Fresh Codex review clean at exact HEAD 77d9697f8e

**Exact-head qualification complete. Wait for owner GO before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
