### PR TITLE
fix(audit): record effective runtime quota envelope

### DIFF
--- a/crates/prom-audit/src/lib.rs
+++ b/crates/prom-audit/src/lib.rs
@@ -8,7 +8,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use hello_observation_audit::ControlledObservationAuditDecision;
 use prom_cap::{CapabilityKind, CapabilityManifestMetadata, CapabilityManifestVersion};
-use sm_runtime_core::ExecutionContext;
+use sm_runtime_core::{ExecutionContext, RuntimeQuotas};
 
 const AUDIT_REPLAY_ARCHIVE_MAGIC: &str = "semantic_audit_replay_archive";
 const MULTI_SESSION_REPLAY_ARCHIVE_MAGIC: &str = "semantic_multi_session_replay_archive";
@@ -19,6 +19,7 @@ pub struct AuditEventId(pub u64);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditSessionMetadata {
     pub context: ExecutionContext,
+    pub quotas: RuntimeQuotas,
     pub capability_manifest: CapabilityManifestMetadata,
     pub gate_registry_bound: bool,
 }
@@ -80,7 +81,7 @@ pub struct ReplayMetadata {
     pub last_event_id: Option<AuditEventId>,
 }
 
-pub const AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION: u32 = 1;
+pub const AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION: u32 = 2;
 pub const MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -197,6 +198,28 @@ impl AuditReplayArchive {
         } else {
             "false"
         });
+        out.push('\t');
+        out.push_str(&self.session.quotas.max_steps.to_string());
+        out.push('\t');
+        out.push_str(&self.session.quotas.max_calls.to_string());
+        out.push('\t');
+        out.push_str(&self.session.quotas.max_stack_depth.to_string());
+        out.push('\t');
+        out.push_str(&self.session.quotas.max_frames.to_string());
+        out.push('\t');
+        out.push_str(&self.session.quotas.max_registers.to_string());
+        out.push('\t');
+        out.push_str(&self.session.quotas.max_symbol_table.to_string());
+        out.push('\t');
+        out.push_str(&self.session.quotas.max_effect_calls.to_string());
+        out.push('\t');
+        out.push_str(
+            &self
+                .session
+                .quotas
+                .max_debug_symbols_per_function
+                .to_string(),
+        );
         out.push('\n');
         out.push_str("events\t");
         out.push_str(&self.events.len().to_string());
