### PR TITLE
test(runtime): qualify snake-learning explicit envelope (#1902)

### DIFF
--- a/tests/snake_learning_benchmark.rs
+++ b/tests/snake_learning_benchmark.rs
@@ -31,15 +31,18 @@ fn mk_temp_dir(prefix: &str) -> PathBuf {
     dir
 }
 
-fn check_run_compile_verify(rel: &str) {
+/// #1902 (FA-08-012) split of the previously-bundled `check`+`run`+
+/// `compile`+`verify` test (`ssf08_1902_snake_learning_envelope_decision.md`,
+/// Model E): `check`/`compile`/`verify` never construct an `ExecutionConfig`
+/// or execute the VM, so they carry no dependency on any runtime quota
+/// envelope. Proves language acceptance and bytecode verification only -
+/// see `snake_learning_completes_under_explicit_high_budget_envelope` for
+/// the separate full-completion guarantee.
+fn check_compile_verify(rel: &str) {
     let input = repo_path(rel);
     cli_ok(
         vec!["check".to_string(), input.clone()],
         &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
     );
 
     let dir = mk_temp_dir("smc_snake_learning_benchmark");
@@ -61,27 +64,66 @@ fn check_run_compile_verify(rel: &str) {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
-/// Ignored as a direct, expected consequence of #1759 (FA-08-001) making the
-/// `Steps` runtime quota real for the first time: this benchmark's `smc run`
-/// invocation executes under the `VerifiedLocal` context's already-published
-/// `max_steps = 100000` baseline (`RuntimeQuotas::verified_local`) and now
-/// exceeds it by exactly one opcode (`QuotaExceeded { kind: Steps, limit:
-/// 100000, used: 100001 }`) - a real violation of an already-existing,
-/// already-documented contract that #1759's enforcement correctly surfaced,
-/// not a defect in #1759 itself. Tracked as its own issue, #1902
-/// (FA-08-012), independent of #1759 - #1759 will close once its own
-/// implementation lands, and this residual must not become an ignore
-/// annotation citing an already-closed issue. Left ignored rather than
-/// silently "fixed" by editing this benchmark's content/parameters, adding
-/// a CLI quota override, or raising the published `verified_local`
-/// baseline - each is a legitimate but separate decision belonging to
-/// #1902, not to #1759's own narrow contract scope
-/// (docs/roadmap/stable_foundation/ssf08_1759_steps_calls_contract_decision.md).
-/// Also recorded in
-/// docs/roadmap/stable_foundation/ssf08_lane5_resource_failure_closure_audit.md
-/// §8 finding 5, pending #1902's own separately authorized fix.
 #[test]
-#[ignore = "FA-08-012 (#1902): exceeds the published VerifiedLocal max_steps=100000 budget by 1 opcode now that Steps is actually enforced - see ssf08_lane5_resource_failure_closure_audit.md §8 finding 5"]
-fn snake_learning_passes_check_run_compile_verify() {
-    check_run_compile_verify("examples/benchmarks/snake_learning.sm");
+fn snake_learning_passes_check_compile_verify() {
+    check_compile_verify("examples/benchmarks/snake_learning.sm");
+}
+
+/// #1902 (FA-08-012) / `ssf08_1902_snake_learning_envelope_decision.md`
+/// (Model E + C): `smc run`'s default `VerifiedLocal` envelope
+/// (`max_steps = 100_000`, `max_calls = 16_384`) is far short of this
+/// benchmark's real, measured, deterministic cost (753,864 Steps quota
+/// charges / 42,477 Calls quota charges - the decision document's §13).
+/// This is a residual workload/envelope mismatch, not an enforcement
+/// defect (#1759's Steps/Calls enforcement is correct), so the fix is to
+/// give the full-completion guarantee its own dedicated, explicitly-scoped
+/// test rather than widen the published default for every program.
+///
+/// This does not change, and must not be read as changing, `smc run`'s
+/// default behavior: `smc run examples/benchmarks/snake_learning.sm`
+/// remains fail-closed under the ordinary CLI envelope, exactly as
+/// before.
+#[test]
+fn snake_learning_completes_under_explicit_high_budget_envelope() {
+    use sm_emit::compile_program_to_semcode;
+    use sm_runtime_core::{ExecutionConfig, ExecutionContext, RuntimeQuotas};
+    use sm_verify::verify_semcode_token_with_quotas;
+    use sm_vm::run_verified_entry_semcode_with_config;
+
+    let src = std::fs::read_to_string(repo_path("examples/benchmarks/snake_learning.sm"))
+        .expect("read snake_learning.sm");
+    let bytes = compile_program_to_semcode(&src).expect("compile snake_learning.sm");
+
+    // Explicit, test-local custom envelope (decision §22/§27): only
+    // max_steps/max_calls move, with wide measured headroom (~49.7%/
+    // ~52.8% over the exact 753,864/42,477 measured cost); every other
+    // field stays at VerifiedLocal's published default. One `quotas`
+    // value is the sole authority, threaded unchanged into both
+    // admission and execution (#1762 single-authority discipline).
+    let quotas = RuntimeQuotas {
+        max_steps: 1_500_000,
+        max_calls: 90_000,
+        ..RuntimeQuotas::verified_local()
+    };
+
+    let token = verify_semcode_token_with_quotas(&bytes, quotas)
+        .expect("snake_learning SemCode must verify under the explicit test envelope");
+    let entry = token
+        .require_entry("main")
+        .expect("snake_learning must expose main");
+
+    // Canonical verified execution path (verify_semcode_token_with_quotas
+    // -> require_entry -> run_verified_entry_semcode_with_config) - never
+    // the raw/bypass path. Success (`Ok(())`) is the completion proof:
+    // the embedded Semantic assertions (`total_score == 8`,
+    // `total_steps == 1417`, non-empty Q-table) are load-bearing inside
+    // `main` itself, and a failed `assert` would surface as
+    // `RuntimeError::Trap(RuntimeTrap::AssertionFailed)`, not `Ok`. This
+    // API returns `Result<(), RuntimeError>`, not `main`'s locals, so
+    // there is no separate value to assert here.
+    run_verified_entry_semcode_with_config(
+        &entry,
+        ExecutionConfig::new(ExecutionContext::VerifiedLocal, quotas),
+    )
+    .expect("snake_learning must complete under its explicit test envelope");
 }


### PR DESCRIPTION
## Summary

Closes #1902
SSF-08 umbrella #1579 remains OPEN

Implements frozen [#1914](https://github.com/skulmakov-oss/Semantic/pull/1914) Model E + C
(`ssf08_1902_snake_learning_envelope_decision.md`). No architectural
re-decision - this PR mechanically executes an already-frozen contract.

## What changed

- Restores unignored `check`/`compile`/`verify` coverage for
  `examples/benchmarks/snake_learning.sm` (`snake_learning_passes_check_compile_verify`)
  - these never construct an `ExecutionConfig` or execute the VM, so
  they carry zero dependency on any execution envelope.
- Adds a separate, unignored verified completion test
  (`snake_learning_completes_under_explicit_high_budget_envelope`) under
  a test-local explicit envelope: `max_steps = 1,500,000`,
  `max_calls = 90,000`, every other `RuntimeQuotas` field at
  `VerifiedLocal`'s published default.
- Removes the old, single, bundled, `#[ignore]`d
  `snake_learning_passes_check_run_compile_verify` test.

## Explicitly unchanged

- `VerifiedLocal` published baseline - unchanged.
- `KernelBound` - unchanged.
- `smc` CLI - unchanged, no new flags/env vars.
- `examples/benchmarks/snake_learning.sm` - unchanged, not one line touched.
- Production code (`crates/*`) - unchanged.
- `fallback` = NONE.
- `automatic quota escalation` = NONE.
- `smc run examples/benchmarks/snake_learning.sm` remains fail-closed
  under the ordinary CLI envelope, exactly as before - this PR does not
  make it succeed, and is not intended to.

## Canonical verified pipeline used

```
compile_program_to_semcode
  -> verify_semcode_token_with_quotas(bytes, quotas)
  -> require_entry("main")
  -> run_verified_entry_semcode_with_config(&entry, ExecutionConfig::new(VerifiedLocal, quotas))
  -> Ok(())
```

One `quotas: RuntimeQuotas` value is the sole authority, threaded
unchanged into both admission and execution (the `#1762`
single-authority discipline). The raw/bypass execution path is never
used. `run_verified_entry_semcode_with_config` returns
`Result<(), RuntimeError>`, not `main`'s locals - successful completion
is itself the proof that the benchmark's embedded golden assertions
(`total_score == 8`, `total_steps == 1417`, non-empty Q-table) held,
since a failed `assert` surfaces as
`RuntimeError::Trap(RuntimeTrap::AssertionFailed)`, not `Ok`.

## Mutation proofs (run and reverted, not committed)

- **M1** - `max_steps = 100_000` (all else unchanged): RED -
  `QuotaExceeded { kind: Steps, limit: 100000, used: 100001 }`.
- **M2** - `max_calls = 16_384` (all else unchanged): RED -
  `QuotaExceeded { kind: Calls, limit: 16384, used: 16385 }`.
- Final envelope (`1,500,000` / `90,000`): PASS, confirmed across 3
  consecutive deterministic runs.

## Test plan

- [x] `cargo test --test snake_learning_benchmark` - both tests pass, 0 ignored
- [x] Completion test run 3x - 3/3 PASS
- [x] Mutation M1 (Steps) - RED, reverted
- [x] Mutation M2 (Calls) - RED, reverted
- [x] `cargo fmt --all --check` - clean
- [x] `cargo test --workspace --all-targets` - all green, zero failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` - clean
- [x] `git diff --check` - clean, exactly one file changed
- [x] Hosted CI green at exact HEAD `a3228a382c`
- [x] Fresh Codex review clean at exact HEAD `a3228a382c`

**Exact-head qualification complete. Wait for owner GO before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