@@ -242,7 +265,7 @@ impl AuditReplayArchive {
             .next()
             .ok_or_else(|| AuditReplayArchiveFormatError::new("missing session line"))?;
         let session_parts = split_archive_line(session_line);
-        if session_parts.len() != 5 || session_parts[0] != "session" {
+        if session_parts.len() != 13 || session_parts[0] != "session" {
             return Err(AuditReplayArchiveFormatError::new("invalid session line"));
         }
         let session = AuditSessionMetadata {
@@ -252,6 +275,19 @@ impl AuditReplayArchive {
                 version: parse_manifest_version(session_parts[3])?,
             },
             gate_registry_bound: parse_bool_field(session_parts[4], "gate registry bound")?,
+            quotas: RuntimeQuotas {
+                max_steps: parse_usize_field(session_parts[5], "max_steps")?,
+                max_calls: parse_usize_field(session_parts[6], "max_calls")?,
+                max_stack_depth: parse_usize_field(session_parts[7], "max_stack_depth")?,
+                max_frames: parse_usize_field(session_parts[8], "max_frames")?,
+                max_registers: parse_usize_field(session_parts[9], "max_registers")?,
+                max_symbol_table: parse_usize_field(session_parts[10], "max_symbol_table")?,
+                max_effect_calls: parse_usize_field(session_parts[11], "max_effect_calls")?,
+                max_debug_symbols_per_function: parse_usize_field(
+                    session_parts[12],
+                    "max_debug_symbols_per_function",
+                )?,
+            },
         };
 
         let events_line = lines
@@ -980,6 +1016,7 @@ mod tests {
     fn sample_session() -> AuditSessionMetadata {
         AuditSessionMetadata {
             context: ExecutionContext::KernelBound,
+            quotas: RuntimeQuotas::kernel_bound(),
             capability_manifest: CapabilityManifestMetadata {
                 schema: "prom.cap.manifest".to_string(),
                 version: prom_cap::CapabilityManifestVersion::V1,
@@ -1271,8 +1308,8 @@ mod tests {
     #[test]
     fn replay_archive_rejects_event_count_mismatch() {
         let text = "\
-semantic_audit_replay_archive\t1\n\
-session\tkernel-bound\tprom.cap.manifest\tv1\ttrue\n\
+semantic_audit_replay_archive\t2\n\
+session\tkernel-bound\tprom.cap.manifest\tv1\ttrue\t250000\t32768\t256\t256\t8192\t16384\t4096\t16384\n\
 events\t1\n\
 replay\t0\tnone\n";
 
@@ -1284,8 +1321,8 @@ replay\t0\tnone\n";
     #[test]
     fn replay_archive_rejects_non_monotonic_event_ids() {
         let text = "\
-semantic_audit_replay_archive\t1\n\
-session\tkernel-bound\tprom.cap.manifest\tv1\ttrue\n\
+semantic_audit_replay_archive\t2\n\
+session\tkernel-bound\tprom.cap.manifest\tv1\ttrue\t250000\t32768\t256\t256\t8192\t16384\t4096\t16384\n\
 events\t1\n\
 event\t9\tsession-finished\n\
 replay\t1\t9\n";
@@ -1355,7 +1392,7 @@ replay\t1\t9\n";
         assert_eq!(lines[0], "semantic_multi_session_replay_archive\t1");
         assert_eq!(lines[1], "sessions\t2");
         assert!(lines[2].starts_with("session\t0\t"));
-        assert!(lines[3].starts_with("archive\tsemantic_audit_replay_archive\t1"));
+        assert!(lines[3].starts_with("archive\tsemantic_audit_replay_archive\t2"));
     }
 
     #[test]
@@ -1364,8 +1401,8 @@ replay\t1\t9\n";
 semantic_multi_session_replay_archive\t1\n\
 sessions\t2\n\
 session\t0\t4\n\
-archive\tsemantic_audit_replay_archive\t1\n\
-archive\tsession\tkernel-bound\tprom.cap.manifest\tv1\ttrue\n\
+archive\tsemantic_audit_replay_archive\t2\n\
+archive\tsession\tkernel-bound\tprom.cap.manifest\tv1\ttrue\t250000\t32768\t256\t256\t8192\t16384\t4096\t16384\n\
 archive\tevents\t0\n\
 archive\treplay\t0\tnone\n";
 
@@ -1380,13 +1417,271 @@ archive\treplay\t0\tnone\n";
 semantic_multi_session_replay_archive\t1\n\
 sessions\t1\n\
 session\t9\t4\n\
-archive\tsemantic_audit_replay_archive\t1\n\
-archive\tsession\tkernel-bound\tprom.cap.manifest\tv1\ttrue\n\
+archive\tsemantic_audit_replay_archive\t2\n\
+archive\tsession\tkernel-bound\tprom.cap.manifest\tv1\ttrue\t250000\t32768\t256\t256\t8192\t16384\t4096\t16384\n\
 archive\tevents\t0\n\
 archive\treplay\t0\tnone\n";
 
         let err = MultiSessionReplayArchive::from_canonical_text(text).expect_err("must reject");
 
         assert!(err.message.contains("monotonic"));
+    }
+
+    // #1762 (FA-08-004): a custom envelope whose eight values cannot
+    // plausibly be mistaken for any baseline profile - makes any
+    // re-derivation-from-context or field-order mistake obvious.
+    fn custom_quota_envelope() -> RuntimeQuotas {
+        RuntimeQuotas {
+            max_steps: 101,
+            max_calls: 102,
+            max_stack_depth: 103,
+            max_frames: 104,
+            max_registers: 105,
+            max_symbol_table: 106,
+            max_effect_calls: 107,
+            max_debug_symbols_per_function: 108,
+        }
+    }
+
+    fn custom_session(context: ExecutionContext) -> AuditSessionMetadata {
+        AuditSessionMetadata {
+            context,
+            quotas: custom_quota_envelope(),
+            capability_manifest: CapabilityManifestMetadata {
+                schema: "prom.cap.manifest".to_string(),
+                version: prom_cap::CapabilityManifestVersion::V1,
+            },
+            gate_registry_bound: false,
+        }
+    }
+
+    // #1762 primary regression: the distinct custom envelope must survive
+    // AuditSessionMetadata -> AuditReplayArchive -> canonical text ->
+    // parsed archive -> ReplayMetadata bit-for-bit, with no re-derivation
+    // from `context` anywhere in the pipeline.
+    #[test]
+    fn effective_quota_envelope_survives_full_canonical_pipeline() {
+        let mut trail = AuditTrail::new(custom_session(ExecutionContext::VerifiedLocal));
+        trail.record(AuditEventKind::SessionStarted {
+            entry: "main".to_string(),
+        });
+
+        let archive = trail.replay_archive();
+        assert_eq!(archive.session.quotas, custom_quota_envelope());
+
+        let text = archive.to_canonical_text();
+        let parsed = AuditReplayArchive::from_canonical_text(&text).expect("parse");
+
+        assert_eq!(parsed, archive);
+        assert_eq!(parsed.session.quotas, custom_quota_envelope());
+        assert_eq!(parsed.replay.session.quotas, custom_quota_envelope());
+    }
+
+    // #1762: exact wire shape - 13 tokens, quota fields in RuntimeQuotas
+    // struct declaration order.
+    #[test]
+    fn canonical_session_line_emits_thirteen_tokens_in_frozen_quota_order() {
+        let trail = AuditTrail::new(custom_session(ExecutionContext::VerifiedLocal));
+        let text = trail.replay_archive().to_canonical_text();
+        let session_line = text.lines().nth(1).expect("session line");
+
+        assert_eq!(
+            session_line,
+            "session\tverified-local\tprom.cap.manifest\tv1\tfalse\t101\t102\t103\t104\t105\t106\t107\t108"
+        );
+        assert_eq!(session_line.split('\t').count(), 13);
+    }
+
+    // #1762 (§12): ReplayMetadata does not own a second, independently
+    // derived quota field - `archive.session.quotas` and
+    // `archive.replay.session.quotas` must be the identical value, both
+    // immediately after construction and after a canonical round-trip.
+    #[test]
+    fn replay_metadata_session_matches_archive_session_including_quotas() {
+        let mut trail = AuditTrail::new(custom_session(ExecutionContext::KernelBound));
+        trail.record(AuditEventKind::SessionFinished);
+
+        let archive = trail.replay_archive();
+        assert_eq!(archive.session.quotas, archive.replay.session.quotas);
+
+        let parsed =
+            AuditReplayArchive::from_canonical_text(&archive.to_canonical_text()).expect("parse");
+        assert_eq!(parsed.session.quotas, parsed.replay.session.quotas);
+        assert_eq!(parsed.session.quotas, custom_quota_envelope());
+    }
+
+    // #1762 (§10): a legacy v1 archive (5-token session line, no quota
+    // data ever recorded) must be rejected by the v2 reader through the
+    // existing version-mismatch channel - never silently backfilled with
+    // a context-derived baseline.
+    #[test]
+    fn replay_archive_rejects_legacy_v1_format_version() {
+        let text = "\
+semantic_audit_replay_archive\t1\n\
+session\tkernel-bound\tprom.cap.manifest\tv1\ttrue\n\
+events\t0\n\
+replay\t0\tnone\n";
+
+        let err = AuditReplayArchive::from_canonical_text(text).expect_err("must reject v1");
+
+        assert!(err.message.contains("unsupported archive format version 1"));
+        assert!(err.message.contains("expected 2"));
+    }
+
+    // #1762 (§9): a malformed quota numeric field must fail deterministically
+    // through the existing `AuditReplayArchiveFormatError` channel, exactly
+    // like any other malformed numeric field in this format.
+    #[test]
+    fn replay_archive_rejects_malformed_quota_numeric_field() {
+        let text = "\
+semantic_audit_replay_archive\t2\n\
+session\tverified-local\tprom.cap.manifest\tv1\tfalse\t101\tnot-a-number\t103\t104\t105\t106\t107\t108\n\
+events\t0\n\
+replay\t0\tnone\n";
+
+        let err = AuditReplayArchive::from_canonical_text(text).expect_err("must reject");
+
+        assert!(err.message.contains("max_calls"));
+    }
+
+    // #1762 (§9): no permissive parser - a session line with one field too
+    // few or too many must reject, not silently truncate/pad.
+    #[test]
+    fn replay_archive_rejects_session_line_with_wrong_token_count() {
+        let too_few = "\
+semantic_audit_replay_archive\t2\n\
+session\tverified-local\tprom.cap.manifest\tv1\tfalse\t101\t102\t103\t104\t105\t106\t107\n\
+events\t0\n\
+replay\t0\tnone\n";
+        let err =
+            AuditReplayArchive::from_canonical_text(too_few).expect_err("12 tokens must reject");
+        assert!(err.message.contains("invalid session line"));
+
+        let too_many = "\
+semantic_audit_replay_archive\t2\n\
+session\tverified-local\tprom.cap.manifest\tv1\tfalse\t101\t102\t103\t104\t105\t106\t107\t108\t109\n\
+events\t0\n\
+replay\t0\tnone\n";
+        let err =
+            AuditReplayArchive::from_canonical_text(too_many).expect_err("14 tokens must reject");
+        assert!(err.message.contains("invalid session line"));
+    }
+
+    // #1762 (§11, §16): the outer multi-session format stays at version 1
+    // while its embedded archives are independently versioned v2 - proving
+    // the frozen "outer version unchanged" decision round-trips for real,
+    // not just in principle.
+    #[test]
+    fn multi_session_replay_archive_keeps_outer_v1_with_embedded_v2_archives() {
+        let mut first = AuditTrail::new(custom_session(ExecutionContext::VerifiedLocal));
+        first.record(AuditEventKind::SessionStarted {
+            entry: "alpha".to_string(),
+        });
+
+        let mut second = AuditTrail::new(sample_session());
+        second.record(AuditEventKind::SessionFinished);
+
+        let archive = MultiSessionReplayArchive::new(vec![
+            MultiSessionReplayArchiveSession::new(0, first.replay_archive()),
+            MultiSessionReplayArchiveSession::new(1, second.replay_archive()),
+        ]);
+        assert_eq!(archive.format_version, 1);
+        assert_eq!(archive.sessions[0].archive.format_version, 2);
+        assert_eq!(archive.sessions[1].archive.format_version, 2);
+
+        let text = archive.to_canonical_text();
+        assert!(text.starts_with("semantic_multi_session_replay_archive\t1\n"));
+        assert!(text.contains("archive\tsemantic_audit_replay_archive\t2\n"));
+
+        let parsed = MultiSessionReplayArchive::from_canonical_text(&text).expect("parse");
+        assert_eq!(parsed, archive);
+        assert_eq!(
+            parsed.sessions[0].archive.session.quotas,
+            custom_quota_envelope()
+        );
+    }
+
+    // #1762 (§16.D): the especially valuable regression - two sessions
+    // sharing the identical ExecutionContext but carrying different
+    // RuntimeQuotas must remain distinguishable after a full multi-session
+    // canonical round-trip. Same label, different effective envelope,
+    // provenance tells them apart.
+    #[test]
+    fn multi_session_replay_archive_distinguishes_same_context_different_quotas() {
+        let mut baseline = AuditTrail::new(AuditSessionMetadata {
+            context: ExecutionContext::VerifiedLocal,
+            quotas: RuntimeQuotas::verified_local(),
+            capability_manifest: CapabilityManifestMetadata {
+                schema: "prom.cap.manifest".to_string(),
+                version: prom_cap::CapabilityManifestVersion::V1,
+            },
+            gate_registry_bound: false,
+        });
+        baseline.record(AuditEventKind::SessionStarted {
+            entry: "main".to_string(),
+        });
+
+        let mut tightened = AuditTrail::new(AuditSessionMetadata {
+            context: ExecutionContext::VerifiedLocal,
+            quotas: RuntimeQuotas {
+                max_effect_calls: 1,
+                ..RuntimeQuotas::verified_local()
+            },
+            capability_manifest: CapabilityManifestMetadata {
+                schema: "prom.cap.manifest".to_string(),
+                version: prom_cap::CapabilityManifestVersion::V1,
+            },
+            gate_registry_bound: false,
+        });
+        tightened.record(AuditEventKind::SessionStarted {
+            entry: "main".to_string(),
+        });
+
+        let archive = MultiSessionReplayArchive::new(vec![
+            MultiSessionReplayArchiveSession::new(0, baseline.replay_archive()),
+            MultiSessionReplayArchiveSession::new(1, tightened.replay_archive()),
+        ]);
+        let parsed = MultiSessionReplayArchive::from_canonical_text(&archive.to_canonical_text())
+            .expect("parse");
+
+        assert_eq!(
+            parsed.sessions[0].archive.session.context,
+            parsed.sessions[1].archive.session.context
+        );
+        assert_eq!(
+            parsed.sessions[0].archive.session.quotas,
+            RuntimeQuotas::verified_local()
+        );
+        assert_eq!(
+            parsed.sessions[1].archive.session.quotas.max_effect_calls,
+            1
+        );
+        assert_ne!(
+            parsed.sessions[0].archive.session.quotas,
+            parsed.sessions[1].archive.session.quotas
+        );
+    }
+
+    // #1762 (§11, §16.E): an old inner v1 archive embedded under an
+    // (unchanged) outer v1 multi-session archive must still be rejected -
+    // proving `MultiSessionReplayArchive` genuinely delegates to
+    // `AuditReplayArchive::from_canonical_text` rather than duplicating a
+    // now-stale copy of the session-line parsing logic.
+    #[test]
+    fn multi_session_replay_archive_rejects_legacy_v1_embedded_archive() {
+        let text = "\
+semantic_multi_session_replay_archive\t1\n\
+sessions\t1\n\
+session\t0\t4\n\
+archive\tsemantic_audit_replay_archive\t1\n\
+archive\tsession\tkernel-bound\tprom.cap.manifest\tv1\ttrue\n\
+archive\tevents\t0\n\
+archive\treplay\t0\tnone\n";
+
+        let err = MultiSessionReplayArchive::from_canonical_text(text)
+            .expect_err("embedded v1 archive must reject");
+
+        assert!(err.message.contains("unsupported archive format version 1"));
+        assert!(err.message.contains("expected 2"));
     }
 }

--- a/crates/prom-runtime/src/lib.rs
+++ b/crates/prom-runtime/src/lib.rs
@@ -10,13 +10,14 @@ use prom_state::{
     ContextWindow, FactResolution, SemanticStateStore, StateEpoch, StateTransitionMetadata,
     StateUpdate, StateValidationError,
 };
-use sm_runtime_core::{ExecutionConfig, ExecutionContext};
+use sm_runtime_core::{ExecutionConfig, ExecutionContext, RuntimeQuotas};
 use sm_verify::{verify_semcode_token_with_quotas, EntryResolutionError};
 use sm_vm::{run_verified_entry_semcode_with_host_and_capabilities_and_config, RuntimeError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeSessionDescriptor {
     pub context: ExecutionContext,
+    pub quotas: RuntimeQuotas,
     pub capability_manifest: CapabilityManifestMetadata,
     pub gate_registry_bound: bool,
 }
@@ -97,6 +98,7 @@ impl std::error::Error for RuleEffectExecutionError {}
 fn build_audit_session(descriptor: &RuntimeSessionDescriptor) -> AuditSessionMetadata {
     AuditSessionMetadata {
         context: descriptor.context,
+        quotas: descriptor.quotas,
         capability_manifest: descriptor.capability_manifest.clone(),
         gate_registry_bound: descriptor.gate_registry_bound,
     }
@@ -240,6 +242,7 @@ impl<'a, H: PrometheusHostAbi, C: CapabilityChecker> ExecutionSession<'a, H, C> 
             capabilities,
             descriptor: RuntimeSessionDescriptor {
                 context: config.context,
+                quotas: config.quotas,
                 capability_manifest,
                 gate_registry_bound: false,
             },
@@ -405,6 +408,7 @@ impl<'a, B: GateBinding, C: CapabilityChecker> GateExecutionSession<'a, B, C> {
             capabilities,
             descriptor: RuntimeSessionDescriptor {
                 context: config.context,
+                quotas: config.quotas,
                 capability_manifest,
                 gate_registry_bound: true,
             },
@@ -866,5 +870,63 @@ mod tests {
         assert_eq!(err.rule_id.0, "rule.alpha");
         assert_eq!(err.effect_ordinal, 0);
         assert!(audit.events().is_empty());
+    }
+
+    // #1762 (FA-08-004) primary trust invariant: the same context label
+    // paired with a deliberately custom, distinct RuntimeQuotas envelope
+    // must propagate that exact envelope - not a context-derived baseline -
+    // all the way from `ExecutionConfig` through `RuntimeSessionDescriptor`
+    // into the audit trail's own session metadata.
+    fn custom_quota_envelope() -> RuntimeQuotas {
+        RuntimeQuotas {
+            max_steps: 101,
+            max_calls: 102,
+            max_stack_depth: 103,
+            max_frames: 104,
+            max_registers: 105,
+            max_symbol_table: 106,
+            max_effect_calls: 107,
+            max_debug_symbols_per_function: 108,
+        }
+    }
+
+    #[test]
+    fn execution_session_propagates_custom_envelope_into_descriptor_and_audit_session() {
+        let manifest = CapabilityManifest::gate_surface();
+        let metadata = manifest.metadata();
+        let mut host = RecordingHostAbi::with_read_value(AbiValue::I32(1));
+        let config = ExecutionConfig::new(ExecutionContext::VerifiedLocal, custom_quota_envelope());
+        let session = ExecutionSession::new(&mut host, &manifest, config, metadata);
+
+        assert_eq!(
+            session.descriptor().context,
+            ExecutionContext::VerifiedLocal
+        );
+        assert_eq!(session.descriptor().quotas, custom_quota_envelope());
+
+        let audit = session.begin_audit_trail();
+        assert_eq!(audit.session().context, ExecutionContext::VerifiedLocal);
+        assert_eq!(audit.session().quotas, custom_quota_envelope());
+    }
+
+    #[test]
+    fn gate_execution_session_propagates_custom_envelope_into_descriptor_and_audit_session() {
+        let manifest = CapabilityManifest::gate_surface();
+        let metadata = manifest.metadata();
+        let registry = GateRegistry::new();
+        let mut binding = DeterministicGateMock::new();
+        let config = ExecutionConfig::new(ExecutionContext::VerifiedLocal, custom_quota_envelope());
+        let session =
+            GateExecutionSession::new(&registry, &mut binding, &manifest, config, metadata);
+
+        assert_eq!(
+            session.descriptor().context,
+            ExecutionContext::VerifiedLocal
+        );
+        assert_eq!(session.descriptor().quotas, custom_quota_envelope());
+
+        let audit = session.begin_audit_trail();
+        assert_eq!(audit.session().context, ExecutionContext::VerifiedLocal);
+        assert_eq!(audit.session().quotas, custom_quota_envelope());
     }
 }

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -665,11 +665,31 @@ pub fn run_verified_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
 pub fn run_semcode_collecting_hello_observations(
     bytes: &[u8],
 ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
+    run_semcode_collecting_hello_observations_with_config(
+        bytes,
+        ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+    )
+}
+
+/// Raw execution path, config-aware sibling of
+/// `run_semcode_collecting_hello_observations`.
+///
+/// Bypasses `sm-verify` admission and executes raw SemCode bytes under the
+/// caller-supplied `ExecutionConfig`, rather than hardcoding one
+/// internally. Lets a caller construct a single `ExecutionConfig` once and
+/// thread the SAME instance through admission, execution, and provenance
+/// recording (#1762, FA-08-004) - never reconstructing a second,
+/// independently-hardcoded config that happens to agree today but is not
+/// the same authority.
+pub fn run_semcode_collecting_hello_observations_with_config(
+    bytes: &[u8],
+    config: ExecutionConfig,
+) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
     let mut events = Vec::new();
     let collected = run_semcode_with_entry_and_config_with_observation_runtime(
         bytes,
         "main",
-        ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+        config,
         HelloObservationRuntime::collect(&mut events),
     )?;
     debug_assert!(events.is_empty());
@@ -8125,6 +8145,49 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].sequence_index, HelloObservationSequenceIndex(0));
         assert_eq!(events[1].sequence_index, HelloObservationSequenceIndex(1));
+    }
+
+    // #1762 (FA-08-004): `run_semcode_collecting_hello_observations_with_config`
+    // must genuinely enforce the caller-supplied `ExecutionConfig`, not
+    // silently fall back to a hardcoded `VerifiedLocal` baseline the
+    // no-config wrapper uses. This is the load-bearing property behind
+    // `smc-cli` threading one `ExecutionConfig` through admission,
+    // execution, and audit provenance: if this function ignored its own
+    // `config` parameter, that single-authority fix would be cosmetic.
+    #[test]
+    fn run_semcode_collecting_hello_observations_with_config_enforces_the_passed_quotas() {
+        let src = r#"
+            fn main() {
+                print("Hello, World!");
+                print("Hello, World!");
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+
+        let baseline = run_semcode_collecting_hello_observations_with_config(
+            &bytes,
+            ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+        )
+        .expect("canonical VerifiedLocal quotas must admit this small program");
+        assert_eq!(baseline.len(), 2);
+
+        let tight_config = ExecutionConfig::new(
+            ExecutionContext::VerifiedLocal,
+            RuntimeQuotas {
+                max_steps: 1,
+                ..RuntimeQuotas::verified_local()
+            },
+        );
+        let err = run_semcode_collecting_hello_observations_with_config(&bytes, tight_config)
+            .expect_err("the passed-in, drastically tighter max_steps must be enforced");
+        assert!(matches!(
+            err,
+            RuntimeError::QuotaExceeded(QuotaExceeded {
+                kind: QuotaKind::Steps,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -31,9 +31,9 @@ use sm_ir::{compile_program_to_ir_with_options_and_profile, lower_logos_laws_to_
 use sm_runtime_core::hello_observation_sink::HelloObservationClass;
 use sm_runtime_core::{ExecutionConfig, ExecutionContext};
 use sm_sema::{check_file_with_provider_and_profile, check_source_with_profile, ModuleProvider};
-use sm_verify::{verify_semcode, verify_semcode_token};
+use sm_verify::{verify_semcode, verify_semcode_token, verify_semcode_token_with_quotas};
 use sm_vm::{
-    disasm_semcode, run_semcode_collecting_hello_observations,
+    disasm_semcode, run_semcode_collecting_hello_observations_with_config,
     run_verified_entry_semcode_with_application_host_and_capabilities_and_config, RuntimeError,
 };
 use std::collections::HashSet;
@@ -2789,9 +2789,20 @@ fn stable_text_hash(text: &str) -> u64 {
 fn collect_controlled_observation_envelope(
     bytes: &[u8],
 ) -> Result<ControlledObservationInternalEnvelope, String> {
-    verify_semcode(bytes).map_err(|report| report.to_string())?;
+    // #1762 (FA-08-004): construct exactly one ExecutionConfig and thread
+    // it, unchanged, through admission, execution, and provenance -
+    // never reconstruct a second, independently-hardcoded config that
+    // happens to agree today. Both `verify_semcode_token_with_quotas` and
+    // `run_semcode_collecting_hello_observations_with_config` consume
+    // this same instance, so the audit metadata built from it below
+    // records the actual authority, not a value derived after the fact.
+    let execution_config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
 
-    let events = run_semcode_collecting_hello_observations(bytes).map_err(|e| e.to_string())?;
+    verify_semcode_token_with_quotas(bytes, execution_config.quotas)
+        .map_err(|report| report.to_string())?;
+
+    let events = run_semcode_collecting_hello_observations_with_config(bytes, execution_config)
+        .map_err(|e| e.to_string())?;
     let mut capability_manifest = CapabilityManifest::new();
     capability_manifest.allow(CapabilityKind::ControlledObservationSink);
 
@@ -2809,14 +2820,11 @@ fn collect_controlled_observation_envelope(
         ));
     };
 
-    // `run_semcode_collecting_hello_observations` internally executes under
-    // `ExecutionConfig::for_context(ExecutionContext::VerifiedLocal)` (see
-    // its own definition) but does not surface that config to this caller.
-    // Constructing the same canonical config here - rather than hardcoding
-    // the context and a separately-derived `RuntimeQuotas` value - records
-    // the effective envelope that actually governs that call, not a
-    // reconstruction of it (#1762).
-    let execution_config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
+    // Reuses the SAME `execution_config` already passed to
+    // `verify_semcode_token_with_quotas` and
+    // `run_semcode_collecting_hello_observations_with_config` above - the
+    // recorded provenance is the actual authority, not a value
+    // reconstructed after the fact (#1762).
     let mut audit_trail = AuditTrail::new(AuditSessionMetadata {
         context: execution_config.context,
         quotas: execution_config.quotas,

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -2809,8 +2809,17 @@ fn collect_controlled_observation_envelope(
         ));
     };
 
+    // `run_semcode_collecting_hello_observations` internally executes under
+    // `ExecutionConfig::for_context(ExecutionContext::VerifiedLocal)` (see
+    // its own definition) but does not surface that config to this caller.
+    // Constructing the same canonical config here - rather than hardcoding
+    // the context and a separately-derived `RuntimeQuotas` value - records
+    // the effective envelope that actually governs that call, not a
+    // reconstruction of it (#1762).
+    let execution_config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
     let mut audit_trail = AuditTrail::new(AuditSessionMetadata {
-        context: ExecutionContext::VerifiedLocal,
+        context: execution_config.context,
+        quotas: execution_config.quotas,
         capability_manifest: capability_manifest.metadata(),
         gate_registry_bound: true,
     });

--- a/docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md
+++ b/docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md
@@ -794,13 +794,24 @@ specified, on top of `main` at `063652dad2c08980e6f134cc3205b064a86059f2`
 - `crates/smc-cli/src/app.rs`: `collect_controlled_observation_envelope`'s
   direct `AuditSessionMetadata` literal previously hardcoded
   `ExecutionContext::VerifiedLocal` with no quota field at all (pre-#1762
-  shape). Since the actual execution
-  (`run_semcode_collecting_hello_observations`) uses an internal,
-  non-surfaced `ExecutionConfig::for_context(ExecutionContext::VerifiedLocal)`,
-  this site now constructs that identical canonical `ExecutionConfig`
-  locally and copies both `.context` and `.quotas` from it - recording the
-  envelope that actually governs that call, not a value reconstructed
-  independently of it.
+  shape). The final implementation constructs exactly **one**
+  `ExecutionConfig::for_context(ExecutionContext::VerifiedLocal)` binding
+  before admission and threads that single instance through every
+  consumer: its `quotas` are supplied to
+  `verify_semcode_token_with_quotas` for admission, the same
+  `ExecutionConfig` value is supplied to the new config-aware
+  `run_semcode_collecting_hello_observations_with_config` (`crates/sm-vm/src/semcode_vm.rs`)
+  for execution, and the same binding's `.context`/`.quotas` populate the
+  `AuditSessionMetadata` literal. The legacy no-config
+  `run_semcode_collecting_hello_observations` now delegates to the
+  config-aware sibling with the canonical default, preserving its existing
+  signature for other callers. No independent context→quota
+  reconstruction remains anywhere in this CLI path - a first attempt at
+  this site (constructing a second, separately-hardcoded canonical config
+  purely for provenance, while execution still hardcoded its own,
+  unparameterized config internally) was caught in review as itself an
+  instance of the pattern this checkpoint exists to eliminate, and was
+  corrected before merge.
 - Compiler fallout after the two struct-shape changes was exactly the
   sites this document's own mechanic predicted:
   `crates/prom-audit/src/lib.rs`'s own parser and one test fixture, the
@@ -820,13 +831,19 @@ specified, on top of `main` at `063652dad2c08980e6f134cc3205b064a86059f2`
   `max_effect_calls: 1`) remain distinguishable after a full
   `MultiSessionReplayArchive` canonical round-trip - the central #1762
   trust invariant, proven end to end, not merely asserted.
-- Three temporary mutations each turned the relevant regression RED and
+- Four temporary mutations each turned the relevant regression RED and
   were fully reverted: (M1) a `prom-runtime` descriptor copy replaced with
   a context-derived `RuntimeQuotas::verified_local()`; (M2) the archive
   parser's eight quota fields replaced with a hardcoded
   `RuntimeQuotas::verified_local()` regardless of what was actually
   serialized; (M3) `AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION` left at `1` after
-  the wire-shape change.
+  the wire-shape change; (M4) the config-aware
+  `run_semcode_collecting_hello_observations_with_config` temporarily
+  ignored its own `config` parameter and used canonical `VerifiedLocal`
+  internally instead - a program that should have failed under a
+  drastically tightened `max_steps` succeeded instead, proving the
+  regression genuinely exercises the passed-in config rather than a
+  config-blind fallback.
 - **A gap discovered during implementation, resolved with explicit owner
   input, not silently:** `tests/golden_snapshots/public_api/prom_audit_lib.txt`
   existed but `tests/public_api_contracts.rs` did not actually track

--- a/docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md
+++ b/docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md
@@ -766,3 +766,95 @@ RECORD-style disposition per the governing brief's own §19 checklist:
 proceed directly from this document without a further design pass.
 
 **Wait for owner GO before implementation.**
+
+## 25. Implementation update (post-freeze)
+
+The RECORD_EFFECTIVE disposition frozen above landed exactly as
+specified, on top of `main` at `063652dad2c08980e6f134cc3205b064a86059f2`
+(PR #1908's merge commit).
+
+- `crates/prom-runtime/src/lib.rs`: `RuntimeSessionDescriptor` gained
+  `pub quotas: RuntimeQuotas`. `ExecutionSession::new` and
+  `GateExecutionSession::new` both copy `quotas: config.quotas` alongside
+  the pre-existing `context: config.context`, from the same
+  `ExecutionConfig` parameter. `build_audit_session` copies
+  `quotas: descriptor.quotas` one hop further into `AuditSessionMetadata`
+  - the one-way `ExecutionConfig` → `RuntimeSessionDescriptor` →
+    `AuditSessionMetadata` copy path is unchanged in shape, only widened.
+- `crates/prom-audit/src/lib.rs`: `AuditSessionMetadata` gained
+  `pub quotas: RuntimeQuotas`. `AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION`
+  bumped `1` → `2`; `MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION` left at
+  `1` exactly as frozen. The canonical `session` line now emits 13
+  tab-separated tokens (up from 5), the eight `RuntimeQuotas` fields
+  appended in struct declaration order as plain decimal `usize` text.
+  `from_canonical_text` parses all eight via the existing
+  `parse_usize_field` discipline into a `RuntimeQuotas` literal - no
+  defaults, no `..RuntimeQuotas::verified_local()`, no
+  `RuntimeQuotas::for_context(...)` fallback.
+- `crates/smc-cli/src/app.rs`: `collect_controlled_observation_envelope`'s
+  direct `AuditSessionMetadata` literal previously hardcoded
+  `ExecutionContext::VerifiedLocal` with no quota field at all (pre-#1762
+  shape). Since the actual execution
+  (`run_semcode_collecting_hello_observations`) uses an internal,
+  non-surfaced `ExecutionConfig::for_context(ExecutionContext::VerifiedLocal)`,
+  this site now constructs that identical canonical `ExecutionConfig`
+  locally and copies both `.context` and `.quotas` from it - recording the
+  envelope that actually governs that call, not a value reconstructed
+  independently of it.
+- Compiler fallout after the two struct-shape changes was exactly the
+  sites this document's own mechanic predicted:
+  `crates/prom-audit/src/lib.rs`'s own parser and one test fixture, the
+  `smc-cli` site above, and two direct literals in
+  `tests/prometheus_audit.rs`. No unaccounted-for production reader
+  appeared. Every non-canonical-propagation literal was classified by
+  hand (SAME AUTHORITY vs. explicit synthetic/audit-only fixture, never a
+  silent context→quota reconstruction where a real `ExecutionConfig` was
+  discarded) rather than mechanically silenced.
+- **Adversarial proof:** a distinct custom envelope (101/102/.../108,
+  chosen so no field could be mistaken for any baseline) survives
+  `ExecutionConfig` → `RuntimeSessionDescriptor` → `AuditSessionMetadata`
+  → `AuditReplayArchive::to_canonical_text` →
+  `AuditReplayArchive::from_canonical_text` → `ReplayMetadata`
+  value-for-value. Two sessions sharing `ExecutionContext::VerifiedLocal`
+  but carrying different `RuntimeQuotas` (canonical `verified_local()` vs.
+  `max_effect_calls: 1`) remain distinguishable after a full
+  `MultiSessionReplayArchive` canonical round-trip - the central #1762
+  trust invariant, proven end to end, not merely asserted.
+- Three temporary mutations each turned the relevant regression RED and
+  were fully reverted: (M1) a `prom-runtime` descriptor copy replaced with
+  a context-derived `RuntimeQuotas::verified_local()`; (M2) the archive
+  parser's eight quota fields replaced with a hardcoded
+  `RuntimeQuotas::verified_local()` regardless of what was actually
+  serialized; (M3) `AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION` left at `1` after
+  the wire-shape change.
+- **A gap discovered during implementation, resolved with explicit owner
+  input, not silently:** `tests/golden_snapshots/public_api/prom_audit_lib.txt`
+  existed but `tests/public_api_contracts.rs` did not actually track
+  `crates/prom-audit/src/lib.rs` in its guarded-file list - a pre-existing
+  omission unrelated to this checkpoint, which meant `AuditSessionMetadata`'s
+  own public API (the exact type this implementation widens) was
+  unguarded. The owner explicitly chose to restore `prom-audit` to the
+  tracked list as part of this same PR. Doing so surfaced accumulated,
+  pre-existing drift unrelated to #1762 (expanded `AuditEventKind`
+  variant text, multi-line constructor signatures) alongside the two
+  intended changes (`quotas` field, format-version bump); the full diff
+  was reviewed manually before regeneration - see the PR body for
+  specifics.
+- Public API guard: RED first (drift isolated to `RuntimeSessionDescriptor`/
+  `AuditSessionMetadata` gaining `quotas: RuntimeQuotas`, plus the version
+  bump and the now-tracked `prom-audit` catch-up noted above), regenerated
+  via `SM_UPDATE_PUBLIC_API_SNAPSHOTS=1`, diff reviewed, then GREEN.
+- `docs/spec/quotas.md` and `docs/spec/audit.md` updated to
+  active-document the implemented provenance rule and the archive
+  wire/version consequence; `docs/spec/vm.md` inspected and found to
+  contain no active contradiction requiring a change.
+- **AC4.c, freshly re-evaluated against the implementation branch:**
+  every production construction site of `RuntimeSessionDescriptor` and
+  `AuditSessionMetadata` was manually classified. Zero production paths
+  discard an available `config.quotas` in favor of a context-derived
+  reconstruction. **AC4.c: SATISFIED.** `AC4.d` and `AC4.e` remain
+  unaddressed - `#1763` territory, not claimed here.
+
+`#1763` and `#1902` were not touched by this implementation.
+
+**Wait for explicit owner GO before merge.**

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -475,27 +475,45 @@ field, struct, archive format constant, or golden snapshot was touched by
 this update - AC4.c remains not satisfied until a separately authorized
 implementation checkpoint executes this now-complete mechanic.**
 
-**Implementation update (RECORD_EFFECTIVE executed, #1762 still OPEN
-pending merge):** `RuntimeSessionDescriptor` and `AuditSessionMetadata`
-both gained `quotas: RuntimeQuotas`, copied one-way from the same
-`ExecutionConfig` used for execution (never re-derived from `context`);
-`AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION` bumped `1` → `2` exactly as frozen,
-`MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION` left at `1`. A distinct
-custom envelope survived the full canonical pipeline value-for-value, and
-two sessions sharing one `ExecutionContext` with different `RuntimeQuotas`
-were proven distinguishable after a multi-session round-trip - the
-central #1762 trust invariant, proven not merely asserted. Three mutation
-proofs (context-derived descriptor reconstruction, parser
-context-derived reconstruction, missed version bump) each turned RED and
-were reverted. A pre-existing, unrelated gap was discovered and resolved
-with explicit owner input: `prom-audit` was missing from the public-API
-golden-snapshot guard's tracked file list entirely, leaving
-`AuditSessionMetadata`'s own public API unguarded; the owner chose to
-restore it to the tracked list within this same PR, which surfaced (and
-required reviewing) unrelated accumulated drift alongside the two
-intended changes. Every production construction site of both structs was
-manually classified; zero discard an available effective envelope in
-favor of a context-derived reconstruction. Full detail:
+**Implementation update (RECORD_EFFECTIVE implemented by PR #1911; issue
+closure is merge-gated):** `RuntimeSessionDescriptor` and
+`AuditSessionMetadata` both gained `quotas: RuntimeQuotas`, copied
+one-way from the same `ExecutionConfig` used for execution (never
+re-derived from `context`); `AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION` bumped
+`1` → `2` exactly as frozen, `MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION`
+left at `1`. A distinct custom envelope survived the full canonical
+pipeline value-for-value, and two sessions sharing one `ExecutionContext`
+with different `RuntimeQuotas` were proven distinguishable after a
+multi-session round-trip - the central #1762 trust invariant, proven not
+merely asserted.
+
+In `crates/smc-cli/src/app.rs`, `collect_controlled_observation_envelope`
+now constructs exactly **one** `ExecutionConfig` binding and threads it
+through every consumer: its `quotas` feed quota-aware verifier admission
+(`verify_semcode_token_with_quotas`), the same binding feeds a new
+config-aware VM observation-execution helper
+(`run_semcode_collecting_hello_observations_with_config`, added to
+`sm-vm` for this purpose - the legacy no-config helper now delegates to
+it with the canonical default), and the same binding populates the audit
+metadata. A first attempt at this site constructed a second,
+independently-hardcoded canonical config purely for provenance while
+execution still hardcoded its own separate config internally - itself an
+instance of the reconstruction pattern this checkpoint exists to
+eliminate - caught in review and corrected before merge.
+
+Four mutation proofs (context-derived descriptor reconstruction, parser
+context-derived reconstruction, missed version bump, and - added for the
+single-authority CLI fix - the config-aware VM helper silently ignoring
+its caller-supplied config and falling back to canonical `VerifiedLocal`
+internally) each turned RED and were reverted. A pre-existing, unrelated
+gap was discovered and resolved with explicit owner input: `prom-audit`
+was missing from the public-API golden-snapshot guard's tracked file list
+entirely, leaving `AuditSessionMetadata`'s own public API unguarded; the
+owner chose to restore it to the tracked list within this same PR, which
+surfaced (and required reviewing) unrelated accumulated drift alongside
+the two intended changes. Every production construction site of both
+structs was manually classified; zero discard an available effective
+envelope in favor of a context-derived reconstruction. Full detail:
 `docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md`
 §25.
 

--- a/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
+++ b/docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
@@ -475,6 +475,30 @@ field, struct, archive format constant, or golden snapshot was touched by
 this update - AC4.c remains not satisfied until a separately authorized
 implementation checkpoint executes this now-complete mechanic.**
 
+**Implementation update (RECORD_EFFECTIVE executed, #1762 still OPEN
+pending merge):** `RuntimeSessionDescriptor` and `AuditSessionMetadata`
+both gained `quotas: RuntimeQuotas`, copied one-way from the same
+`ExecutionConfig` used for execution (never re-derived from `context`);
+`AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION` bumped `1` → `2` exactly as frozen,
+`MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION` left at `1`. A distinct
+custom envelope survived the full canonical pipeline value-for-value, and
+two sessions sharing one `ExecutionContext` with different `RuntimeQuotas`
+were proven distinguishable after a multi-session round-trip - the
+central #1762 trust invariant, proven not merely asserted. Three mutation
+proofs (context-derived descriptor reconstruction, parser
+context-derived reconstruction, missed version bump) each turned RED and
+were reverted. A pre-existing, unrelated gap was discovered and resolved
+with explicit owner input: `prom-audit` was missing from the public-API
+golden-snapshot guard's tracked file list entirely, leaving
+`AuditSessionMetadata`'s own public API unguarded; the owner chose to
+restore it to the tracked list within this same PR, which surfaced (and
+required reviewing) unrelated accumulated drift alongside the two
+intended changes. Every production construction site of both structs was
+manually classified; zero discard an available effective envelope in
+favor of a context-derived reconstruction. Full detail:
+`docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md`
+§25.
+
 ## 7. #1763 — `RuntimeTrap` / `RuntimeError` taxonomy
 
 **Fresh trace, exhaustive, not sampled.** `RuntimeTrap` (13 variants):
@@ -895,13 +919,22 @@ target contract for over-strengthening:
   point-in-time confirmation on the current branch, not a standing
   guarantee against a future addition reopening the same failure mode.)*
 - **AC4.c** — `ExecutionContext`/provenance does not overstate the quota
-  envelope that actually governed execution. *(Not satisfied: `prom-runtime`/
-  `prom-audit` record only the context label, and nothing validates
-  context/quota consistency at construction. Disposition now frozen -
-  RECORD_EFFECTIVE, see
-  `docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md` -
-  but not yet implemented; the exact mechanic (fields, copy path, archive
-  wire/version bump) is fully specified, not an open choice.)*
+  envelope that actually governed execution. *(Satisfied, freshly
+  re-audited against the implementation branch: `RuntimeSessionDescriptor`
+  and `AuditSessionMetadata` both now record `quotas: RuntimeQuotas`,
+  copied one-way from the same `ExecutionConfig` used for execution -
+  never re-derived from `context`. Every production construction site of
+  both structs was manually classified (SAME AUTHORITY or explicit
+  synthetic/audit-only fixture); zero discard an available effective
+  envelope in favor of a context-derived reconstruction. A distinct
+  custom envelope was proven to survive the full canonical archive
+  pipeline value-for-value, and two sessions sharing one `ExecutionContext`
+  with different `RuntimeQuotas` were proven distinguishable after a
+  multi-session round-trip. See
+  `docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md`
+  §25. This is a point-in-time confirmation on the current branch, not a
+  standing guarantee against a future construction site reintroducing the
+  same failure mode.)*
 - **AC4.d** — Verification rejection, runtime quota exhaustion, semantic
   trap, capability denial, and host/ABI failure have an explicit,
   deterministic taxonomy that matches what production code actually

--- a/docs/spec/audit.md
+++ b/docs/spec/audit.md
@@ -58,6 +58,9 @@ Current event invariant:
 Current replay metadata must include:
 
 - execution context
+- effective `RuntimeQuotas` (#1762, FA-08-004) - the actual quota/profile
+  envelope that governed the session, not a baseline re-derived from
+  execution context; see "Effective Quota Provenance Rule" below
 - capability manifest metadata
 - whether a gate registry was bound
 - event count
@@ -67,10 +70,58 @@ Current persisted replay rule:
 
 - `AuditReplayArchive` wraps session metadata, recorded events, and replay
   metadata under one explicit archive envelope
-- archive metadata is explicit through `format_version`
+- archive metadata is explicit through `format_version`, currently `2`
+  (bumped from `1` by #1762 to carry the effective quota envelope - see
+  below)
 - archive materialization/loading uses one canonical deterministic text envelope
 - persisted replay ownership does not widen orchestration or runtime recovery
   semantics by implication
+
+## Effective Quota Provenance Rule
+
+`AuditSessionMetadata` records:
+
+- `ExecutionContext` - a baseline/default selector and audit-class label
+- `RuntimeQuotas` - the actual effective quota/profile envelope that
+  governed the session, copied from the same `ExecutionConfig` used for
+  execution, never re-derived from `context`
+- capability manifest metadata
+- whether a gate registry was bound
+
+This exists because `ExecutionContext` alone does not prove which
+`RuntimeQuotas` values governed a session (`ExecutionConfig::new` permits
+custom envelopes; see `docs/spec/quotas.md`). Recording the effective
+envelope directly means two sessions sharing the same `ExecutionContext`
+but running under different `RuntimeQuotas` are distinguishable in the
+audit trail - see `docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md`
+for the full contract.
+
+Current archive wire rule:
+
+- the canonical `session` line carries all eight `RuntimeQuotas` fields
+  (`max_steps`, `max_calls`, `max_stack_depth`, `max_frames`,
+  `max_registers`, `max_symbol_table`, `max_effect_calls`,
+  `max_debug_symbols_per_function`), in that order, as plain decimal
+  tokens, after the pre-existing context/capability-manifest/
+  gate-registry-bound fields
+- `AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION = 2` archives carry this shape;
+  version `1` archives (recorded before this rule existed) never carried
+  quota data at all
+- a `v2` reader rejects a `v1` archive outright, through the existing
+  version-mismatch channel - it never backfills a `v1` archive's missing
+  quota data with a context-derived baseline, since the archive itself
+  never recorded what actually governed that session
+- `v1` archives remain readable only by `v1`-era reader code; this rule
+  does not add cross-version parsing
+- `MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION` remains `1` - the outer
+  multi-session envelope's own wire shape is unchanged by this rule; it
+  embeds independently-versioned `AuditReplayArchive` records, each
+  version-checked on its own by the same `v2`/`v1` rule above
+
+This does not imply `RuntimeQuotas` captures every independent
+verifier/admission authority - `VerificationLimits`, `sm-format`'s
+structural caps, and capability policy remain outside what this recorded
+envelope attests to (see `docs/spec/quotas.md`'s own scope note).
 
 Current post-stable owner-layer widening on `main`:
 

--- a/docs/spec/quotas.md
+++ b/docs/spec/quotas.md
@@ -15,7 +15,10 @@ Quota model rule:
 - `sm-vm` enforces quotas during execution, except `SymbolTable`, which
   `sm-verify` enforces statically, pre-execution, at admission
 - higher integration layers may choose context-specific quota envelopes, but
-  must not weaken the core safety contract silently
+  must not weaken the core safety contract silently - meaning divergence
+  from the baseline must be explicit in provenance (recorded, not hidden),
+  not that a weaker envelope is itself forbidden; see "Execution Envelope
+  Provenance Rule" below (#1762, FA-08-004)
 
 ## Quota Taxonomy
 
@@ -121,6 +124,36 @@ Contract rule:
 
 - context selection is explicit through `ExecutionConfig`
 - default execution for standard verified runs is `VerifiedLocal`
+
+## Execution Envelope Provenance Rule
+
+Frozen and implemented (#1762, FA-08-004,
+`docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md`):
+
+- `ExecutionContext` is a construction-time baseline/default selector (via
+  `ExecutionConfig::for_context`) and an audit-class label. It is **not**
+  proof, by itself, of which `RuntimeQuotas` values actually governed a
+  given execution.
+- The `RuntimeQuotas` values carried in `ExecutionConfig.quotas` are the
+  actual effective authority for the quota/profile dimensions
+  `RuntimeQuotas` represents. This does **not** extend to
+  `VerificationLimits` (an orthogonal verifier envelope),
+  `sm-format`'s structural decode-time caps, verifier rules unrelated to
+  `RuntimeQuotas`, capability policy, or any other independent admission
+  authority.
+- `ExecutionConfig::new(context, quotas)` remains supported: custom
+  envelopes (a `context` paired with `quotas` that diverge from
+  `for_context`'s canonical mapping) are permitted, with no
+  equality-with-baseline validation and no stricter-than-baseline
+  restriction.
+- Because custom envelopes are permitted, `prom_runtime::RuntimeSessionDescriptor`
+  and `prom_audit::AuditSessionMetadata` record the **effective**
+  `RuntimeQuotas` actually used - copied from the same `ExecutionConfig`
+  passed to session construction, never re-derived from `context` - so
+  that two sessions sharing the same `ExecutionContext` but running under
+  different `RuntimeQuotas` remain distinguishable in provenance. See
+  `docs/spec/audit.md`'s "Effective Quota Provenance Rule" for the archive
+  wire-format consequence.
 
 ## Enforcement Rule
 

--- a/tests/golden_snapshots/public_api/prom_audit_lib.txt
+++ b/tests/golden_snapshots/public_api/prom_audit_lib.txt
@@ -5,10 +5,21 @@ pub struct AuditEventId(pub u64);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditSessionMetadata {
 pub context: ExecutionContext,
+pub quotas: RuntimeQuotas,
 pub capability_manifest: CapabilityManifestMetadata,
 pub gate_registry_bound: bool,
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuditEventKind {
+SessionStarted { entry: String },
+SessionFinished,
+RuleActivated { rule_id: String, salience: i32 },
+StateTransition { key: String, from_epoch: u64, to_epoch: u64 },
+CapabilityDenied { capability: CapabilityKind, call: Option<String> },
+ControlledObservation { operation_kind: String, observation_class: String, payload_hash: Option<u64>, redacted: bool, sequence_index: u64, policy: ControlledObservationAuditDecision, linkage: crate::hello_observation_audit::HelloObservationAuditLinkage },
+GateRead { device_id: u16, port: u16 },
+GateWrite { device_id: u16, port: u16 },
+PulseEmit { signal: String },
+Note { message: String },
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditEvent {
 pub id: AuditEventId,
@@ -18,7 +29,7 @@ pub struct ReplayMetadata {
 pub session: AuditSessionMetadata,
 pub event_count: usize,
 pub last_event_id: Option<AuditEventId>,
-pub const AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION: u32 = 1;
+pub const AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION: u32 = 2;
 pub const MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION: u32 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditReplayArchive {
@@ -48,12 +59,12 @@ pub fn events(&self) -> &[AuditEvent] {
 pub fn record(&mut self, kind: AuditEventKind) -> AuditEventId {
 pub fn replay_metadata(&self) -> ReplayMetadata {
 pub fn replay_archive(&self) -> AuditReplayArchive {
-pub fn new(
+pub fn new( session: AuditSessionMetadata, events: Vec<AuditEvent>, replay: ReplayMetadata, ) -> Self {
 pub fn to_canonical_text(&self) -> String {
 pub fn from_canonical_text(src: &str) -> Result<Self, AuditReplayArchiveFormatError> {
 pub fn new(session_ordinal: u32, archive: AuditReplayArchive) -> Self {
 pub fn new(sessions: Vec<MultiSessionReplayArchiveSession>) -> Self {
 pub fn to_canonical_text(&self) -> String {
-pub fn from_canonical_text(
+pub fn from_canonical_text(src: &str) -> Result<Self, MultiSessionReplayArchiveFormatError> {
 pub fn new(message: impl Into<String>) -> Self {
 pub fn new(message: impl Into<String>) -> Self {

--- a/tests/golden_snapshots/public_api/prom_runtime_lib.txt
+++ b/tests/golden_snapshots/public_api/prom_runtime_lib.txt
@@ -2,6 +2,7 @@ source: crates/prom-runtime/src/lib.rs
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeSessionDescriptor {
 pub context: ExecutionContext,
+pub quotas: RuntimeQuotas,
 pub capability_manifest: CapabilityManifestMetadata,
 pub gate_registry_bound: bool,
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
+++ b/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
@@ -94,6 +94,7 @@ Trap(RuntimeTrap),
 pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
 pub fn run_verified_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
 pub fn run_semcode_collecting_hello_observations( bytes: &[u8], ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
+pub fn run_semcode_collecting_hello_observations_with_config( bytes: &[u8], config: ExecutionConfig, ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
 pub fn run_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), RuntimeError> {
 pub fn run_semcode_with_config(bytes: &[u8], config: ExecutionConfig) -> Result<(), RuntimeError> {
 pub fn run_verified_semcode_with_config( bytes: &[u8], config: ExecutionConfig, ) -> Result<(), RuntimeError> {

--- a/tests/prometheus_audit.rs
+++ b/tests/prometheus_audit.rs
@@ -4,7 +4,7 @@ use semantic_language::prom_audit::{AuditEventKind, AuditSessionMetadata, AuditT
 use semantic_language::prom_cap::{CapabilityKind, CapabilityManifest};
 use semantic_language::prom_gates::{DeterministicGateMock, GateDescriptor, GateId, GateRegistry};
 use semantic_language::prom_runtime::GateExecutionSession;
-use semantic_language::runtime_core::ExecutionContext;
+use semantic_language::runtime_core::{ExecutionContext, RuntimeQuotas};
 
 fn runtime_program() -> Vec<IrFunction> {
     vec![IrFunction {
@@ -47,6 +47,7 @@ fn audit_trail_reuses_runtime_session_descriptor_without_owning_runtime_logic() 
         GateExecutionSession::kernel_bound(&registry, &mut binding, &manifest, manifest.metadata());
     let audit_session = AuditSessionMetadata {
         context: session.descriptor().context,
+        quotas: session.descriptor().quotas,
         capability_manifest: session.descriptor().capability_manifest.clone(),
         gate_registry_bound: session.descriptor().gate_registry_bound,
     };
@@ -80,6 +81,7 @@ fn audit_trail_reuses_runtime_session_descriptor_without_owning_runtime_logic() 
 fn audit_trail_records_capability_denial_with_manifest_context() {
     let mut audit = AuditTrail::new(AuditSessionMetadata {
         context: ExecutionContext::KernelBound,
+        quotas: RuntimeQuotas::kernel_bound(),
         capability_manifest: CapabilityManifest::new().metadata(),
         gate_registry_bound: true,
     });

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -75,6 +75,10 @@ const TARGETS: &[(&str, &str)] = &[
         "tests/golden_snapshots/public_api/prom_cap_lib.txt",
     ),
     (
+        "crates/prom-audit/src/lib.rs",
+        "tests/golden_snapshots/public_api/prom_audit_lib.txt",
+    ),
+    (
         "crates/prom-runtime/src/lib.rs",
         "tests/golden_snapshots/public_api/prom_runtime_lib.txt",
     ),


### PR DESCRIPTION
## Summary

Closes #1762
SSF-08 umbrella #1579 remains OPEN

Implements the RECORD_EFFECTIVE contract frozen by PR #1908
(`docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md`).

- records `RuntimeQuotas` in `RuntimeSessionDescriptor`
- propagates the same effective envelope into `AuditSessionMetadata`
- persists all eight fields in canonical audit archive v2
- keeps the multi-session outer format at v1
- rejects legacy audit archive v1 rather than reconstructing missing quotas
- does not restrict custom `ExecutionConfig` envelopes
- threads exactly one `ExecutionConfig` through admission, execution, and
  audit provenance in `smc-cli` - never reconstructing a second,
  independently-hardcoded config that happens to agree today

Intentional public API widening:
- `RuntimeSessionDescriptor::quotas`
- `AuditSessionMetadata::quotas`
- `sm_vm::run_semcode_collecting_hello_observations_with_config` (new
  config-aware sibling, added during review - see "Corrective round" below)

## The central trust invariant, proven end to end

`ExecutionContext` alone never proved which `RuntimeQuotas` actually
governed a session - `ExecutionConfig::new` legitimately pairs any context
with any quotas (the SSF-04 effect-quota qualification seam has always
done exactly this). Before this PR, `RuntimeSessionDescriptor` and
`AuditSessionMetadata` recorded only the context label, so two sessions
under `VerifiedLocal` - one at the canonical baseline, one with
`max_effect_calls` tightened to `1` - produced an identical `session` line
in the canonical audit archive.

Now: `ExecutionConfig.quotas` is copied one-way into
`RuntimeSessionDescriptor` → `AuditSessionMetadata` → the canonical
archive, never re-derived from `context`. A dedicated regression proves a
distinct custom envelope (values 101-108, chosen so none could be mistaken
for a baseline) survives `ExecutionConfig` →
`AuditReplayArchive::to_canonical_text` →
`AuditReplayArchive::from_canonical_text` → `ReplayMetadata`
value-for-value, and a `MultiSessionReplayArchive` regression proves two
sessions sharing one `ExecutionContext` with different `RuntimeQuotas`
remain distinguishable after a full canonical round-trip.

## Changes

- `crates/prom-runtime/src/lib.rs`: `RuntimeSessionDescriptor` gains
  `pub quotas: RuntimeQuotas`. `ExecutionSession::new` and
  `GateExecutionSession::new` copy `quotas: config.quotas` alongside the
  pre-existing `context: config.context`. `build_audit_session` copies
  `quotas: descriptor.quotas` one hop further - the
  `ExecutionConfig` → `RuntimeSessionDescriptor` → `AuditSessionMetadata`
  path is unchanged in shape, only widened.
- `crates/prom-audit/src/lib.rs`: `AuditSessionMetadata` gains
  `pub quotas: RuntimeQuotas`. `AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION`
  bumped `1` → `2`; `MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION` stays at
  `1` (verified: `MultiSessionReplayArchive::from_canonical_text`
  genuinely delegates each embedded session to
  `AuditReplayArchive::from_canonical_text`, so the outer wire shape is
  untouched). The canonical `session` line now emits 13 tab-separated
  tokens (was 5), the eight `RuntimeQuotas` fields appended in struct
  declaration order as plain decimal text. The parser consumes all eight
  via the existing `parse_usize_field` discipline into a `RuntimeQuotas`
  literal - no defaults, no baseline fallback. Four pre-existing hand-built
  raw-text fixtures (testing event-count-mismatch / non-monotonic-id
  rejection) were updated to the new wire shape so they keep testing what
  they were written to test, rather than failing on version mismatch.
- `crates/sm-vm/src/semcode_vm.rs`: new `pub fn
  run_semcode_collecting_hello_observations_with_config(bytes, config)`,
  the config-aware sibling of `run_semcode_collecting_hello_observations`
  (mirroring the existing `run_semcode_with_entry`/`run_semcode_with_config`
  pattern). The no-config wrapper now delegates to it with the canonical
  default, preserving its existing behavior/signature for other callers.
- `crates/smc-cli/src/app.rs`: `collect_controlled_observation_envelope`
  now constructs exactly **one** `ExecutionConfig` and threads it through
  all three consumers - `verify_semcode_token_with_quotas(bytes,
  execution_config.quotas)` for admission,
  `run_semcode_collecting_hello_observations_with_config(bytes,
  execution_config)` for execution, and the same binding's `.context`/
  `.quotas` for the audit metadata literal. See "Corrective round" below
  for why the first attempt at this site was insufficient.
- `tests/prometheus_audit.rs`: two direct `AuditSessionMetadata` literals
  fixed - one copies `session.descriptor().quotas` (the real session
  object already available), one is a purely synthetic fixture using
  `RuntimeQuotas::kernel_bound()` matching its own labeled context.
- `tests/golden_snapshots/public_api/prom_runtime_lib.txt`,
  `tests/golden_snapshots/public_api/prom_audit_lib.txt`,
  `tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt`: updated via
  `SM_UPDATE_PUBLIC_API_SNAPSHOTS=1` after proving the guard fails RED
  first, in each case.
- `docs/spec/quotas.md`, `docs/spec/audit.md`: active-document the
  implemented provenance rule, the archive wire/version consequence, and
  the explicit scope boundary (this does not extend to
  `VerificationLimits`, `sm-format`'s structural caps, or capability
  policy). `docs/spec/vm.md` inspected; no active contradiction found, left
  unchanged.
- `docs/roadmap/stable_foundation/ssf08_1762_execution_envelope_provenance_decision.md`:
  original decision text preserved unedited; §25 implementation-status
  addendum appended, then corrected once review caught it still described
  the rejected first-attempt CLI fix (see "Corrective round" below).
- `docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md`:
  §6 implementation-complete addendum, AC4.c text updated to SATISFIED
  (freshly re-audited against this branch); addendum heading reworded to
  a merge-stable form so it does not read as false once this PR merges.

## A gap discovered mid-implementation, resolved with explicit owner input

`tests/golden_snapshots/public_api/prom_audit_lib.txt` existed, but
`tests/public_api_contracts.rs` never actually tracked
`crates/prom-audit/src/lib.rs` in its guarded-file list - a pre-existing
omission unrelated to #1762, which meant `AuditSessionMetadata`'s own
public API (the exact type this PR widens) was unguarded going in. Flagged
to the owner before proceeding; the owner chose to restore `prom-audit` to
the tracked list within this same PR. Doing so surfaced accumulated,
unrelated drift (expanded `AuditEventKind` variant text, multi-line
constructor signatures reflecting source changes that predate this PR)
alongside the two intended changes (`quotas` field, format-version bump);
the full diff was reviewed manually before regenerating.

## Corrective round: the CLI fix's first attempt was itself a reconstruction

Review caught that the first version of the `smc-cli` fix constructed a
**second**, independently-hardcoded `ExecutionConfig::for_context(VerifiedLocal)`
purely to source the audit metadata, while the actual execution
(`run_semcode_collecting_hello_observations`, no config parameter existed)
still hardcoded its **own**, separate canonical config internally. Both
values agreed today by construction, but nothing tied them together - a
second instance of exactly the "reconstruct a nicer-looking policy after
the fact" pattern #1762's own trust rule forbids, just one level removed
from the original defect. Fixed by adding the config-aware `sm-vm` sibling
above and constructing the `ExecutionConfig` **once** in `smc-cli`,
threading that single instance through verification, execution, and
provenance. A dedicated `sm-vm` regression
(`run_semcode_collecting_hello_observations_with_config_enforces_the_passed_quotas`)
proves the new function genuinely enforces the caller's quotas rather than
silently falling back to a hardcoded baseline - see **M4** below.

A second review pass then caught that the §25/§6 decision-doc addenda
still described the rejected first attempt and counted only three
mutation proofs; both were corrected in a docs-only follow-up commit
(no production code, tests, snapshots, or archive format touched).

## Mutation proofs (applied and reverted, zero markers remain)

- **M1** (provenance reconstruction): `ExecutionSession::new`'s descriptor
  copy temporarily replaced with a context-derived
  `RuntimeQuotas::verified_local()`. The custom-envelope propagation
  regression turned RED as predicted. Reverted.
- **M2** (parser reconstruction): the archive parser's eight quota fields
  temporarily replaced with a hardcoded `RuntimeQuotas::verified_local()`
  regardless of what was actually serialized. The full-pipeline custom
  envelope regression turned RED. Reverted.
- **M3** (version discipline): `AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION` left
  at `1` after the wire-shape change. Both the v1-rejection and
  embedded-v1-rejection regressions turned RED (wrong error message,
  proving the version gate itself is what makes rejection meaningful, not
  incidental). Reverted.
- **M4** (config-blind fallback): `run_semcode_collecting_hello_observations_with_config`
  temporarily ignored its own `config` parameter and hardcoded canonical
  `VerifiedLocal` internally instead. The passed-quotas-enforcement
  regression turned RED (a program that should have failed under a
  drastically tightened `max_steps` succeeded instead). Reverted.

## AC4.c, freshly re-audited (not assumed)

Every production construction site of `RuntimeSessionDescriptor` and
`AuditSessionMetadata` was manually classified as either SAME AUTHORITY
(copies an available `config.quotas`/`descriptor.quotas`) or explicit
synthetic/audit-only fixture. Zero production paths discard an available
effective envelope in favor of a context-derived reconstruction, including
the corrected `smc-cli` site, which now sources verify/execute/audit from
one shared binding rather than three independent (if value-equal)
constructions. **AC4.c: SATISFIED.** `AC4.d`/`AC4.e` remain `#1763`
territory, not claimed here.

## Explicitly out of scope

- Moving quota storage off `RuntimeQuotas` (digest/delta/boolean alternatives)
- `VerificationLimits`, `sm-format`'s structural caps, capability policy
- `RuntimeQuotas` baseline value changes
- Restricting custom `ExecutionConfig` envelopes
- `MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION` bump
- Backward-compatible v1 archive parsing
- `RuntimeTrap`/`RuntimeError` restructuring (`#1763`)
- `#1902` snake_learning

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clean` + `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p sm-vm --lib` (incl. the new config-enforcement regression)
- [x] `cargo test -p prom-audit --all-features` (26/26)
- [x] `cargo test -p prom-runtime --all-features` (10/10)
- [x] `cargo test --test prometheus_audit` (2/2)
- [x] `cargo test --test public_api_contracts` (RED with stale golden each
      time a surface widened - `prom-runtime`, `prom-audit`, then
      `sm-vm`'s new helper - isolated diffs reviewed; GREEN after
      regeneration, 88/88)
- [x] `cargo test --workspace --no-fail-fast` (zero failures)
- [x] `cargo check -p prom-audit --no-default-features`,
      `cargo check -p prom-runtime --no-default-features` (both hit a
      pre-existing, unrelated `format!`-macro no_std bug in `prom-cap`/
      `prom-state`/`prom-gates` - empirically confirmed identical on the
      pre-#1762 baseline commit in a throwaway worktree, not caused by
      this change)
- [x] `git diff --check`
- [x] Custom-envelope full-pipeline exact-preservation regression
- [x] Same-context/different-quotas multi-session distinguishability regression
- [x] Config-aware `sm-vm` helper genuinely enforces passed-in quotas regression
- [x] M1/M2/M3/M4 mutation proofs (RED, reverted)
- [x] Hosted CI green at exact HEAD fd3d9c47ffc1c859c5b2486c255008aee17be149
- [x] Fresh Codex review clean at exact HEAD fd3d9c47ff

**Exact-head qualification complete. Wait for owner GO before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
